### PR TITLE
Fix link management

### DIFF
--- a/libc/inc/fcntl.h
+++ b/libc/inc/fcntl.h
@@ -15,33 +15,3 @@
 #define O_APPEND    00002000U ///< Set append mode.
 #define O_NONBLOCK  00004000U ///< No delay.
 #define O_DIRECTORY 00200000U ///< If file exists has no effect. Otherwise, the file is created.
-
-/// @defgroup ModeBitsAccessPermission Mode Bits for Access Permission
-/// @brief The file modes.
-/// @{
-
-#define S_ISUID 0x0800 ///< Set user id on execution
-#define S_ISGID 0x0400 ///< Set group id on execution
-#define S_ISVTX 0x0200 ///< Save swapped text even after use (Sticky Bit)
-#define S_IRWXU 0x01C0 ///< rwx------ : User can read/write/execute
-#define S_IRUSR 0x0100 ///< r-------- : User can read
-#define S_IWUSR 0x0080 ///< -w------- : User can write
-#define S_IXUSR 0x0040 ///< --x------ : User can execute
-#define S_IRWXG 0x0038 ///< ---rwx--- : Group can read/write/execute
-#define S_IRGRP 0x0020 ///< ---r----- : Group can read
-#define S_IWGRP 0x0010 ///< ----w---- : Group can write
-#define S_IXGRP 0x0008 ///< -----x--- : Group can execute
-#define S_IRWXO 0x0007 ///< ------rwx : Others can read/write/execute
-#define S_IROTH 0x0004 ///< ------r-- : Others can read
-#define S_IWOTH 0x0002 ///< -------w- : Others can write
-#define S_IXOTH 0x0001 ///< --------x : Others can execute
-
-#define S_ISDIR(m)  (((m)&0170000) == 0040000) ///< directory.
-#define S_ISCHR(m)  (((m)&0170000) == 0020000) ///< char special
-#define S_ISBLK(m)  (((m)&0170000) == 0060000) ///< block special
-#define S_ISREG(m)  (((m)&0170000) == 0100000) ///< regular file
-#define S_ISFIFO(m) (((m)&0170000) == 0010000) ///< fifo
-#define S_ISLNK(m)  (((m)&0170000) == 0120000) ///< symbolic link
-#define S_ISSOCK(m) (((m)&0170000) == 0140000) ///< socket
-
-/// @}

--- a/libc/inc/sys/stat.h
+++ b/libc/inc/sys/stat.h
@@ -10,6 +10,51 @@
 #include "stddef.h"
 #include "time.h"
 
+/// @defgroup FileTypes File Types Macros
+/// @brief These constants allow to identify file types.
+/// @{
+#define S_IFMT   0xF000 ///< Format mask
+#define S_IFSOCK 0xC000 ///< Socket
+#define S_IFLNK  0xA000 ///< Symbolic link
+#define S_IFREG  0x8000 ///< Regular file
+#define S_IFBLK  0x6000 ///< Block device
+#define S_IFDIR  0x4000 ///< Directory
+#define S_IFCHR  0x2000 ///< Character device
+#define S_IFIFO  0x1000 ///< Fifo
+/// @}
+
+/// @defgroup FileTypeTest File Type Test Macros
+/// @brief These macros allows to easily identify file types.
+/// @{
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK) ///< Check if the input values identifies a socket.
+#define S_ISLNK(m)  (((m) & S_IFMT) == S_IFLNK)  ///< Check if the input values identifies a symbolic link.
+#define S_ISREG(m)  (((m) & S_IFMT) == S_IFREG)  ///< Check if the input values identifies a regular file.
+#define S_ISBLK(m)  (((m) & S_IFMT) == S_IFBLK)  ///< Check if the input values identifies a block special.
+#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)  ///< Check if the input values identifies a directory.
+#define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)  ///< Check if the input values identifies a char special.
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)  ///< Check if the input values identifies a fifo.
+/// @}
+
+/// @defgroup ModeBitsAccessPermission Mode Bits for Access Permission
+/// @brief These constants allow to control access permission for files.
+/// @{
+#define S_ISUID 0x0800 ///< Set user id on execution
+#define S_ISGID 0x0400 ///< Set group id on execution
+#define S_ISVTX 0x0200 ///< Save swapped text even after use (Sticky Bit)
+#define S_IRWXU 0x01C0 ///< rwx------ : User can read/write/execute
+#define S_IRUSR 0x0100 ///< r-------- : User can read
+#define S_IWUSR 0x0080 ///< -w------- : User can write
+#define S_IXUSR 0x0040 ///< --x------ : User can execute
+#define S_IRWXG 0x0038 ///< ---rwx--- : Group can read/write/execute
+#define S_IRGRP 0x0020 ///< ---r----- : Group can read
+#define S_IWGRP 0x0010 ///< ----w---- : Group can write
+#define S_IXGRP 0x0008 ///< -----x--- : Group can execute
+#define S_IRWXO 0x0007 ///< ------rwx : Others can read/write/execute
+#define S_IROTH 0x0004 ///< ------r-- : Others can read
+#define S_IWOTH 0x0002 ///< -------w- : Others can write
+#define S_IXOTH 0x0001 ///< --------x : Others can execute
+/// @}
+
 /// @brief Retrieves information about the file at the given location.
 /// @param path The path to the file that is being inquired.
 /// @param buf  A structure where data about the file will be stored.

--- a/libc/src/string.c
+++ b/libc/src/string.c
@@ -5,9 +5,9 @@
 
 #include "string.h"
 #include "ctype.h"
-#include "fcntl.h"
 #include "stdio.h"
 #include "stdlib.h"
+#include "sys/stat.h"
 
 #ifdef __KERNEL__
 #include "mem/kheap.h"

--- a/mentos/src/fs/ext2.c
+++ b/mentos/src/fs/ext2.c
@@ -6,7 +6,7 @@
 // Setup the logging for this file (do this before any other include).
 #include "sys/kernel_levels.h"           // Include kernel log levels.
 #define __DEBUG_HEADER__ "[EXT2  ]"      ///< Change header.
-#define __DEBUG_LEVEL__  LOGLEVEL_NOTICE ///< Set log level.
+#define __DEBUG_LEVEL__  LOGLEVEL_DEBUG ///< Set log level.
 #include "io/debug.h"                    // Include debugging functions.
 
 #include "assert.h"
@@ -21,22 +21,13 @@
 #include "stdio.h"
 #include "string.h"
 #include "sys/errno.h"
+#include "sys/stat.h"
 
 #define EXT2_SUPERBLOCK_MAGIC  0xEF53 ///< Magic value used to identify an ext2 filesystem.
 #define EXT2_DIRECT_BLOCKS     12     ///< Amount of indirect blocks in an inode.
 #define EXT2_PATH_MAX          4096   ///< Maximum length of a pathname.
 #define EXT2_MAX_SYMLINK_COUNT 8      ///< Maximum nesting of symlinks, used to prevent a loop.
 #define EXT2_NAME_LEN          255    ///< The lenght of names inside directory entries.
-
-// File types.
-#define EXT2_S_IFMT   0xF000 ///< Format mask
-#define EXT2_S_IFSOCK 0xC000 ///< Socket
-#define EXT2_S_IFLNK  0xA000 ///< Symbolic link
-#define EXT2_S_IFREG  0x8000 ///< Regular file
-#define EXT2_S_IFBLK  0x6000 ///< Block device
-#define EXT2_S_IFDIR  0x4000 ///< Directory
-#define EXT2_S_IFCHR  0x2000 ///< Character device
-#define EXT2_S_IFIFO  0x1000 ///< Fifo
 
 // Permissions bit.
 #define EXT2_S_ISUID 0x0800 ///< SUID
@@ -1851,7 +1842,7 @@ static inline int ext2_directory_is_empty(ext2_filesystem_t *fs, uint8_t *cache,
 static int ext2_clean_inode_content(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index)
 {
     // Check the type of operation.
-    if ((inode->mode & EXT2_S_IFREG) != EXT2_S_IFREG) {
+    if ((inode->mode & S_IFREG) != S_IFREG) {
         pr_alert("Trying to clean the content of a non-regular file.\n");
         return 1;
     }
@@ -2170,7 +2161,7 @@ static int ext2_allocate_direntry(
         return -1;
     }
     // Check that the parent is a directory.
-    if (!bitmask_check(parent_inode.mode, EXT2_S_IFDIR)) {
+    if (!bitmask_check(parent_inode.mode, S_IFDIR)) {
         pr_err("The parent inode is not a directory (ino: %d, mode: %d).\n", parent_inode_index, parent_inode.mode);
         return -1;
     }
@@ -2306,7 +2297,7 @@ static int ext2_find_direntry(ext2_filesystem_t *fs, ino_t ino, const char *name
         return -1;
     }
     // Check that the parent is a directory.
-    if (!bitmask_check(inode.mode, EXT2_S_IFDIR)) {
+    if (!bitmask_check(inode.mode, S_IFDIR)) {
         pr_err("The parent inode is not a directory (ino: %d, mode: %d).\n", ino, inode.mode);
         return -1;
     }
@@ -2473,22 +2464,22 @@ static int ext2_init_vfs_file(
     file->gid = inode->gid;
     // Set the VFS specific flags.
     file->flags = 0;
-    if ((inode->mode & EXT2_S_IFREG) == EXT2_S_IFREG) {
+    if ((inode->mode & S_IFREG) == S_IFREG) {
         file->flags |= DT_REG;
     }
-    if ((inode->mode & EXT2_S_IFDIR) == EXT2_S_IFDIR) {
+    if ((inode->mode & S_IFDIR) == S_IFDIR) {
         file->flags |= DT_DIR;
     }
-    if ((inode->mode & EXT2_S_IFBLK) == EXT2_S_IFBLK) {
+    if ((inode->mode & S_IFBLK) == S_IFBLK) {
         file->flags |= DT_BLK;
     }
-    if ((inode->mode & EXT2_S_IFCHR) == EXT2_S_IFCHR) {
+    if ((inode->mode & S_IFCHR) == S_IFCHR) {
         file->flags |= DT_CHR;
     }
-    if ((inode->mode & EXT2_S_IFIFO) == EXT2_S_IFIFO) {
+    if ((inode->mode & S_IFIFO) == S_IFIFO) {
         file->flags |= DT_FIFO;
     }
-    if ((inode->mode & EXT2_S_IFLNK) == EXT2_S_IFLNK) {
+    if ((inode->mode & S_IFLNK) == S_IFLNK) {
         file->flags |= DT_LNK;
     }
     // Set the inode.
@@ -2682,7 +2673,7 @@ static vfs_file_t *ext2_creat(const char *path, mode_t mode)
         return file;
     }
     // Set the inode mode.
-    mode = EXT2_S_IFREG | (0xFFF & mode);
+    mode = S_IFREG | (0xFFF & mode);
     // Get the group index of the parent.
     uint32_t group_index = ext2_inode_index_to_group_index(fs, parent->ino);
     // Create and initialize the new inode.
@@ -2768,9 +2759,6 @@ static vfs_file_t *ext2_open(const char *path, int flags, mode_t mode)
         errno = ENOENT;
         return NULL;
     }
-    if (search.direntry.file_type == ext2_file_type_symbolic_link) {
-        pr_alert("Beware, it is a symbolic link.\n");
-    }
     // Prepare the structure for the inode.
     ext2_inode_t inode;
     memset(&inode, 0, sizeof(ext2_inode_t));
@@ -2787,7 +2775,7 @@ static vfs_file_t *ext2_open(const char *path, int flags, mode_t mode)
     }
 
     // Check if the file is a regular file, and the user wants to write and truncate.
-    if (bitmask_exact(inode.mode, EXT2_S_IFREG) && (bitmask_exact(flags, O_RDWR | O_TRUNC) || bitmask_exact(flags, O_RDONLY | O_TRUNC))) {
+    if (bitmask_exact(inode.mode, S_IFREG) && (bitmask_exact(flags, O_RDWR | O_TRUNC) || bitmask_exact(flags, O_RDONLY | O_TRUNC))) {
         // Clean the content of the newly created file.
         if (ext2_clean_inode_content(fs, &inode, search.direntry.inode) < 0) {
             pr_err("Failed to clean the content of the newly created inode.\n");
@@ -2947,7 +2935,7 @@ static ssize_t ext2_read(vfs_file_t *file, char *buffer, off_t offset, size_t nb
         return -1;
     }
     // Disallow reading directories using read
-    if ((inode.mode & EXT2_S_IFDIR) == EXT2_S_IFDIR) {
+    if ((inode.mode & S_IFDIR) == S_IFDIR) {
         pr_err("Reading a directory `%s` is not allowed.\n", file->name);
         return -EISDIR;
     }
@@ -3173,6 +3161,7 @@ static ssize_t ext2_readlink(vfs_file_t *file, char *buffer, size_t bufsize)
     ssize_t nbytes = min(strlen(inode.data.symlink), bufsize);
     // Copy the symlink information.
     strncpy(buffer, inode.data.symlink, nbytes);
+    pr_emerg("LINK: %d `%s`\n", file->ino, inode.data.symlink);
     // Return how much we read.
     return nbytes;
 }
@@ -3215,7 +3204,7 @@ static int ext2_mkdir(const char *path, mode_t permission)
         return -EEXIST;
     }
     // Set the inode mode.
-    uint32_t mode = EXT2_S_IFDIR;
+    uint32_t mode = S_IFDIR;
     mode |= 0xFFF & permission;
     // Get the group index of the parent.
     uint32_t group_index = ext2_inode_index_to_group_index(fs, search.parent_inode);
@@ -3552,7 +3541,7 @@ static vfs_file_t *ext2_mount(vfs_file_t *block_device, const char *path)
         // Free the block_buffer, the block_groups and the filesystem.
         goto free_block_buffer;
     }
-    if ((root_inode.mode & EXT2_S_IFDIR) != EXT2_S_IFDIR) {
+    if ((root_inode.mode & S_IFDIR) != S_IFDIR) {
         pr_err("The root is not a directory.\n");
         // Free the block_buffer, the block_groups and the filesystem.
         goto free_block_buffer;

--- a/mentos/src/fs/ext2.c
+++ b/mentos/src/fs/ext2.c
@@ -6,7 +6,7 @@
 // Setup the logging for this file (do this before any other include).
 #include "sys/kernel_levels.h"           // Include kernel log levels.
 #define __DEBUG_HEADER__ "[EXT2  ]"      ///< Change header.
-#define __DEBUG_LEVEL__  LOGLEVEL_DEBUG ///< Set log level.
+#define __DEBUG_LEVEL__  LOGLEVEL_NOTICE ///< Set log level.
 #include "io/debug.h"                    // Include debugging functions.
 
 #include "assert.h"
@@ -3161,7 +3161,6 @@ static ssize_t ext2_readlink(vfs_file_t *file, char *buffer, size_t bufsize)
     ssize_t nbytes = min(strlen(inode.data.symlink), bufsize);
     // Copy the symlink information.
     strncpy(buffer, inode.data.symlink, nbytes);
-    pr_emerg("LINK: %d `%s`\n", file->ino, inode.data.symlink);
     // Return how much we read.
     return nbytes;
 }

--- a/mentos/src/fs/namei.c
+++ b/mentos/src/fs/namei.c
@@ -7,6 +7,7 @@
 #include "assert.h"
 #include "limits.h"
 #include "fcntl.h"
+#include "sys/stat.h"
 #include "fs/vfs.h"
 #include "io/debug.h"
 #include "process/scheduler.h"
@@ -77,12 +78,14 @@ int sys_symlink(const char *linkname, const char *path)
 
 int sys_readlink(const char *path, char *buffer, size_t bufsize)
 {
+    pr_crit("Open...\n");
     // Try to open the file.
     vfs_file_t *file = vfs_open(path, O_RDONLY, 0);
     if (file == NULL) {
         return -errno;
     }
     // Read the link.
+    pr_crit("Readlink...\n");
     ssize_t nbytes = vfs_readlink(file, buffer, bufsize);
     // Close the file.
     vfs_close(file);

--- a/mentos/src/fs/namei.c
+++ b/mentos/src/fs/namei.c
@@ -16,21 +16,21 @@
 
 /// Appends the path with a "/" as separator.
 #define APPEND_PATH_SEP_OR_FAIL(b, remaining) \
-{                                             \
-    strncat(b, "/", remaining);               \
-    remaining--;                              \
-    if (remaining < 0)                        \
-        return -ENAMETOOLONG;                 \
-}
+    {                                         \
+        strncat(b, "/", remaining);           \
+        remaining--;                          \
+        if (remaining < 0)                    \
+            return -ENAMETOOLONG;             \
+    }
 
 /// Appends the path with a "/" as separator.
 #define APPEND_PATH_OR_FAIL(b, path, remaining) \
-{                                               \
-    strncat(b, path, remaining);                \
-    remaining -= strlen(path);                  \
-    if (remaining < 0)                          \
-        return -ENAMETOOLONG;                   \
-}
+    {                                           \
+        strncat(b, path, remaining);            \
+        remaining -= strlen(path);              \
+        if (remaining < 0)                      \
+            return -ENAMETOOLONG;               \
+    }
 
 int sys_unlink(const char *path)
 {
@@ -65,7 +65,7 @@ int sys_creat(const char *path, mode_t mode)
 
     // Set the file descriptor id.
     task->fd_list[fd].file_struct = file;
-    task->fd_list[fd].flags_mask = O_WRONLY|O_CREAT|O_TRUNC;
+    task->fd_list[fd].flags_mask  = O_WRONLY | O_CREAT | O_TRUNC;
 
     // Return the file descriptor and increment it.
     return fd;
@@ -78,14 +78,21 @@ int sys_symlink(const char *linkname, const char *path)
 
 int sys_readlink(const char *path, char *buffer, size_t bufsize)
 {
-    pr_crit("Open...\n");
+    // Allocate a variable for the path.
+    char absolute_path[PATH_MAX];
+    // Resolve the path.
+    int ret = resolve_path(path, absolute_path, sizeof(absolute_path), 0);
+    if (ret < 0) {
+        pr_err("sys_readlink(%s): Cannot resolve path!\n", path);
+        return ret;
+    }
     // Try to open the file.
-    vfs_file_t *file = vfs_open(path, O_RDONLY, 0);
+    vfs_file_t *file = vfs_open_abspath(absolute_path, O_RDONLY, 0);
     if (file == NULL) {
+        pr_err("sys_readlink(%s): Cannot open file!\n", path);
         return -errno;
     }
     // Read the link.
-    pr_crit("Readlink...\n");
     ssize_t nbytes = vfs_readlink(file, buffer, bufsize);
     // Close the file.
     vfs_close(file);
@@ -93,7 +100,8 @@ int sys_readlink(const char *path, char *buffer, size_t bufsize)
     return nbytes;
 }
 
-char *realpath(const char *path, char *buffer, size_t buflen) {
+char *realpath(const char *path, char *buffer, size_t buflen)
+{
     int ret = resolve_path(path, buffer, buflen, REMOVE_TRAILING_SLASH);
     if (ret < 0) {
         errno = -ret;
@@ -110,7 +118,7 @@ int resolve_path(const char *path, char *buffer, size_t buflen, int flags)
     // Buffer used to build up the absolute path
     char abspath[buflen];
     // Null-terminate our work buffer
-    memset(abspath,0, buflen);
+    memset(abspath, 0, buflen);
     int remaining = buflen - 1;
 
     // Track the resolved symlinks to ensure we do not end up in a loop
@@ -158,7 +166,7 @@ resolve_abspath:
                 buffer[pathidx++] = abspath[absidx++];
 
                 // Find the next separator after the current path component
-                char* sep_after_cur = strchr(abspath + absidx, '/');
+                char *sep_after_cur = strchr(abspath + absidx, '/');
                 if (sep_after_cur) {
                     // Null-terminate work buffer to properly open the current component
                     *sep_after_cur = 0;
@@ -187,7 +195,7 @@ resolve_abspath:
                 if (symlinks > SYMLOOP_MAX) { return -ELOOP; }
 
                 char link[PATH_MAX];
-                vfs_file_t* link_file = vfs_open_abspath(abspath, O_RDONLY, 0);
+                vfs_file_t *link_file = vfs_open_abspath(abspath, O_RDONLY, 0);
                 if (link_file == NULL) { return -errno; }
                 ssize_t nbytes = vfs_readlink(link_file, link, sizeof(link));
                 vfs_close(link_file);
@@ -208,7 +216,7 @@ resolve_abspath:
                     strncpy(abspath, link, remaining);
 
                     remaining -= strlen(link);
-                    if (remaining  < 0) { return -ENAMETOOLONG; }
+                    if (remaining < 0) { return -ENAMETOOLONG; }
 
                     // This is not the last component, therefore it must be a directory
                     if (sep_after_cur) {
@@ -217,7 +225,7 @@ resolve_abspath:
                         APPEND_PATH_OR_FAIL(abspath, buffer, remaining);
                     }
                     goto resolve_abspath;
-                // Link is relative, add it and continue
+                    // Link is relative, add it and continue
                 } else {
                     // Recalculate the remaining space in the working buffer
                     remaining = buflen - absidx - 1;
@@ -239,11 +247,10 @@ resolve_abspath:
             }
             // Copy the path component
             else {
-copy_path_component:
+            copy_path_component:
                 do {
                     buffer[pathidx++] = abspath[absidx++];
-                }
-                while (abspath[absidx] && abspath[absidx] != '/');
+                } while (abspath[absidx] && abspath[absidx] != '/');
             }
         }
     }

--- a/mentos/src/fs/procfs.c
+++ b/mentos/src/fs/procfs.c
@@ -11,6 +11,7 @@
 
 #include "assert.h"
 #include "fcntl.h"
+#include "sys/stat.h"
 #include "fs/procfs.h"
 #include "fs/vfs.h"
 #include "libgen.h"

--- a/mentos/src/fs/vfs.c
+++ b/mentos/src/fs/vfs.c
@@ -358,6 +358,7 @@ ssize_t vfs_readlink(vfs_file_t *file, char *buffer, size_t bufsize)
         pr_err("vfs_readlink(%s): Function not supported in current filesystem.", file->name);
         return -ENOSYS;
     }
+    pr_debug("vfs_readlink(file: %s, ino:%d)\n", file->name, file->ino);
     // Perform the read.
     return file->fs_operations->readlink_f(file, buffer, bufsize);
 }

--- a/mentos/src/fs/vfs.c
+++ b/mentos/src/fs/vfs.c
@@ -10,6 +10,7 @@
 #include "io/debug.h"                    // Include debugging functions.
 
 #include "fcntl.h"
+#include "sys/stat.h"
 #include "assert.h"
 #include "fs/procfs.h"
 #include "fs/namei.h"

--- a/mentos/src/io/video.c
+++ b/mentos/src/io/video.c
@@ -7,6 +7,7 @@
 #include "ctype.h"
 #include "io/vga/vga.h"
 #include "io/video.h"
+#include "io/debug.h"
 #include "stdbool.h"
 #include "stdio.h"
 #include "string.h"
@@ -27,6 +28,8 @@ struct ansi_color_map_t {
 }
 /// @brief The mapping.
 ansi_color_map[] = {
+    { 0, 7 },
+
     { 30, 0 },
     { 31, 4 },
     { 32, 2 },
@@ -61,9 +64,7 @@ ansi_color_map[] = {
     { 104, 9 },
     { 105, 13 },
     { 106, 11 },
-    { 107, 15 },
-
-    { 0, 0 }
+    { 107, 15 }
 };
 
 /// Pointer to a position of the screen writer.
@@ -111,17 +112,18 @@ static inline void __draw_char(char c)
 /// @param ansi_code The ansi code describing background and foreground color.
 static inline void __set_color(uint8_t ansi_code)
 {
-    struct ansi_color_map_t *it = ansi_color_map;
-    while (it->ansi_color != 0) {
-        if (ansi_code == it->ansi_color) {
-            if (((ansi_code >= 30) && (ansi_code <= 37)) || ((ansi_code >= 90) && (ansi_code <= 97))) {
-                color = (color & 0xF0U) | it->video_color;
+    for (size_t i = 0; i < count_of(ansi_color_map); ++i) {
+        if (ansi_code == ansi_color_map[i].ansi_color) {
+            if (
+                (ansi_code == 0) ||
+                ((ansi_code >= 30) && (ansi_code <= 37)) ||
+                ((ansi_code >= 90) && (ansi_code <= 97))) {
+                color = (color & 0xF0U) | ansi_color_map[i].video_color;
             } else {
-                color = (color & 0x0FU) | (it->video_color << 4U);
+                color = (color & 0x0FU) | (ansi_color_map[i].video_color << 4U);
             }
             break;
         }
-        ++it;
     }
 }
 

--- a/mentos/src/ipc/ipc.c
+++ b/mentos/src/ipc/ipc.c
@@ -6,6 +6,7 @@
 #include "ipc/ipc.h"
 
 #include "assert.h"
+#include "sys/stat.h"
 #include "fcntl.h"
 #include "io/debug.h"
 #include "process/scheduler.h"

--- a/mentos/src/klib/string.c
+++ b/mentos/src/klib/string.c
@@ -5,7 +5,7 @@
 
 #include "string.h"
 #include "ctype.h"
-#include "fcntl.h"
+#include "sys/stat.h"
 #include "stdio.h"
 #include "stdlib.h"
 

--- a/mentos/src/process/process.c
+++ b/mentos/src/process/process.c
@@ -12,6 +12,7 @@
 #include "assert.h"
 #include "elf/elf.h"
 #include "fcntl.h"
+#include "sys/stat.h"
 #include "fs/vfs.h"
 #include "hardware/timer.h"
 #include "klib/stack_helper.h"

--- a/programs/ls.c
+++ b/programs/ls.c
@@ -15,18 +15,39 @@
 #include <libgen.h>
 #include <sys/bitops.h>
 #include <io/debug.h>
+#include <io/ansi_colors.h>
 
 #define FLAG_L (1U << 0U)
 #define FLAG_A (1U << 1U)
 #define FLAG_I (1U << 2U)
 #define FLAG_1 (1U << 3U)
 
-#define FG_BRIGHT_GREEN  "\033[92m"
-#define FG_BRIGHT_CYAN   "\033[96m"
-#define FG_BRIGHT_WHITE  "\033[97m"
-#define FG_BRIGHT_YELLOW "\033[93m"
-
 #define DENTS_NUM 12
+
+static inline void print_dir_entry_name(const char *name, mode_t st_mode)
+{
+    if (S_ISSOCK(st_mode)) {
+        printf(FG_YELLOW "%s" FG_RESET, name);
+    }
+    if (S_ISLNK(st_mode)) {
+        printf(FG_CYAN "%s" FG_RESET, name);
+    }
+    if (S_ISREG(st_mode)) {
+        printf(FG_WHITE "%s" FG_RESET, name);
+    }
+    if (S_ISBLK(st_mode)) {
+        printf(FG_GREEN "%s" FG_RESET, name);
+    }
+    if (S_ISDIR(st_mode)) {
+        printf(FG_BLUE "%s" FG_RESET, name);
+    }
+    if (S_ISCHR(st_mode)) {
+        printf(FG_YELLOW "%s" FG_RESET, name);
+    }
+    if (S_ISFIFO(st_mode)) {
+        printf(FG_YELLOW "%s" FG_RESET, name);
+    }
+}
 
 static inline void print_dir_entry(dirent_t *dirent, const char *path, unsigned int flags, size_t *total_size)
 {
@@ -49,15 +70,6 @@ static inline void print_dir_entry(dirent_t *dirent, const char *path, unsigned 
     // Stat the file.
     if (stat(relative_path, &dstat) == -1) {
         return;
-    }
-
-    // Deal with the coloring.
-    if ((dirent->d_type == DT_REG) && bitmask_check(dstat.st_mode, S_IXUSR)) {
-        puts(FG_BRIGHT_YELLOW);
-    } else if (dirent->d_type == DT_DIR) {
-        puts(FG_BRIGHT_CYAN);
-    } else if (dirent->d_type == DT_BLK) {
-        puts(FG_BRIGHT_GREEN);
     }
 
     // Deal with the -l.
@@ -83,22 +95,23 @@ static inline void print_dir_entry(dirent_t *dirent, const char *path, unsigned 
         // Add a space.
         putchar(' ');
         // Print the rest.
-        printf("%4d %4d %11s %02d/%02d %02d:%02d %s",
+        printf("%4d %4d %11s %02d/%02d %02d:%02d ",
                dstat.st_uid,
                dstat.st_gid,
                to_human_size(dstat.st_size),
                timeinfo->tm_mon,
                timeinfo->tm_mday,
                timeinfo->tm_hour,
-               timeinfo->tm_min,
-               dirent->d_name);
+               timeinfo->tm_min);
+
+        print_dir_entry_name(dirent->d_name, dstat.st_mode);
+
         if (S_ISLNK(dstat.st_mode)) {
             char link_buffer[PATH_MAX];
             ssize_t len;
-            pr_emerg("Read link...\n");
             if ((len = readlink(relative_path, link_buffer, sizeof(link_buffer))) != -1) {
                 link_buffer[len] = '\0';
-                printf(" -> %s\n", link_buffer);
+                printf(" -> %s", link_buffer);
             }
         }
         putchar('\n');
@@ -108,7 +121,7 @@ static inline void print_dir_entry(dirent_t *dirent, const char *path, unsigned 
         if (bitmask_check(flags, FLAG_I)) {
             printf("%d ", dirent->d_ino);
         }
-        puts(dirent->d_name);
+        print_dir_entry_name(dirent->d_name, dstat.st_mode);
         // Print in 1 column if requested.
         if (bitmask_check(flags, FLAG_1)) {
             putchar('\n');
@@ -116,9 +129,6 @@ static inline void print_dir_entry(dirent_t *dirent, const char *path, unsigned 
             putchar(' ');
         }
     }
-
-    // Reset the color.
-    puts(FG_BRIGHT_WHITE);
 }
 
 static void print_ls(int fd, const char *path, unsigned int flags)

--- a/programs/shell.c
+++ b/programs/shell.c
@@ -177,7 +177,7 @@ static inline void __prompt_print(void)
     } else {
         HOSTNAME = buffer.nodename;
     }
-    printf(FG_GREEN "%s" FG_WHITE "@" FG_CYAN "%s " FG_BLUE_BRIGHT "[%02d:%02d:%02d]" FG_WHITE " [%s] " FG_WHITE_BRIGHT "\n-> %% ",
+    printf(FG_GREEN "%s" FG_WHITE "@" FG_CYAN "%s " FG_BLUE_BRIGHT "[%02d:%02d:%02d]" FG_WHITE " [%s] " FG_RESET "\n-> %% ",
            USER, HOSTNAME, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, CWD);
 }
 

--- a/programs/stat.c
+++ b/programs/stat.c
@@ -46,15 +46,16 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    printf("File: %s\n", argv[1]);
+    printf("File: %s", argv[1]);
     if (S_ISLNK(dstat.st_mode)) {
         char link_buffer[PATH_MAX];
         ssize_t len;
         if ((len = readlink(argv[1], link_buffer, sizeof(link_buffer))) != -1) {
             link_buffer[len] = '\0';
-            printf(" -> %s\n", link_buffer);
+            printf(" -> %s", link_buffer);
         }
     }
+    putchar('\n');
     printf("Size: %s\n", to_human_size(dstat.st_size));
     printf("File type: ");
     switch (dstat.st_mode & S_IFMT) {

--- a/programs/tests/t_dup.c
+++ b/programs/tests/t_dup.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <sys/unistd.h>
 #include <strerror.h>
 #include <string.h>

--- a/programs/tests/t_msgget.c
+++ b/programs/tests/t_msgget.c
@@ -3,14 +3,15 @@
 /// @copyright (c) 2014-2024 This file is distributed under the MIT License.
 /// See LICENSE.md for details.
 
-#include "string.h"
-#include "sys/unistd.h"
-#include "sys/errno.h"
-#include "sys/msg.h"
-#include "sys/ipc.h"
-#include "stdlib.h"
-#include "fcntl.h"
-#include "stdio.h"
+#include <sys/unistd.h>
+#include <sys/errno.h>
+#include <sys/stat.h>
+#include <sys/msg.h>
+#include <sys/ipc.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <stdio.h>
 
 #define MESSAGE_LEN 100
 

--- a/programs/tests/t_semflg.c
+++ b/programs/tests/t_semflg.c
@@ -3,13 +3,14 @@
 /// @copyright (c) 2014-2024 This file is distributed under the MIT License.
 /// See LICENSE.md for details.
 
-#include "sys/unistd.h"
-#include "sys/errno.h"
-#include "sys/sem.h"
-#include "sys/ipc.h"
-#include "stdlib.h"
-#include "fcntl.h"
-#include "stdio.h"
+#include <sys/unistd.h>
+#include <sys/errno.h>
+#include <sys/stat.h>
+#include <sys/sem.h>
+#include <sys/ipc.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <stdio.h>
 
 int main(int argc, char *argv[])
 {

--- a/programs/tests/t_semget.c
+++ b/programs/tests/t_semget.c
@@ -5,13 +5,14 @@
 /// @copyright (c) 2014-2024 This file is distributed under the MIT License.
 /// See LICENSE.md for details.
 
-#include "sys/unistd.h"
-#include "sys/errno.h"
-#include "sys/sem.h"
-#include "sys/ipc.h"
-#include "stdlib.h"
-#include "fcntl.h"
-#include "stdio.h"
+#include <sys/unistd.h>
+#include <sys/errno.h>
+#include <sys/stat.h>
+#include <sys/sem.h>
+#include <sys/ipc.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <stdio.h>
 
 int main(int argc, char *argv[])
 {

--- a/programs/tests/t_semop.c
+++ b/programs/tests/t_semop.c
@@ -3,14 +3,15 @@
 /// @copyright (c) 2014-2024 This file is distributed under the MIT License.
 /// See LICENSE.md for details.
 
-#include "sys/sem.h"
-#include "stdio.h"
-#include "sys/ipc.h"
-#include "sys/errno.h"
-#include "sys/wait.h"
-#include "stdlib.h"
-#include "sys/unistd.h"
-#include "fcntl.h"
+#include <sys/unistd.h>
+#include <sys/errno.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/sem.h>
+#include <sys/ipc.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
 
 int main(int argc, char *argv[])
 {

--- a/programs/touch.c
+++ b/programs/touch.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <sys/unistd.h>
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This PR solves a couple of problems:

1. `readlink` was not opening the link correctly. Now it does;
2. Now both `stat` and `ls` correctly display the actual symlink path;
3. While fixing those commands, I noticed that ANSI coloring was wrong, so I fixed it.