### PR TITLE
Fix grub entry

### DIFF
--- a/iso/boot/grub/grub.cfg
+++ b/iso/boot/grub/grub.cfg
@@ -2,6 +2,6 @@ set timeout=5
 set default=0
 
 menuentry "MentOS" {
-     multiboot /boot/kernel-bootloader.bin
+     multiboot /boot/bootloader.bin
      boot
 }


### PR DESCRIPTION
During the cmake cleanup the bootloader binary was renamed from `kernel-bootloader.bin` to `bootloader.bin` however the GRUB boot menu entry was not updated accordingly.