### PR TITLE
fix path resolution when creating files

### DIFF
--- a/mentos/inc/fs/namei.h
+++ b/mentos/inc/fs/namei.h
@@ -9,6 +9,7 @@
 
 #define REMOVE_TRAILING_SLASH 1 << 0
 #define FOLLOW_LINKS 1 << 1
+#define CREAT_LAST_COMPONENT 1 << 2
 
 /// @brief Resolve the path by following all symbolic links.
 /// @param path The path to resolve.

--- a/mentos/src/fs/vfs.c
+++ b/mentos/src/fs/vfs.c
@@ -147,8 +147,13 @@ vfs_file_t *vfs_open(const char *path, int flags, mode_t mode)
 {
     // Allocate a variable for the path.
     char absolute_path[PATH_MAX];
-    // If the first character is not the '/' then get the absolute path.
-    int ret = resolve_path(path, absolute_path, sizeof(absolute_path), FOLLOW_LINKS);
+    // Resolve all symbolic links in the path before opening the file.
+    int resolve_flags = FOLLOW_LINKS;
+    // Allow the last component to be non existing when attempting to create it.
+    if (bitmask_check(flags, O_CREAT)) {
+        resolve_flags |= CREAT_LAST_COMPONENT;
+    }
+    int ret = resolve_path(path, absolute_path, sizeof(absolute_path), resolve_flags);
     if (ret < 0) {
         pr_err("vfs_open(%s): Cannot resolve path!\n", path);
         errno = -ret;


### PR DESCRIPTION
When attempting to create a file the last path component, the file, does not exist. This is now allowed during path resolution when specifying the CREAT_LAST_COMPONENT flag.

This was detected by our `t_dup` test.