### PR TITLE
fix str[n]len implementations

### DIFF
--- a/libc/src/string.c
+++ b/libc/src/string.c
@@ -489,15 +489,14 @@ char *strcpy(char *dst, const char *src)
 size_t strlen(const char *s)
 {
     const char *it = s;
-    while (*(++it) != 0) {}
-    return ((it - s) < 0) ? 0 : (size_t)(it - s);
+    for (; *it; it++);
+    return (size_t)(it - s);
 }
 
 size_t strnlen(const char *s, size_t count)
 {
-    const char *it = s;
-    while ((*(++it) != 0) && --count) {}
-    return ((it - s) < 0) ? 0 : (size_t)(it - s);
+    const char *p = memchr(s, 0, count);
+    return p ? (size_t)(p-s) : count;
 }
 
 int strcmp(const char *s1, const char *s2)

--- a/mentos/src/klib/string.c
+++ b/mentos/src/klib/string.c
@@ -488,15 +488,14 @@ char *strcpy(char *dst, const char *src)
 size_t strlen(const char *s)
 {
     const char *it = s;
-    while (*(++it) != 0) {}
-    return ((it - s) < 0) ? 0 : (size_t)(it - s);
+    for(; *it; it++);
+    return (size_t)(it - s);
 }
 
 size_t strnlen(const char *s, size_t count)
 {
-    const char *it = s;
-    while ((*(++it) != 0) && --count) {}
-    return ((it - s) < 0) ? 0 : (size_t)(it - s);
+    const char *p = memchr(s, 0, count);
+    return p ? (size_t)(p-s) : count;
 }
 
 int strcmp(const char *s1, const char *s2)


### PR DESCRIPTION
The current implementations do not count the length of empty strings correctly.
The following buffer content `"\0foo\0"` is considered a string with length 4, because the iteration pointer is incremented before it is dereferenced to check for a null char.

Replace the broken `strlen` functions with the implementation of musl libc.

This fixes subtle bugs in the shell's code (e.g., `cmd_put("\0");`).