### PR TITLE
Monitor VFS and ET2 files. Fix memory leack.

### DIFF
--- a/mentos/CMakeLists.txt
+++ b/mentos/CMakeLists.txt
@@ -13,6 +13,8 @@ set(BOOTLOADER_NAME   bootloader)
 # Enables memory allocation tracing.
 option(ENABLE_KMEM_TRACE "Enables kmalloc tracing." OFF)
 option(ENABLE_PAGE_TRACE "Enables page allocation tracing." OFF)
+option(ENABLE_EXT2_TRACE "Enables EXT2 allocation tracing." OFF)
+option(ENABLE_FILE_TRACE "Enables vfs_file allocation tracing." OFF)
 # Enables scheduling feedback on terminal.
 option(ENABLE_SCHEDULER_FEEDBACK "Enables scheduling feedback on terminal." OFF)
 
@@ -144,6 +146,12 @@ endif(ENABLE_KMEM_TRACE)
 if(ENABLE_PAGE_TRACE)
     target_compile_definitions(${KERNEL_NAME} PUBLIC ENABLE_PAGE_TRACE)
 endif(ENABLE_PAGE_TRACE)
+if(ENABLE_EXT2_TRACE)
+    target_compile_definitions(${KERNEL_NAME} PUBLIC ENABLE_EXT2_TRACE)
+endif(ENABLE_EXT2_TRACE)
+if(ENABLE_FILE_TRACE)
+    target_compile_definitions(${KERNEL_NAME} PUBLIC ENABLE_FILE_TRACE)
+endif(ENABLE_FILE_TRACE)
 
 # =============================================================================
 # Enables scheduling feedback on terminal.

--- a/mentos/inc/fs/vfs.h
+++ b/mentos/inc/fs/vfs.h
@@ -6,13 +6,11 @@
 #pragma once
 
 #include "fs/vfs_types.h"
+#include "os_root_path.h"
 #include "mem/slab.h"
 
 /// Maximum number of opened file.
 #define MAX_OPEN_FD 16
-
-/// Cache for file structures in the VFS.
-extern kmem_cache_t *vfs_file_cache;
 
 /// @brief Forward declaration of task_struct.
 /// Used for task management in the VFS.
@@ -22,6 +20,26 @@ struct task_struct;
 /// This function sets up necessary resources and structures for the VFS. It
 /// must be called before any other VFS functions.
 void vfs_init(void);
+
+/// @brief Allocates a VFS file structure from the cache.
+/// @param file Source file where the allocation is requested (for logging).
+/// @param fun Function name where the allocation is requested (for logging).
+/// @param line Line number where the allocation is requested (for logging).
+/// @return Pointer to the allocated VFS file structure, or NULL if allocation fails.
+vfs_file_t *pr_vfs_alloc_file(const char *file, const char *fun, int line);
+
+/// @brief Frees a VFS file structure back to the cache.
+/// @param file Source file where the deallocation is requested (for logging).
+/// @param fun Function name where the deallocation is requested (for logging).
+/// @param line Line number where the deallocation is requested (for logging).
+/// @param vfs_file Pointer to the VFS file structure to free.
+void pr_vfs_dealloc_file(const char *file, const char *fun, int line, vfs_file_t *vfs_file);
+
+/// Wrapper that provides the filename, the function and line where the alloc is happening.
+#define vfs_alloc_file(...) pr_vfs_alloc_file(__RELATIVE_PATH__, __func__, __LINE__)
+
+/// Wrapper that provides the filename, the function and line where the free is happening.
+#define vfs_dealloc_file(...) pr_vfs_dealloc_file(__RELATIVE_PATH__, __func__, __LINE__, __VA_ARGS__)
 
 /// @brief Register a new filesystem.
 /// @param fs A pointer to the information concerning the new filesystem.

--- a/mentos/src/drivers/ata.c
+++ b/mentos/src/drivers/ata.c
@@ -1300,7 +1300,7 @@ static int ata_close(vfs_file_t *file)
         pr_debug("ata_close: Removed file `%s` from the opened file list.\n", file->name);
 
         // Free the file from cache.
-        kmem_cache_free(file);
+        vfs_dealloc_file(file);
         pr_debug("ata_close: Freed memory for file `%s`.\n", file->name);
     }
 
@@ -1552,7 +1552,7 @@ static vfs_file_operations_t ata_fs_operations = {
 static vfs_file_t *ata_device_create(ata_device_t *dev)
 {
     // Create the file.
-    vfs_file_t *file = kmem_cache_alloc(vfs_file_cache, GFP_KERNEL);
+    vfs_file_t *file = vfs_alloc_file();
     if (file == NULL) {
         pr_err("Failed to create ATA device.\n");
         return NULL;
@@ -1613,7 +1613,7 @@ static ata_device_type_t ata_device_detect(ata_device_t *dev)
         if (!vfs_register_superblock(dev->fs_root->name, dev->path, &ata_file_system_type, dev->fs_root)) {
             pr_alert("Failed to mount ata device!\n");
             // Free the memory.
-            kmem_cache_free(dev->fs_root);
+            vfs_dealloc_file(dev->fs_root);
             return ata_dev_type_unknown;
         }
         // Increment the drive letter.

--- a/mentos/src/drivers/mem.c
+++ b/mentos/src/drivers/mem.c
@@ -185,7 +185,7 @@ static struct memdev *null_device_create(const char *name)
     dev->next = NULL;
 
     // Allocate memory for the associated file structure.
-    dev->file = kmem_cache_alloc(vfs_file_cache, GFP_KERNEL);
+    dev->file = vfs_alloc_file();
     if (dev->file == NULL) {
         pr_err("null_device_create: Failed to allocate memory for file\n");
         kfree(dev); // Free the previously allocated device memory.
@@ -287,7 +287,7 @@ static int null_close(vfs_file_t *file)
         pr_debug("null_close: Removed file `%s` from the opened file list.\n", file->name);
 
         // Free the file from cache.
-        kmem_cache_free(file);
+        vfs_dealloc_file(file);
         pr_debug("null_close: Freed memory for file `%s`.\n", file->name);
     }
 

--- a/mentos/src/fs/pipe.c
+++ b/mentos/src/fs/pipe.c
@@ -630,7 +630,7 @@ static inline int pipe_is_blocking(vfs_file_t *file)
 static inline vfs_file_t *pipe_create_file_struct(const char *path, int flags, mode_t mode)
 {
     // Allocate memory for the VFS file structure.
-    vfs_file_t *vfs_file = kmem_cache_alloc(vfs_file_cache, GFP_KERNEL);
+    vfs_file_t *vfs_file = vfs_alloc_file();
     if (!vfs_file) {
         pr_err("Failed to allocate memory for VFS file!\n");
         return NULL;
@@ -879,7 +879,7 @@ static int pipe_close(vfs_file_t *file)
         list_head_remove(&file->siblings);
 
         // Free the file from cache.
-        kmem_cache_free(file);
+        vfs_dealloc_file(file);
     }
 
     return 0;

--- a/mentos/src/fs/procfs.c
+++ b/mentos/src/fs/procfs.c
@@ -317,7 +317,7 @@ static inline vfs_file_t *procfs_create_file_struct(procfs_file_t *procfs_file)
         pr_err("procfs_create_file_struct(%p): Procfs file not valid!\n", procfs_file);
         return NULL;
     }
-    vfs_file_t *vfs_file = kmem_cache_alloc(vfs_file_cache, GFP_KERNEL);
+    vfs_file_t *vfs_file = vfs_alloc_file();
     if (!vfs_file) {
         pr_err("procfs_create_file_struct(%p): Failed to allocate memory for VFS file!\n", procfs_file);
         return NULL;
@@ -557,7 +557,7 @@ static int procfs_close(vfs_file_t *file)
         pr_debug("procfs_close: Removed file `%s` from the opened file list.\n", file->name);
 
         // Free the file from cache.
-        kmem_cache_free(file);
+        vfs_dealloc_file(file);
         pr_debug("procfs_close: Freed memory for file `%s`.\n", file->name);
     }
 

--- a/mentos/src/mem/slab.c
+++ b/mentos/src/mem/slab.c
@@ -442,7 +442,7 @@ int kmem_cache_init(void)
     list_head_init(&kmem_caches_list);
 
 #ifdef ENABLE_KMEM_TRACE
-    resource_id = register_resource("kmem");
+    ENABLE_EXT2_TRACE = register_resource("kmem");
 #endif
 
     // Create a cache to store metadata about kmem_cache_t structures.

--- a/programs/login.c
+++ b/programs/login.c
@@ -268,13 +268,12 @@ int main(int argc, char **argv)
             continue; // Retry after error
         }
 
-        struct spwd *spwd;
-        if ((spwd = getspnam(username)) == NULL) {
+        struct spwd *shadow;
+        if ((shadow = getspnam(username)) == NULL) {
             printf("Could not retrieve the secret password of %s: %s\n", username, strerror(errno));
             continue; // Retry if unable to get shadow password
         }
 
-        // Hash the input password for verification
         unsigned char hash[SHA256_BLOCK_SIZE]       = { 0 };
         char hash_string[SHA256_BLOCK_SIZE * 2 + 1] = { 0 };
         SHA256_ctx_t ctx;
@@ -286,7 +285,7 @@ int main(int argc, char **argv)
         sha256_bytes_to_hex(hash, SHA256_BLOCK_SIZE, hash_string, SHA256_BLOCK_SIZE * 2 + 1);
 
         // Verify the password against the stored hash
-        if (strcmp(spwd->sp_pwdp, hash_string) != 0) {
+        if (strcmp(shadow->sp_pwdp, hash_string) != 0) {
             printf("Wrong password.\n");
             continue; // Retry on incorrect password
         }


### PR DESCRIPTION
- Set up the resources monitoring for VFS files and ET2 files.
- Found a memory leack in shadow.c thanks to the resource monitor (good boy).