### PR TITLE
Added project(MentOS) to top of cmake file to silent warning no project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8.4)
 
+project(MentOS)
+
 # ------------------------------------------------------------------------------
 # Add the debugging option.
 set(DEBUGGING_TYPE "DEBUG_STDIO" CACHE STRING


### PR DESCRIPTION
Added project to silent warning.

<details>
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.
</detail>