### PR TITLE
support shebangs

### DIFF
--- a/mentos/src/process/process.c
+++ b/mentos/src/process/process.c
@@ -111,6 +111,12 @@ static int __reset_process(task_struct *task)
     return 1;
 }
 
+static int __has_shebang(vfs_file_t *file) {
+    char buf[2];
+    vfs_read(file, buf, 0, sizeof(buf));
+    return buf[0] == '#' && buf[1] == '!';
+}
+
 /// @brief Replace the current process with a loaded exectuable
 /// @param path the path to the executable to load.
 /// @param task the task to laod the exectuable.
@@ -118,6 +124,10 @@ static int __reset_process(task_struct *task)
 /// @return -errno or 0 on failure, 1 on success
 static int __load_executable(const char *path, task_struct *task, uint32_t *entry)
 {
+    // Return code variable.
+    int ret = 0;
+    int interpreter_loop = 0;
+start:
     pr_debug("__load_executable(`%s`, %p `%s`, %p)\n", path, task, task->name, entry);
     vfs_file_t *file = vfs_open(path, O_RDONLY, 0);
     if (file == NULL) {
@@ -127,12 +137,14 @@ static int __load_executable(const char *path, task_struct *task, uint32_t *entr
     // Check that the file has the execute permission set
     if (!vfs_valid_exec_permission(task, file)) {
         pr_err("This is not executable `%s`!\n", path);
-        return -EACCES;
+        ret = -EACCES;
+        goto close_and_return;
     }
     // Check that the file is actually an executable before destroying the `mm`.
-    if (!elf_check_file_type(file, ET_EXEC)) {
-        pr_err("This is not a valid ELF executable `%s`!\n", path);
-        return -ENOEXEC;
+    if (!(elf_check_file_type(file, ET_EXEC) || __has_shebang(file))) {
+        pr_debug("This is not a valid executable `%s`!\n", path);
+        ret = -ENOEXEC;
+        goto close_and_return;
     }
     // Set the effective uid if the setuid bit is present.
     if (bitmask_check(file->mask, S_ISUID)) {
@@ -149,15 +161,53 @@ static int __load_executable(const char *path, task_struct *task, uint32_t *entr
     if (task->mm) {
         destroy_process_image(task->mm);
     }
-    // Return code variable.
-    int ret = 0;
     // Recreate the memory of the process.
-    if (__reset_process(task)) {
-        // Load the elf file, check if 0 is returned and print the error.
-        if (!(ret = elf_load_file(task, file, entry))) {
-            pr_err("Failed to load ELF file `%s`!\n", path);
-        }
+    if (!__reset_process(task)) {
+        ret = -ENOMEM;
+        goto close_and_return;
     }
+
+    // Load potential interpreter specified by a shebang line
+    if (__has_shebang(file)) {
+        // Disallow interpreter loops
+        if (interpreter_loop) {
+            ret = -ELOOP;
+            // Free interpreter buffer
+            kfree((void*)path);
+            goto close_and_return;
+        }
+
+        // Read shebang line
+        char buf[PATH_MAX];
+        ssize_t bytes_read = vfs_read(file, buf, 2, sizeof(buf));
+        buf[bytes_read] = 0;
+        vfs_close(file);
+
+        // Find end of the line
+        char *lineend = strchr(buf, '\n');
+        if (!lineend) {
+            ret = -ENAMETOOLONG;
+            goto close_and_return;
+        }
+        *lineend = 0;
+
+        path = strdup(buf);
+        interpreter_loop++;
+        goto start;
+    }
+
+    // Load the elf file, check if 0 is returned and print the error.
+    if (!(ret = elf_load_file(task, file, entry))) {
+        pr_err("Failed to load ELF file `%s`!\n", path);
+    }
+
+    // Free potential interpreter path
+    if (interpreter_loop) {
+        // Free interpreter buffer
+        kfree((void*)path);
+    }
+
+close_and_return:
     // Close the file.
     vfs_close(file);
     return ret;

--- a/programs/shell.c
+++ b/programs/shell.c
@@ -955,8 +955,13 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    // We have been executed as script interpreter
+    if (!strstr(argv[0], "shell")) {
+        return __execute_file(argv[0]);
+    }
+
     // Interactive
-    if (argc < 2) {
+    if (argc == 1) {
         // Move inside the home directory.
         __cd(0, NULL);
         __interactive_mode();


### PR DESCRIPTION
Only a single interpreter is allowed. Loops are not permitted. The interpreter path has to immediately follow the shebang.