### PR TITLE
creat: set flags in opened file descriptor

### DIFF
--- a/mentos/src/fs/namei.c
+++ b/mentos/src/fs/namei.c
@@ -58,6 +58,7 @@ int sys_creat(const char *path, mode_t mode)
 
     // Set the file descriptor id.
     task->fd_list[fd].file_struct = file;
+    task->fd_list[fd].flags_mask = O_WRONLY|O_CREAT|O_TRUNC;
 
     // Return the file descriptor and increment it.
     return fd;


### PR DESCRIPTION
creat.2 is supposed to be equivalent to open.2 with the flags O_WRONLY|O_CREAT|O_TRUNC.

However, in MentOS the fd returned by creat.2 has no flags whatsoever and is thus not writable.

Set the flags of the file descriptor before returning it.