### PR TITLE
Workararound to let GCC 10 link executables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set_property(
     DEBUG_LOG)
 if ("${DEBUGGING_TYPE}" STREQUAL "DEBUG_STDIO" OR
     "${DEBUGGING_TYPE}" STREQUAL "DEBUG_LOG")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D${DEBUGGING_TYPE}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon -D${DEBUGGING_TYPE}")
     message(STATUS "Setting debugging type to ${DEBUGGING_TYPE}.")
 else ()
     message(FATAL_ERROR "Debugging type ${DEBUGGING_TYPE} is not valid.")


### PR DESCRIPTION
In new GCC version, `-fno-common ` is set in CFLAGS, instead of the old `-fcommon`, so the linker returns errors of `multiple definition`.
Probably this is not the ideal fix, but I think it could work as workaround.