### PR TITLE
Fix `getgrnam` and `getpwnam` functions

### DIFF
--- a/libc/src/grp.c
+++ b/libc/src/grp.c
@@ -74,7 +74,7 @@ static inline int __search_entry(int fd, char *buf, size_t buflen, const char *n
             buf[pos] = 0;
             // Check the entry.
             if (name) {
-                if (strncmp(buf, name, strlen(name)) == 0) {
+                if (strncmp(buf, name, strlen(name)) == 0 && buf[strlen(name)] == ':') {
                     return 1;
                 }
             } else {

--- a/libc/src/pwd.c
+++ b/libc/src/pwd.c
@@ -72,7 +72,8 @@ static inline char *__search_entry(int fd, char *buffer, int buflen, const char 
             char *name_end = strchr(buffer, ':');
             if (name_end) {
                 *name_end = '\0';
-                if (strncmp(buffer, name, strlen(name)) == 0) {
+                if (strlen(name) == strlen(buffer) &&
+                    strncmp(buffer, name, strlen(name)) == 0) {
                     *name_end = ':';
                     return buffer;
                 }

--- a/programs/runtests.c
+++ b/programs/runtests.c
@@ -40,6 +40,7 @@ static char *all_tests[] = {
     "t_exec execvpe",
     "t_fork 10",
     "t_gid",
+    "t_grp",
     "t_groups",
     "t_itimer",
     "t_kill",
@@ -49,6 +50,7 @@ static char *all_tests[] = {
     /* "t_periodic1", */
     /* "t_periodic2", */
     /* "t_periodic3", */
+    "t_pwd",
     "t_schedfb",
     "t_semflg",
     "t_semget",

--- a/programs/tests/CMakeLists.txt
+++ b/programs/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 # List of programs.
 set(TEST_LIST
+    t_grp.c
+    t_pwd.c
     t_mkdir.c
     t_dup.c
     t_creat.c

--- a/programs/tests/t_grp.c
+++ b/programs/tests/t_grp.c
@@ -1,0 +1,35 @@
+/// @file t_pwd.c
+/// @brief Test the libc grp.h interface
+/// @copyright (c) 2014-2024 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <grp.h>
+#include <err.h>
+#include <sys/unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <strerror.h>
+
+static void __test_getgrnam(void) {
+    // Test that getpwnam matches the whole group name literally
+    if (getgrnam("r") != NULL)
+        errx(EXIT_FAILURE, "Group entry for non-existent group \"r\" found");
+
+    if (getgrnam("root") == NULL)
+        errx(EXIT_FAILURE, "Group entry for root group not found");
+}
+
+static void __test_getgrgid(void) {
+    if (getgrgid(1337) != NULL)
+        errx(EXIT_FAILURE, "Group entry for non-existent gid 1337 found");
+
+    if (getgrgid(0) == NULL)
+        errx(EXIT_FAILURE, "Group entry for gid 0 not found");
+}
+
+int main(int argc, char *argv[])
+{
+    __test_getgrnam();
+    __test_getgrgid();
+}

--- a/programs/tests/t_pwd.c
+++ b/programs/tests/t_pwd.c
@@ -1,0 +1,35 @@
+/// @file t_pwd.c
+/// @brief Test the libc pwd.h interface
+/// @copyright (c) 2014-2024 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <pwd.h>
+#include <err.h>
+#include <sys/unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <strerror.h>
+
+static void __test_getpwnam(void) {
+    // Test that getpwnam matches the whole user name literally
+    if (getpwnam("r") != NULL)
+        errx(EXIT_FAILURE, "Password entry for non-existent user \"r\" found");
+
+    if (getpwnam("root") == NULL)
+        errx(EXIT_FAILURE, "Password entry for root user not found");
+}
+
+static void __test_getpwuid(void) {
+    if (getpwuid(1337) != NULL)
+        errx(EXIT_FAILURE, "Password entry for non-existent uid 1337 found");
+
+    if (getpwuid(0) == NULL)
+        errx(EXIT_FAILURE, "Password entry for uid 0 not found");
+}
+
+int main(int argc, char *argv[])
+{
+    __test_getpwnam();
+    __test_getpwuid();
+}


### PR DESCRIPTION
Both functions comparing the user or group name did match on prefixes of the names and not only on literal matches.

This is fixed and tests are added to ensure this behavior.