### PR TITLE
Improve echo

### DIFF
--- a/files/usr/share/man/echo.man
+++ b/files/usr/share/man/echo.man
@@ -1,6 +1,14 @@
 SYNOPSIS
-    echo [STRING]
+    echo [OPTIONS] [STRING]
 
 DESCRIPTION
-    Displays a line of text.
-    
+    echo displays a line of text.
+
+    The following options are available:
+
+    -n    Do not output a newline.
+    -e    Enable interpretation of backslash escapes.
+
+    If -e is in effect, the following sequences are recognized:
+
+    \n     new line

--- a/programs/echo.c
+++ b/programs/echo.c
@@ -6,111 +6,18 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/bitops.h>
-
-#define ENV_NORM 1
-#define ENV_BRAK 2
-#define ENV_PROT 3
-
-void expand_env(char *str, char *buf, size_t buf_len, int first_word, int last_word)
-{
-    // Buffer where we store the name of the variable.
-    char buffer[BUFSIZ] = { 0 };
-    // Flags used to keep track of the special characters.
-    unsigned flags = 0;
-    // We keep track of where teh
-    char *env_start = NULL;
-    // Where we store the retrieved environmental variable value.
-    char *ENV = NULL;
-    // Get the length of the string.
-    size_t str_len = strlen(str);
-    // Position where we are writing on the buffer.
-    int b_pos = 0;
-    // Iterate the string.
-    for (int s_pos = 0; s_pos < str_len; ++s_pos) {
-        if (first_word && (s_pos == 0) && str[s_pos] == '"')
-            continue;
-        if (last_word && (s_pos == (str_len - 1)) && str[s_pos] == '"')
-            continue;
-        // If we find the backslash, we need to protect the next character.
-        if (str[s_pos] == '\\') {
-            if (bit_check(flags, ENV_PROT))
-                buf[b_pos++] = '\\';
-            else
-                bit_set_assign(flags, ENV_PROT);
-            continue;
-        }
-        // If we find the dollar, we need to catch the meaning.
-        if (str[s_pos] == '$') {
-            // If the previous character is a backslash, we just need to print the dollar.
-            if (bit_check(flags, ENV_PROT)) {
-                buf[b_pos++] = '$';
-            } else if ((s_pos < (str_len - 2)) && ((str[s_pos + 1] == '{'))) {
-                // Toggle the open bracket method of accessing env variables.
-                bit_set_assign(flags, ENV_BRAK);
-                // We need to skip both the dollar and the open bracket `${`.
-                env_start = &str[s_pos + 2];
-            } else {
-                // Toggle the normal method of accessing env variables.
-                bit_set_assign(flags, ENV_NORM);
-                // We need to skip the dollar `$`.
-                env_start = &str[s_pos + 1];
-            }
-            continue;
-        }
-        if (bit_check(flags, ENV_BRAK)) {
-            if (str[s_pos] == '}') {
-                // Copy the environmental variable name.
-                strncpy(buffer, env_start, &str[s_pos] - env_start);
-                // Search for the environmental variable, and print it.
-                if ((ENV = getenv(buffer)))
-                    for (int k = 0; k < strlen(ENV); ++k)
-                        buf[b_pos++] = ENV[k];
-                // Remove the flag.
-                bit_clear_assign(flags, ENV_BRAK);
-            }
-            continue;
-        }
-        if (bit_check(flags, ENV_NORM)) {
-            if (str[s_pos] == ':') {
-                // Copy the environmental variable name.
-                strncpy(buffer, env_start, &str[s_pos] - env_start);
-                // Search for the environmental variable, and print it.
-                if ((ENV = getenv(buffer)))
-                    for (int k = 0; k < strlen(ENV); ++k)
-                        buf[b_pos++] = ENV[k];
-                // Copy the `:`.
-                buf[b_pos++] = str[s_pos];
-                // Remove the flag.
-                bit_clear_assign(flags, ENV_NORM);
-            }
-            continue;
-        }
-        buf[b_pos++] = str[s_pos];
-    }
-    if (bit_check(flags, ENV_NORM)) {
-        // Copy the environmental variable name.
-        strcpy(buffer, env_start);
-        // Search for the environmental variable, and print it.
-        if ((ENV = getenv(buffer)))
-            for (int k = 0; k < strlen(ENV); ++k)
-                buf[b_pos++] = ENV[k];
-        // Remove the flag.
-        bit_clear_assign(flags, ENV_NORM);
-    }
-}
 
 int main(int argc, char **argv)
 {
-    char buffer[BUFSIZ];
-    // Iterate all the words.
-    for (int i = 1; i < argc; ++i) {
-        memset(buffer, 0, BUFSIZ);
-        expand_env(argv[i], buffer, BUFSIZ, (i == 1), (i == (argc - 1)));
-        puts(buffer);
-        if (i < (argc - 1))
+    char *arg;
+
+    // Iterate all words.
+    while ((arg = *++argv) != NULL) {
+        puts(arg);
+        if (*(argv+1) != NULL) {
             putchar(' ');
+        }
     }
-    printf("\n\n");
+    printf("\n");
     return 0;
 }

--- a/programs/echo.c
+++ b/programs/echo.c
@@ -9,15 +9,71 @@
 
 int main(int argc, char **argv)
 {
+    int newline = 1;
+    int eflag = 0;
+    char buffer[BUFSIZ];
+    char *buf = buffer;
     char *arg;
 
-    // Iterate all words.
+    // Iterate all the words.
     while ((arg = *++argv) != NULL) {
-        puts(arg);
-        if (*(argv+1) != NULL) {
-            putchar(' ');
+        if (arg[0] != '-') {
+            break;
+        }
+
+        // parse the options string
+        while (*arg++) {
+            if (*arg == 'n') {
+                newline = 0;
+            } else if (*arg == 'e') {
+                eflag = '\\';
+            } else {
+                break;
+            }
         }
     }
-    printf("\n");
+
+    // Iterate all remaining words.
+    while ((arg = *argv) != NULL) {
+        // We do not expand escape codes.
+        if (!eflag) {
+            puts(arg);
+            goto next_word;
+        }
+
+        // Expand escape codes
+        int c;
+        while ((c = *arg++) != 0) {
+            if (c != eflag) {
+                *buf++ = c;
+            } else {
+                switch (*arg) {
+                case 'n':
+                    *buf++ = '\n';
+                    break;
+                default:
+                    *buf++ =  *(arg-1);
+                    *buf++ = *arg;
+                }
+                arg++;
+            }
+        }
+        // null-terminate the current word
+        *buf = 0;
+        puts(buffer);
+
+next_word:
+        // Add space if there are more words and the last word did not end with a new line
+        if ((*(argv+1) != NULL) && *(buf-1) != '\n') {
+            putchar(' ');
+        }
+        // reset buf pointer
+        buf = buffer;
+        argv++;
+    }
+
+    if (newline) {
+        printf("\n");
+    }
     return 0;
 }


### PR DESCRIPTION
* Remove environment expansions (This is the shell's job)
* Support escape sequences

This should be merged after !43 especially after cada224b25454adcf0b413e2f530fe881ea33c5f.