### PR TITLE
Add cdrom.iso target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,3 +160,12 @@ add_custom_target(
   DEPENDS gdb_file kernel-bootloader.bin initrd)
 
 add_custom_target(all-execs-clion-embedded DEPENDS gdb_file_clion_embedded kernel-bootloader.bin initrd)
+
+add_custom_target(
+    cdrom.iso
+    COMMAND cp mentos/kernel-bootloader.bin iso/boot
+    COMMAND cp initrd iso/boot
+    COMMAND grub-mkrescue -o cdrom.iso iso
+    DEPENDS kernel-bootloader.bin
+    DEPENDS initrd
+)

--- a/iso/boot/grub/grub.cfg
+++ b/iso/boot/grub/grub.cfg
@@ -1,0 +1,8 @@
+set timeout=1
+set default=0
+
+menuentry "MentOS" {
+     multiboot /boot/kernel-bootloader.bin
+     module /boot/initrd initrd
+     boot
+}


### PR DESCRIPTION
This requires the GRUB `grub-mkrescue` command to be available. Can be found in the grub2 / grub-pc packages on most Linux distributions.