### PR TITLE
set procfs file masks

### DIFF
--- a/mentos/inc/fs/procfs.h
+++ b/mentos/inc/fs/procfs.h
@@ -57,6 +57,12 @@ proc_dir_entry_t *proc_create_entry(const char *name, proc_dir_entry_t *parent);
 /// @return 0 if succeed, or -errno in case of error.
 int proc_destroy_entry(const char *name, proc_dir_entry_t *parent);
 
+/// @brief Sets the mask of a given procfs entry.
+/// @param entry Pointer to the entry.
+/// @param mask The mask to set.
+/// @return 0 if succeed, or -errno in case of error.
+int proc_entry_set_mask(proc_dir_entry_t *entry, mode_t mask);
+
 /// @brief Create the entire procfs entry tree for the give process.
 /// @param entry Pointer to the task_struct of the process.
 /// @return 0 if succeed, or -errno in case of error.

--- a/mentos/src/fs/procfs.c
+++ b/mentos/src/fs/procfs.c
@@ -668,6 +668,7 @@ static int __procfs_stat(procfs_file_t *file, stat_t *stat)
     } else {
         return -ENOENT;
     }
+    stat->st_mode  = stat->st_mode | file->mask;
     stat->st_uid   = file->uid;
     stat->st_gid   = file->gid;
     stat->st_dev   = 0;
@@ -1017,5 +1018,16 @@ int proc_destroy_entry(const char *name, proc_dir_entry_t *parent)
         pr_err("proc_destroy_entry(%s): Failed to remove file.\n", entry_path);
         return -ENOENT;
     }
+    return 0;
+}
+
+int proc_entry_set_mask(proc_dir_entry_t *entry, mode_t mask)
+{
+    procfs_file_t *procfs_file = container_of(entry, procfs_file_t, dir_entry);
+    if (procfs_file == NULL) {
+        pr_err("proc_destroy_entry(%s): Cannot find proc entry.\n", entry->name);
+        return -ENOENT;
+    }
+    procfs_file->mask = mask;
     return 0;
 }

--- a/mentos/src/io/proc_feedback.c
+++ b/mentos/src/io/proc_feedback.c
@@ -56,5 +56,9 @@ int procfb_module_init(void)
     // Set the specific operations.
     file->sys_operations = &procfb_sys_operations;
     file->fs_operations  = &procfb_fs_operations;
+    if (proc_entry_set_mask(file, 0444) < 0) {
+        pr_err("Cannot set mask of `/proc/feedback`.\n");
+        return 1;
+    }
     return 0;
 }

--- a/mentos/src/io/proc_system.c
+++ b/mentos/src/io/proc_system.c
@@ -101,65 +101,23 @@ static vfs_file_operations_t procs_fs_operations = {
 int procs_module_init(void)
 {
     proc_dir_entry_t *system_entry;
-    // == /proc/uptime ========================================================
-    if ((system_entry = proc_create_entry("uptime", NULL)) == NULL) {
-        pr_err("Cannot create `/proc/uptime`.\n");
-        return 1;
+    char* entry_names[] = {"uptime", "version", "mounts", "cpuinfo", "meminfo", "stat"};
+    for (int i = 0; i < count_of(entry_names); i++) {
+        char *entry_name = entry_names[i];
+        if ((system_entry = proc_create_entry(entry_name, NULL)) == NULL) {
+            pr_err("Cannot create `/proc/%s`.\n", entry_name);
+            return 1;
+        }
+        pr_debug("Created `/proc/%s` (%p)\n", entry_name, system_entry);
+        // Set the specific operations.
+        system_entry->sys_operations = &procs_sys_operations;
+        system_entry->fs_operations  = &procs_fs_operations;
+        if (proc_entry_set_mask(system_entry, 0444) < 0) {
+            pr_err("Cannot set mask of `/proc/%s`.\n", entry_name);
+            return 1;
+        }
     }
-    pr_debug("Created `/proc/uptime` (%p)\n", system_entry);
-    // Set the specific operations.
-    system_entry->sys_operations = &procs_sys_operations;
-    system_entry->fs_operations  = &procs_fs_operations;
 
-    // == /proc/version ========================================================
-    if ((system_entry = proc_create_entry("version", NULL)) == NULL) {
-        pr_err("Cannot create `/proc/version`.\n");
-        return 1;
-    }
-    pr_debug("Created `/proc/version` (%p)\n", system_entry);
-    // Set the specific operations.
-    system_entry->sys_operations = &procs_sys_operations;
-    system_entry->fs_operations  = &procs_fs_operations;
-
-    // == /proc/mounts ========================================================
-    if ((system_entry = proc_create_entry("mounts", NULL)) == NULL) {
-        pr_err("Cannot create `/proc/mounts`.\n");
-        return 1;
-    }
-    pr_debug("Created `/proc/mounts` (%p)\n", system_entry);
-    // Set the specific operations.
-    system_entry->sys_operations = &procs_sys_operations;
-    system_entry->fs_operations  = &procs_fs_operations;
-
-    // == /proc/cpuinfo ========================================================
-    if ((system_entry = proc_create_entry("cpuinfo", NULL)) == NULL) {
-        pr_err("Cannot create `/proc/cpuinfo`.\n");
-        return 1;
-    }
-    pr_debug("Created `/proc/cpuinfo` (%p)\n", system_entry);
-    // Set the specific operations.
-    system_entry->sys_operations = &procs_sys_operations;
-    system_entry->fs_operations  = &procs_fs_operations;
-
-    // == /proc/meminfo ========================================================
-    if ((system_entry = proc_create_entry("meminfo", NULL)) == NULL) {
-        pr_err("Cannot create `/proc/meminfo`.\n");
-        return 1;
-    }
-    pr_debug("Created `/proc/meminfo` (%p)\n", system_entry);
-    // Set the specific operations.
-    system_entry->sys_operations = &procs_sys_operations;
-    system_entry->fs_operations  = &procs_fs_operations;
-
-    // == /proc/stat ========================================================
-    if ((system_entry = proc_create_entry("stat", NULL)) == NULL) {
-        pr_err("Cannot create `/proc/stat`.\n");
-        return 1;
-    }
-    pr_debug("Created `/proc/stat` (%p)\n", system_entry);
-    // Set the specific operations.
-    system_entry->sys_operations = &procs_sys_operations;
-    system_entry->fs_operations  = &procs_fs_operations;
     return 0;
 }
 

--- a/mentos/src/io/proc_video.c
+++ b/mentos/src/io/proc_video.c
@@ -194,18 +194,6 @@ static ssize_t procv_write(vfs_file_t *file, const void *buf, off_t offset, size
     }
     return nbyte;
 }
-
-static int procv_fstat(vfs_file_t *file, stat_t *stat)
-{
-    stat->st_dev = 0;
-    stat->st_mode = 0666;
-    stat->st_uid = 0;
-    stat->st_gid = 0;
-    stat->st_size = 0;
-    stat->st_mtime = sys_time(NULL);
-    return 0;
-}
-
 static int procv_ioctl(vfs_file_t *file, int request, void *data)
 {
     task_struct *process = scheduler_get_current_process();
@@ -239,7 +227,7 @@ static vfs_file_operations_t procv_fs_operations = {
     .read_f     = procv_read,
     .write_f    = procv_write,
     .lseek_f    = NULL,
-    .stat_f     = procv_fstat,
+    .stat_f     = NULL,
     .ioctl_f    = procv_ioctl,
     .getdents_f = NULL,
     .readlink_f = NULL,
@@ -256,5 +244,11 @@ int procv_module_init(void)
     // Set the specific operations.
     video->sys_operations = &procv_sys_operations;
     video->fs_operations  = &procv_fs_operations;
+
+    if (proc_entry_set_mask(video, 0666) < 0) {
+        pr_err("Cannot set mask for `/proc/video`.\n");
+        return 1;
+    }
+
     return 0;
 }


### PR DESCRIPTION
Currently all entries in the proc file system report `0000` as mask.

Address this issue by using the `mask` member included in the `procfs_file_t` struct and setting it accordingly via the new function `proc_entry_set_mask`.

Additionally, use loops to create some entries removing code duplication.

## Before
![20240730_17h57m53s_grim](https://github.com/user-attachments/assets/32cf0323-6526-4f82-8c28-c888535bc68d)

## After
![20240730_17h57m29s_grim](https://github.com/user-attachments/assets/d55a18a2-bf47-4a9b-979e-7645e0cd79f0)
