### PR TITLE
Improve process termination

### DIFF
--- a/libc/src/unistd/waitpid.c
+++ b/libc/src/unistd/waitpid.c
@@ -1,6 +1,6 @@
 /// @file waitpid.c
 /// @brief
-/// @copyright (c) 2014-2023 This file is distributed under the MIT License.
+/// @copyright (c) 2014-2024 This file is distributed under the MIT License.
 /// See LICENSE.md for details.
 
 #include "sys/unistd.h"
@@ -18,19 +18,17 @@ pid_t waitpid(pid_t pid, int *status, int options)
     int __status = 0;
     do {
         __inline_syscall3(__res, waitpid, pid, &__status, options);
-        if (__res < 0) {
+        if (__res != 0) {
             break;
-}
-        if (__status == EXIT_ZOMBIE) {
-            break;
-}
+        }
         if (options && WNOHANG) {
             break;
-}
+        }
     } while (1);
+
     if (status) {
         *status = __status;
-}
+    }
     __syscall_return(pid_t, __res);
 }
 

--- a/mentos/inc/process/scheduler.h
+++ b/mentos/inc/process/scheduler.h
@@ -112,3 +112,7 @@ int sys_waitperiod(void);
 /// @param gid ID of the group
 /// @return 1 if the group is orphan, 0 otherwise.
 int is_orphaned_pgrp(pid_t gid);
+
+/// @brief Exit the current process with status
+/// @param status The exit status of the current process
+void do_exit(int status);

--- a/mentos/src/process/scheduler.c
+++ b/mentos/src/process/scheduler.c
@@ -517,7 +517,7 @@ pid_t sys_waitpid(pid_t pid, int *status, int options)
     return 0;
 }
 
-void sys_exit(int exit_code)
+void do_exit(int exit_code)
 {
     // Get the current task.
     if (runqueue.curr == NULL) {
@@ -571,6 +571,11 @@ void sys_exit(int exit_code)
     destroy_process_image(runqueue.curr->mm);
     // Debugging message.
     pr_debug("Process %d exited with value %d\n", runqueue.curr->pid, exit_code);
+}
+
+void sys_exit(int exit_code)
+{
+    do_exit(exit_code << 8);
 }
 
 int sys_sched_setparam(pid_t pid, const sched_param_t *param)

--- a/mentos/src/system/signal.c
+++ b/mentos/src/system/signal.c
@@ -495,38 +495,38 @@ int do_signal(struct pt_regs *f)
 
                 continue;
             case SIGQUIT:
-                sys_exit(GET_EXIT_STATUS(1));
+                do_exit(GET_EXIT_STATUS(1));
                 continue;
             case SIGILL:
-                sys_exit(GET_EXIT_STATUS(132));
+                do_exit(GET_EXIT_STATUS(132));
                 continue;
             case SIGTRAP:
-                sys_exit(GET_EXIT_STATUS(133));
+                do_exit(GET_EXIT_STATUS(133));
                 continue;
             case SIGABRT:
-                sys_exit(GET_EXIT_STATUS(134));
+                do_exit(GET_EXIT_STATUS(134));
                 continue;
             case SIGFPE:
-                sys_exit(GET_EXIT_STATUS(136) | signr);
+                do_exit(GET_EXIT_STATUS(136) | signr);
                 __unlock_task_sighand(current_process);
                 return 1;
             case SIGBUS:
-                sys_exit(GET_EXIT_STATUS(138) | signr);
+                do_exit(GET_EXIT_STATUS(138) | signr);
                 __unlock_task_sighand(current_process);
                 return 1;
             case SIGSEGV:
-                sys_exit(GET_EXIT_STATUS(139) | signr);
+                do_exit(GET_EXIT_STATUS(139) | signr);
                 __unlock_task_sighand(current_process);
                 return 1;
             case SIGXCPU:
-                sys_exit(GET_EXIT_STATUS(158) | signr);
+                do_exit(GET_EXIT_STATUS(158) | signr);
                 __unlock_task_sighand(current_process);
             case SIGXFSZ:
-                sys_exit(GET_EXIT_STATUS(159) | signr);
+                do_exit(GET_EXIT_STATUS(159) | signr);
                 __unlock_task_sighand(current_process);
             case SIGSYS:
             default:
-                sys_exit(GET_EXIT_STATUS(exit_code) | signr);
+                do_exit(GET_EXIT_STATUS(exit_code) | signr);
                 __unlock_task_sighand(current_process);
                 return 1;
             }


### PR DESCRIPTION
I noticed that with the current develop branch `waitpid` was not properly returning.
This is due to a change to the reported status now being the exit code instead of the process state (`EXIT_ZOMBIE`).
The first commit fixes `waitpid` by removing the now broken state check.

Secondly I was confused because normally exiting process with exit code > 0 where reported as terminated by a signal by the shell.
This is caused due to the exit() syscall not `properly` using the upper bytes (`0xff00`) of the exit code.