### PR TITLE
do not append to gdb.run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ add_custom_target(
     COMMAND echo "break boot.c: boot_main" >> ${CMAKE_BINARY_DIR}/.gdbinit
     COMMAND echo "break kernel.c: kmain" >> ${CMAKE_BINARY_DIR}/.gdbinit
     # Create the GDB connection file.
-    COMMAND echo "target remote localhost:1234" >> ${CMAKE_BINARY_DIR}/gdb.run
+    COMMAND echo "target remote localhost:1234" > ${CMAKE_BINARY_DIR}/gdb.run
     DEPENDS kernel-bootloader.bin
     DEPENDS all_programs
     DEPENDS all_tests


### PR DESCRIPTION
Currently each time the target gdbinit is executed a new line containing 'target remote localhost:1234' will be added to the gdb.run file.

Loading a file with multiple lines of 'target ...' causes qemu to terminate.