### PR TITLE
libc: prevent execvp to search for files containing '/'

### DIFF
--- a/libc/src/unistd/exec.c
+++ b/libc/src/unistd/exec.c
@@ -72,21 +72,7 @@ int execv(const char *path, char *const argv[])
 
 int execvp(const char *file, char *const argv[])
 {
-    if (!file || !argv || !environ) {
-        errno = ENOENT;
-        return -1;
-    }
-    if (file[0] == '/') {
-        return execve(file, argv, environ);
-    }
-    // Prepare a buffer for the absolute path.
-    char absolute_path[PATH_MAX] = { 0 };
-    // Find the file inside the entries of the PATH variable.
-    if (__find_in_path(file, absolute_path, PATH_MAX) == 0) {
-        return execve(absolute_path, argv, environ);
-    }
-    errno = ENOENT;
-    return -1;
+    return execvpe(file, argv, environ);
 }
 
 int execvpe(const char *file, char *const argv[], char *const envp[])
@@ -95,7 +81,7 @@ int execvpe(const char *file, char *const argv[], char *const envp[])
         errno = ENOENT;
         return -1;
     }
-    if (file[0] == '/') {
+    if (strchr(file, '/')) {
         return execve(file, argv, envp);
     }
     // Prepare a buffer for the absolute path.


### PR DESCRIPTION
The current implementation always searches for the file in `PATH` if it is not an absolute path.
This prevents executing relative paths like `./executable`.

As specified by `man exec.3p` the p-family of exec functions only search if the filename does not contain slash '/' characters.