### PR TITLE
CI: add 10 minute timeout

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -86,6 +86,7 @@ jobs:
                   cmake --build build --parallel 2
     test:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - name: Clone repository
               uses: actions/checkout@v4

--- a/programs/cat.c
+++ b/programs/cat.c
@@ -55,6 +55,5 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
     }
-    putchar('\n');
     return ret;
 }


### PR DESCRIPTION
Currently our tests run for less than two minutes.
	Adding a timeout of 10 minutes seems save and prevents wasting resources.