### PR TITLE
fix __is_a_link helper

### DIFF
--- a/mentos/src/fs/namei.c
+++ b/mentos/src/fs/namei.c
@@ -108,7 +108,7 @@ char *realpath(const char *path, char *buffer, size_t buflen)
 static inline int __is_a_link(const char *path)
 {
     stat_t statbuf;
-    if (vfs_stat(path, &statbuf) > 0) {
+    if (vfs_stat(path, &statbuf) == 0) {
         return S_ISLNK(statbuf.st_mode);
     }
     return 0;


### PR DESCRIPTION
`vfs_stat` returns 0 on success, but `__is_a_link` checked for `> 0` and therefore never detected any symbolic links.

Fixes: f384cb91f74200ad496e150c60d501a45329d1dd