### PR TITLE
Fix ext2 read and write

### DIFF
--- a/mentos/src/fs/ext2.c
+++ b/mentos/src/fs/ext2.c
@@ -4,10 +4,10 @@
 /// See LICENSE.md for details.
 
 // Setup the logging for this file (do this before any other include).
-#include "sys/kernel_levels.h"          // Include kernel log levels.
-#define __DEBUG_HEADER__ "[EXT2  ]"     ///< Change header.
-#define __DEBUG_LEVEL__  LOGLEVEL_DEBUG ///< Set log level.
-#include "io/debug.h"                   // Include debugging functions.
+#include "sys/kernel_levels.h"           // Include kernel log levels.
+#define __DEBUG_HEADER__ "[EXT2  ]"      ///< Change header.
+#define __DEBUG_LEVEL__  LOGLEVEL_NOTICE ///< Set log level.
+#include "io/debug.h"                    // Include debugging functions.
 
 #include "assert.h"
 #include "fcntl.h"

--- a/programs/tests/CMakeLists.txt
+++ b/programs/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_LIST
     t_shm_write.c
     t_mem.c
     t_shm_read.c
+    t_big_write.c
 )
 
 # Set the directory where the compiled binaries will be placed.

--- a/programs/tests/t_big_write.c
+++ b/programs/tests/t_big_write.c
@@ -1,0 +1,44 @@
+/// @file t_big_write.c
+/// @author Enrico Fraccaroli (enry.frak@gmail.com)
+/// @brief Test writing a big file.
+/// @copyright (c) 2024 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/unistd.h>
+#include <math.h>
+#include <io/debug.h>
+
+int main(int argc, char *argv[])
+{
+    int flags               = O_WRONLY | O_CREAT | O_TRUNC;
+    mode_t mode             = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
+    char *filename          = "/home/user/test.txt";
+    char buffer[4 * BUFSIZ] = { 0 };
+    // Open the file.
+    int fd = open(filename, flags, mode);
+    if (fd < 0) {
+        printf("Failed to open file %s: %s\n", filename, strerror(errno));
+        return EXIT_FAILURE;
+    }
+    // Write the content.
+    for (unsigned times = 0; times < 128; ++times) {
+        for (unsigned i = 'A'; i < 'z'; ++i) {
+            memset(buffer, i, 4 * BUFSIZ);
+            if (write(fd, buffer, 4 * BUFSIZ) < 0) {
+                printf("Writing on file %s failed: %s\n", filename, strerror(errno));
+                close(fd);
+                unlink(filename);
+                return EXIT_FAILURE;
+            }
+        }
+    }
+    close(fd);
+    // unlink(filename);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- Improve `ext2_dump_inode output`;
- Rename `EXT2_INDIRECT_BLOCKS` to `EXT2_DIRECT_BLOCKS`;
- Simplify and fix `ext2_get_real_block_index`;
- Simplify and fix `ext2_read_inode_data`;
- Remove `indirect_blocks_index`, `doubly_indirect_blocks_index`, and `trebly_indirect_blocks_index` from the fs structure;
- Simplify and fix `ext2_set_real_block_index`, we were not saving the block in `ext2_set_real_block_index`;
- Create a stress test for big files;
- Fix `ext2_write_inode_data`;
- Add more comments to `ext2_allocate_block`;
- Add more logging messages where needed;