### PR TITLE
Fix `resolve_path` infinite loop

### DIFF
--- a/mentos/src/fs/namei.c
+++ b/mentos/src/fs/namei.c
@@ -182,7 +182,10 @@ resolve_abspath:
                 if (symlinks > SYMLOOP_MAX) { return -ELOOP; }
 
                 char link[PATH_MAX];
-                ssize_t nbytes = sys_readlink(abspath, link, sizeof(link));
+                vfs_file_t* link_file = vfs_open_abspath(abspath, O_RDONLY, 0);
+                if (link_file == NULL) { return -errno; }
+                ssize_t nbytes = vfs_readlink(link_file, link, sizeof(link));
+                vfs_close(link_file);
                 if (nbytes == -1) { return -errno; }
 
                 // Null-terminate link

--- a/mentos/src/fs/vfs.c
+++ b/mentos/src/fs/vfs.c
@@ -147,24 +147,21 @@ vfs_file_t *vfs_open(const char *path, int flags, mode_t mode)
 {
     pr_debug("vfs_open(path: %s, flags: %d, mode: %d)\n", path, flags, mode);
     assert(path && "Provided null path.");
-    if (path[0] != '/') {
-        // Allocate a variable for the path.
-        char absolute_path[PATH_MAX];
-        // Resolve all symbolic links in the path before opening the file.
-        int resolve_flags = FOLLOW_LINKS;
-        // Allow the last component to be non existing when attempting to create it.
-        if (bitmask_check(flags, O_CREAT)) {
-            resolve_flags |= CREAT_LAST_COMPONENT;
-        }
-        int ret = resolve_path(path, absolute_path, sizeof(absolute_path), resolve_flags);
-        if (ret < 0) {
-            pr_err("vfs_open(%s): Cannot resolve path!\n", path);
-            errno = -ret;
-            return NULL;
-        }
-        return vfs_open_abspath(absolute_path, flags, mode);
+    // Allocate a variable for the path.
+    char absolute_path[PATH_MAX];
+    // Resolve all symbolic links in the path before opening the file.
+    int resolve_flags = FOLLOW_LINKS;
+    // Allow the last component to be non existing when attempting to create it.
+    if (bitmask_check(flags, O_CREAT)) {
+        resolve_flags |= CREAT_LAST_COMPONENT;
     }
-    return vfs_open_abspath(path, flags, mode);
+    int ret = resolve_path(path, absolute_path, sizeof(absolute_path), resolve_flags);
+    if (ret < 0) {
+        pr_err("vfs_open(%s): Cannot resolve path!\n", path);
+        errno = -ret;
+        return NULL;
+    }
+    return vfs_open_abspath(absolute_path, flags, mode);
 }
 
 int vfs_close(vfs_file_t *file)


### PR DESCRIPTION
As mentioned in #75, this reverts the change in `vfs_open` and fixed the recursive `vfs_open` call in `resolve_path`.

Afterwards both

```
$ cat README
$ cat /home/user/README
```

work fine.