### PR TITLE
Fix struct vs. typedef naming mismatch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,8 @@
         "span": "cpp",
         "format": "cpp",
         "cstdio": "c",
-        "algorithm": "c"
+        "algorithm": "c",
+        "fdc.h": "c",
+        "rbtree.h": "c"
     }
 }

--- a/libc/inc/array.h
+++ b/libc/inc/array.h
@@ -14,7 +14,7 @@
 /// @param type The data type of the array elements.
 /// @param name The base name for the generated structure and functions.
 #define DECLARE_ARRAY(type, name)                                                                                      \
-    typedef struct arr_##name##_t {                                                                                    \
+    typedef struct arr_##name##{                                                                                       \
         const unsigned size;                                                                                           \
         type *buffer;                                                                                                  \
     } arr_##name##_t;                                                                                                  \

--- a/libc/inc/dirent.h
+++ b/libc/inc/dirent.h
@@ -41,7 +41,7 @@ static const char dt_char_array[] = {
 };
 
 /// Directory entry.
-typedef struct dirent_t {
+typedef struct dirent {
     ino_t d_ino;             ///< Inode number.
     off_t d_off;             ///< Offset to next linux_dirent.
     unsigned short d_reclen; ///< Length of this linux_dirent.

--- a/libc/inc/list.h
+++ b/libc/inc/list.h
@@ -13,13 +13,13 @@
 #include <string.h>
 
 /// @brief Represents the node of a list.
-typedef struct listnode_t {
+typedef struct listnode {
     list_head_t list; ///< List structure for this node.
     void *value;      ///< Pointer to node's value.
 } listnode_t;
 
 /// @brief Represents the list.
-typedef struct list_t {
+typedef struct list {
     list_head_t head;              ///< Head of the list.
     unsigned int size;             ///< Size of the list.
     listnode_t *(*alloc)(void);    ///< Node allocation function.

--- a/libc/inc/pwd.h
+++ b/libc/inc/pwd.h
@@ -8,7 +8,7 @@
 #include "stddef.h"
 
 /// @brief Stores user account information.
-typedef struct passwd_t {
+typedef struct passwd {
     char *pw_name;   ///< User's login name.
     char *pw_passwd; ///< Encrypted password (not currently).
     uid_t pw_uid;    ///< User ID.

--- a/libc/inc/stdbool.h
+++ b/libc/inc/stdbool.h
@@ -6,7 +6,7 @@
 #pragma once
 
 /// @brief Define boolean value.
-typedef enum bool_t {
+typedef enum bool {
     false, ///< [0] False.
     true   ///< [1] True.
 } __attribute__((__packed__)) bool_t;

--- a/libc/inc/sys/utsname.h
+++ b/libc/inc/sys/utsname.h
@@ -9,7 +9,7 @@
 #define SYS_LEN 257
 
 /// @brief Holds information concerning the machine and the os.
-typedef struct utsname_t {
+typedef struct utsname {
     /// The name of the system.
     char sysname[SYS_LEN];
     /// The name of the node.

--- a/mentos/inc/boot.h
+++ b/mentos/inc/boot.h
@@ -8,7 +8,7 @@
 #include "multiboot.h"
 
 /// @brief Mentos structure to communicate bootloader info to the kernel
-typedef struct boot_info_t {
+typedef struct boot_info {
     /// Boot magic number.
     unsigned int magic;
 

--- a/mentos/inc/descriptor_tables/gdt.h
+++ b/mentos/inc/descriptor_tables/gdt.h
@@ -73,7 +73,7 @@
 ///
 ///  You can have both 16 bit and 32 bit selectors at once.
 ///
-enum gdt_bits_t {
+enum gdt_bits {
     /// @brief `0b10000000U` (Present): This must be 1 for all valid selectors.
     GDT_PRESENT      = 128U,
     /// @brief `0b00000000U` (Privilege): Sets the 2 privilege bits (ring level) to 0 = highest (kernel).
@@ -104,7 +104,7 @@ enum gdt_bits_t {
 #define IDT_PADDING 14U // `0b00001110U
 
 /// @brief Data structure representing a GDT descriptor.
-typedef struct gdt_descriptor_t {
+typedef struct gdt_descriptor {
     /// The lower 16 bits of the limit.
     uint16_t limit_low;
     /// The lower 16 bits of the base.
@@ -120,7 +120,7 @@ typedef struct gdt_descriptor_t {
 } __attribute__((packed)) gdt_descriptor_t;
 
 /// @brief Data structure used to load the GDT into the GDTR.
-typedef struct gdt_pointer_t {
+typedef struct gdt_pointer {
     /// The size of the GDT (entry number).
     uint16_t limit;
     /// The starting address of the GDT.

--- a/mentos/inc/descriptor_tables/idt.h
+++ b/mentos/inc/descriptor_tables/idt.h
@@ -44,7 +44,7 @@
  */
 
 /// @brief This structure describes one interrupt gate.
-typedef struct idt_descriptor_t {
+typedef struct idt_descriptor {
     /// The lower 16 bits of the ISR's address.
     uint16_t offset_low;
     /// The GDT segment selector that the CPU will load into CS before calling the ISR.
@@ -58,7 +58,7 @@ typedef struct idt_descriptor_t {
 } __attribute__((packed)) idt_descriptor_t;
 
 /// @brief A pointer structure used for informing the CPU about our IDT.
-typedef struct idt_pointer_t {
+typedef struct idt_pointer {
     /// The size of the IDT (entry number).
     uint16_t limit;
     /// The start address of the IDT.

--- a/mentos/inc/drivers/keyboard/keymap.h
+++ b/mentos/inc/drivers/keyboard/keymap.h
@@ -20,7 +20,7 @@ typedef enum {
 } keymap_type_t;
 
 /// @brief Defines the mapping of a single scancode towards a set of characters.
-typedef struct keymap_t {
+typedef struct keymap {
     /// The basic mapping.
     int normal;
     /// The mapping when shifted.

--- a/mentos/inc/elf/elf.h
+++ b/mentos/inc/elf/elf.h
@@ -160,7 +160,7 @@ typedef struct elf_symbol {
 } elf_symbol_t;
 
 /// @brief Holds information about relocation object (that do not need an addend).
-typedef struct elf_rel_t {
+typedef struct elf_rel {
     /// TODO: Comment.
     uint32_t r_offset;
     /// TODO: Comment.
@@ -168,7 +168,7 @@ typedef struct elf_rel_t {
 } elf_rel_t;
 
 /// @brief Holds information about relocation object (that need an addend).
-typedef struct elf_rela_t {
+typedef struct elf_rela {
     /// TODO: Comment.
     uint32_t r_offset;
     /// TODO: Comment.

--- a/mentos/inc/fs/procfs.h
+++ b/mentos/inc/fs/procfs.h
@@ -8,7 +8,7 @@
 #include "process/process.h"
 
 /// @brief Stores information about a procfs directory entry.
-typedef struct proc_dir_entry_t {
+typedef struct proc_dir_entry {
     /// Generic system operations.
     vfs_sys_operations_t *sys_operations;
     /// Files operations.

--- a/mentos/inc/hardware/cpuid.h
+++ b/mentos/inc/hardware/cpuid.h
@@ -19,7 +19,7 @@
 #define EDX_FLAGS_SIZE 32
 
 /// @brief Contains the information concerning the CPU.
-typedef struct cpuinfo_t {
+typedef struct cpuinfo {
     /// The name of the vendor.
     char cpu_vendor[13];
     /// The type of the CPU.

--- a/mentos/inc/klib/mutex.h
+++ b/mentos/inc/klib/mutex.h
@@ -8,7 +8,7 @@
 #include "stdint.h"
 
 /// @brief Structure of a mutex.
-typedef struct mutex_t {
+typedef struct mutex {
     /// The state of the mutex.
     uint8_t state;
     /// The owner of the mutex.

--- a/mentos/inc/klib/rbtree.h
+++ b/mentos/inc/klib/rbtree.h
@@ -14,11 +14,11 @@
 // Opaque types.
 
 /// @brief Node of the tree.
-typedef struct rbtree_node_t rbtree_node_t;
+typedef struct rbtree_node rbtree_node_t;
 /// @brief The tree itself.
-typedef struct rbtree_t rbtree_t;
+typedef struct rbtree rbtree_t;
 /// @brief Iterator for traversing the tree.
-typedef struct rbtree_iter_t rbtree_iter_t;
+typedef struct rbtree_iter rbtree_iter_t;
 
 // ============================================================================
 // Comparison functions.

--- a/mentos/inc/mem/buddy_system.h
+++ b/mentos/inc/mem/buddy_system.h
@@ -20,7 +20,7 @@
 #define PG_FROM_BBSTRUCT(bbstruct, page, element) ((page *)(((uint32_t)(bbstruct)) - BBSTRUCT_OFFSET(page, element)))
 
 /// The base structure representing a bb page
-typedef struct bb_page_t {
+typedef struct bb_page {
     /// The flags of the page.
     volatile unsigned long flags;
     /// The current page order.
@@ -36,7 +36,7 @@ typedef struct bb_page_t {
 
 /// @brief Buddy system descriptor: collection of free page blocks.
 /// Each block represents 2^k free contiguous page.
-typedef struct bb_free_area_t {
+typedef struct bb_free_area {
     /// free_list collectes the first page descriptors of a blocks of 2^k frames
     list_head_t free_list;
     /// nr_free specifies the number of blocks of free pages.
@@ -45,7 +45,7 @@ typedef struct bb_free_area_t {
 
 /// @brief Buddy system instance,
 /// that represents a memory area managed by the buddy system
-typedef struct bb_instance_t {
+typedef struct bb_instance {
     /// Name of this bb instance
     const char *name;
     /// List of buddy system pages grouped by level.

--- a/mentos/inc/mem/paging.h
+++ b/mentos/inc/mem/paging.h
@@ -30,7 +30,7 @@
 #define MAX_PAGE_DIR_ENTRIES   1024
 
 /// @brief An entry of a page directory.
-typedef struct page_dir_entry_t {
+typedef struct page_dir_entry {
     unsigned int present : 1;   ///< Page is present in memory.
     unsigned int rw : 1;        ///< Read/write permission (0 = read-only, 1 = read/write).
     unsigned int user : 1;      ///< User/supervisor (0 = supervisor, 1 = user).
@@ -45,7 +45,7 @@ typedef struct page_dir_entry_t {
 } page_dir_entry_t;
 
 /// @brief An entry of a page table.
-typedef struct page_table_entry_t {
+typedef struct page_table_entry {
     unsigned int present : 1;    ///< Page is present in memory.
     unsigned int rw : 1;         ///< Read/write permission (0 = read-only, 1 = read/write).
     unsigned int user : 1;       ///< User/supervisor (0 = supervisor, 1 = user).
@@ -74,14 +74,14 @@ enum MEMMAP_FLAGS {
 /// @brief A page table.
 /// @details
 /// It contains 1024 entries which can be addressed by 10 bits (log_2(1024)).
-typedef struct page_table_t {
+typedef struct page_table {
     /// @brief Array of page table entries.
     page_table_entry_t pages[MAX_PAGE_TABLE_ENTRIES];
 } __attribute__((aligned(PAGE_SIZE))) page_table_t;
 
 /// @brief A page directory.
 /// @details In the two-level paging, this is the first level.
-typedef struct page_directory_t {
+typedef struct page_directory {
     /// @brief Array of page directory entries.
     /// @details
     /// We need a table that contains virtual addresses, so that we can actually
@@ -90,9 +90,9 @@ typedef struct page_directory_t {
 } __attribute__((aligned(PAGE_SIZE))) page_directory_t;
 
 /// @brief Virtual Memory Area, used to store details of a process segment.
-typedef struct vm_area_struct_t {
+typedef struct vm_area_struct {
     /// Pointer to the memory descriptor associated with this area.
-    struct mm_struct_t *vm_mm;
+    struct mm_struct *vm_mm;
     /// Start address of the segment, inclusive.
     uint32_t vm_start;
     /// End address of the segment, exclusive.
@@ -106,7 +106,7 @@ typedef struct vm_area_struct_t {
 } vm_area_struct_t;
 
 /// @brief Memory Descriptor, used to store details about the memory of a user process.
-typedef struct mm_struct_t {
+typedef struct mm_struct {
     /// List of memory areas (vm_area_struct references).
     list_head_t mmap_list;
     /// Pointer to the last used memory area.

--- a/mentos/inc/mem/slab.h
+++ b/mentos/inc/mem/slab.h
@@ -24,7 +24,7 @@ typedef void (*kmem_fun_t)(void *);
     kmem_cache_create(#objtype, sizeof(objtype), alignof(objtype), GFP_KERNEL, (kmem_fun_t)(ctor), NULL)
 
 /// @brief Stores the information of a cache.
-typedef struct kmem_cache_t {
+typedef struct kmem_cache {
     /// Link to place this cache in a global list of caches.
     list_head_t cache_list;
     /// Name of the cache.

--- a/mentos/inc/mem/vmem_map.h
+++ b/mentos/inc/mem/vmem_map.h
@@ -10,13 +10,13 @@
 #include "mem/zone_allocator.h"
 
 /// @brief Virtual mapping manager.
-typedef struct virt_map_page_manager_t {
+typedef struct virt_map_page_manager {
     /// The buddy system used to manage the pages.
     bb_instance_t bb_instance;
 } virt_map_page_manager_t;
 
 /// @brief Virtual mapping.
-typedef struct virt_map_page_t {
+typedef struct virt_map_page {
     /// A buddy system page.
     bb_page_t bbpage;
 } virt_map_page_t;

--- a/mentos/inc/mem/zone_allocator.h
+++ b/mentos/inc/mem/zone_allocator.h
@@ -22,7 +22,7 @@
 
 /// @brief Page descriptor. Use as a bitmap to understand the order of the block
 /// and if it is free or allocated.
-typedef struct page_t {
+typedef struct page {
     /// @brief Array of flags encoding also the zone number to which the page
     /// frame belongs.
     unsigned long flags;
@@ -44,7 +44,7 @@ typedef struct page_t {
     union {
         /// @brief Holds the slab page used to handle this memory region (root
         /// page).
-        struct page_t *slab_main_page;
+        struct page *slab_main_page;
         /// @brief Holds the slab cache pointer on the main page.
         kmem_cache_t *slab_cache;
     } container;
@@ -73,7 +73,7 @@ enum zone_type {
 };
 
 /// @brief Data structure to differentiate memory zone.
-typedef struct zone_t {
+typedef struct zone {
     /// Zone's name.
     char *name;
     /// Pointer to first page descriptor of the zone.
@@ -92,7 +92,7 @@ typedef struct zone_t {
 
 /// @brief Data structure to rapresent a memory node. In Uniform memory access
 /// (UMA) architectures there is only one node called contig_page_data.
-typedef struct pg_data_t {
+typedef struct pg_data {
     /// Zones of the node.
     zone_t node_zones[__MAX_NR_ZONES];
     /// Number of zones in the node.

--- a/mentos/inc/multiboot.h
+++ b/mentos/inc/multiboot.h
@@ -74,7 +74,7 @@
 //            +-------------------+
 
 /// The symbol table for a.out.
-typedef struct multiboot_aout_symbol_table_t {
+typedef struct multiboot_aout_symbol_table {
     /// TODO: Comment.
     uint32_t tabsize;
     /// TODO: Comment.
@@ -86,7 +86,7 @@ typedef struct multiboot_aout_symbol_table_t {
 } multiboot_aout_symbol_table_t;
 
 /// The section header table for ELF.
-typedef struct multiboot_elf_section_header_table_t {
+typedef struct multiboot_elf_section_header_table {
     /// TODO: Comment.
     uint32_t num;
     /// TODO: Comment.
@@ -98,7 +98,7 @@ typedef struct multiboot_elf_section_header_table_t {
 } multiboot_elf_section_header_table_t;
 
 /// @brief Stores information about a module.
-typedef struct multiboot_module_t {
+typedef struct multiboot_module {
     // The memory used goes from bytes 'mod_start' to 'mod_end-1' inclusive.
     /// The starting address of the modules.
     uint32_t mod_start;
@@ -111,7 +111,7 @@ typedef struct multiboot_module_t {
 } multiboot_module_t;
 
 /// @brief Stores information about memory mapping.
-typedef struct multiboot_memory_map_t {
+typedef struct multiboot_memory_map {
     /// Size of this entry.
     uint32_t size;
     /// Lower bytes of the base address.
@@ -127,7 +127,7 @@ typedef struct multiboot_memory_map_t {
 } multiboot_memory_map_t;
 
 /// @brief Multiboot information structure.
-typedef struct multiboot_info_t {
+typedef struct multiboot_info {
     /// Multiboot info version number.
     uint32_t flags;
     /// Lower memory available from the BIOS.

--- a/mentos/inc/process/process.h
+++ b/mentos/inc/process/process.h
@@ -29,7 +29,7 @@
 /// in which 0 to 99 for real time and 100 to 139 for users.
 /// The nice value range is -20 to +19 where -20 is highest, 0 default and +19
 /// is lowest. relation between nice value and priority is : PR = 20 + NI.
-typedef struct sched_entity_t {
+typedef struct sched_entity {
     /// Static execution priority.
     int prio;
 
@@ -65,7 +65,7 @@ typedef struct sched_entity_t {
 } sched_entity_t;
 
 /// @brief Stores the status of CPU and FPU registers.
-typedef struct thread_struct_t {
+typedef struct thread_struct {
     /// Stored status of registers.
     pt_regs regs;
     /// Stored status of registers befor jumping into a signal handler.

--- a/mentos/inc/process/scheduler.h
+++ b/mentos/inc/process/scheduler.h
@@ -13,7 +13,7 @@
 #define MAX_PROCESSES 256
 
 /// @brief Structure that contains information about live processes.
-typedef struct runqueue_t {
+typedef struct runqueue {
     /// Number of queued processes.
     size_t num_active;
     /// Number of queued periodic processes.
@@ -25,7 +25,7 @@ typedef struct runqueue_t {
 } runqueue_t;
 
 /// @brief Structure that describes scheduling parameters.
-typedef struct sched_param_t {
+typedef struct sched_param {
     /// Static execution priority.
     int sched_priority;
     /// Expected period of the task

--- a/mentos/inc/system/signal.h
+++ b/mentos/inc/system/signal.h
@@ -165,13 +165,13 @@ typedef void (*sighandler_t)(int);
 /// Signals are divided into two cathegories, identified by the two unsigned longs:
 ///     [ 1, 31] corresponds to normal signals;
 ///     [32, 64] corresponds to real-time signals.
-typedef struct sigset_t {
+typedef struct sigset {
     /// Signals divided into two cathegories.
     unsigned long sig[2];
 } sigset_t;
 
 /// @brief Holds the information on how to handle a specific signal.
-typedef struct sigaction_t {
+typedef struct sigaction {
     /// This field specifies the type of action to be performed; its value can be a pointer
     /// to the signal handler, SIG_DFL (that is, the value 0) to specify that the default
     /// action is performed, or SIG_IGN (that is, the value 1) to specify that the signal is
@@ -184,7 +184,7 @@ typedef struct sigaction_t {
 } sigaction_t;
 
 /// @brief Describes how each signal must be handled.
-typedef struct sighand_t {
+typedef struct sighand {
     /// Usage counter of the signal handler descriptor.
     atomic_t count;
     /// Array of structures specifying the actions to be performed upon delivering the signals
@@ -200,7 +200,7 @@ typedef union sigval {
 } sigval_t;
 
 /// @brief Stores information about an occurrence of a specific signal.
-typedef struct siginfo_t {
+typedef struct siginfo {
     /// The signal number.
     int si_signo;
     /// A code identifying who raised the signal (see signal_sender_code_t).
@@ -222,7 +222,7 @@ typedef struct siginfo_t {
 } siginfo_t;
 
 /// @brief An entry of the signal queue.
-typedef struct sigqueue_t {
+typedef struct sigqueue {
     /// Links for the pending signal queue’s list.
     list_head_t list;
     /// Flags associated with the queued signal.
@@ -234,7 +234,7 @@ typedef struct sigqueue_t {
 } sigqueue_t;
 
 /// @brief Keeps information of pending signals.
-typedef struct sigpending_t {
+typedef struct sigpending {
     /// Head of the list of pending signals.
     list_head_t list;
     /// The mask which can be queried to know which signals are pending.

--- a/mentos/src/boot.c
+++ b/mentos/src/boot.c
@@ -18,7 +18,7 @@
 /// @param stack_pointer The stack base pointer, usually at the end of the lowmem.
 /// @param entry
 /// @param boot_info
-extern void boot_kernel(uint32_t stack_pointer, uint32_t entry, struct boot_info_t *boot_info);
+extern void boot_kernel(uint32_t stack_pointer, uint32_t entry, boot_info_t *boot_info);
 
 /// @brief Size of the kernel's stack.
 #define KERNEL_STACK_SIZE 0x100000

--- a/mentos/src/descriptor_tables/interrupt.c
+++ b/mentos/src/descriptor_tables/interrupt.c
@@ -18,7 +18,7 @@
 #include "system/printk.h"
 
 /// @brief Shared interrupt handlers, stored into a double-linked list.
-typedef struct irq_struct_t {
+typedef struct irq_struct {
     /// Pointer to the IRQ handler.
     interrupt_handler_t handler;
     /// Pointer to the description of the handler.

--- a/mentos/src/drivers/ata.c
+++ b/mentos/src/drivers/ata.c
@@ -29,7 +29,7 @@
 #include "system/panic.h"
 
 /// @brief IDENTIFY device data (response to 0xEC).
-typedef struct ata_identity_t {
+typedef struct ata_identity {
     /// Word      0 : General configuration.
     struct {
         /// Reserved.
@@ -135,7 +135,7 @@ typedef struct ata_identity_t {
 ///         |    byte 3  |  byte 2  |  byte 1  |  byte 0    |
 /// Dword 0 |  Memory Region Physical Base Address [31:1] |0|
 /// Dword 1 |  EOT | reserved       | Byte Count   [15:1] |0|
-typedef struct prdt_t {
+typedef struct prdt {
     /// The first 4 bytes specify the byte address of a physical memory region.
     unsigned int physical_address;
     /// The next two bytes specify the count of the region in bytes (64K byte limit per region).
@@ -145,7 +145,7 @@ typedef struct prdt_t {
 } prdt_t;
 
 /// @brief Stores information about an ATA device.
-typedef struct ata_device_t {
+typedef struct ata_device {
     /// Name of the device.
     char name[NAME_MAX];
     /// Name of the device.

--- a/mentos/src/drivers/fdc.c
+++ b/mentos/src/drivers/fdc.c
@@ -16,7 +16,7 @@
 #include "io/video.h"
 
 /// @brief Floppy Disk Controller (FDC) registers.
-typedef enum fdc_registers_t {
+typedef enum fdc_registers {
     STATUS_REGISTER_A              = 0x3F0,
     ///< This register is read-only and monitors the state of the
     ///< interrupt pin and several disk interface pins.

--- a/mentos/src/fs/ext2.c
+++ b/mentos/src/fs/ext2.c
@@ -59,7 +59,7 @@ static int resource_id = -1;
 // ============================================================================
 
 /// @brief Types of file in an EXT2 filesystem.
-typedef enum ext2_file_type_t {
+typedef enum ext2_file_type {
     ext2_file_type_unknown,          ///< Unknown type.
     ext2_file_type_regular_file,     ///< Regular file.
     ext2_file_type_directory,        ///< Directory.
@@ -76,7 +76,7 @@ typedef enum ext2_file_type_t {
 /// bytes from the start of the device, and it is essential to mounting the
 /// filesystem. Since it is so important, backup copies of the superblock are
 /// stored in block groups throughout the filesystem.
-typedef struct ext2_superblock_t {
+typedef struct ext2_superblock {
     /// @brief Total number of inodes in file system.
     uint32_t inodes_count;
     /// @brief Total number of blocks in file system
@@ -203,7 +203,7 @@ typedef struct ext2_superblock_t {
 } ext2_superblock_t;
 
 /// @brief Entry of the Block Group Descriptor Table (BGDT).
-typedef struct ext2_group_descriptor_t {
+typedef struct ext2_group_descriptor {
     /// @brief The block number of the block bitmap for this Block Group
     uint32_t block_bitmap;
     /// @brief The block number of the inode allocation bitmap for this Block Group.
@@ -223,7 +223,7 @@ typedef struct ext2_group_descriptor_t {
 } ext2_group_descriptor_t;
 
 /// @brief The ext2 inode.
-typedef struct ext2_inode_t {
+typedef struct ext2_inode {
     /// @brief File mode
     uint16_t mode;
     /// @brief The user identifiers of the owners.
@@ -277,7 +277,7 @@ typedef struct ext2_inode_t {
 } ext2_inode_t;
 
 /// @brief The header of an ext2 directory entry.
-typedef struct ext2_dirent_t {
+typedef struct ext2_dirent {
     /// Number of the inode that this directory entry points to.
     uint32_t inode;
     /// Length of this directory entry. Must be a multiple of 4.
@@ -291,7 +291,7 @@ typedef struct ext2_dirent_t {
 } ext2_dirent_t;
 
 /// @brief The details regarding the filesystem.
-typedef struct ext2_filesystem_t {
+typedef struct ext2_filesystem {
     /// Pointer to the block device.
     vfs_file_t *block_device;
     /// Device superblock, contains important information.
@@ -328,7 +328,7 @@ typedef struct ext2_filesystem_t {
 } ext2_filesystem_t;
 
 /// @brief Structure used when searching for a directory entry.
-typedef struct ext2_direntry_search_t {
+typedef struct ext2_direntry_search {
     /// The inode of the parent directory.
     ino_t parent_inode;
     /// The index of the block where the direntry resides.
@@ -1902,7 +1902,7 @@ static ssize_t ext2_write_inode_data(
 // ============================================================================
 
 /// @brief Iterator for visiting the directory entries.
-typedef struct ext2_direntry_iterator_t {
+typedef struct ext2_direntry_iterator {
     ext2_filesystem_t *fs;   ///< A pointer to the filesystem.
     uint8_t *cache;          ///< Cache used for reading.
     ext2_inode_t *inode;     ///< A pointer to the directory inode.

--- a/mentos/src/fs/procfs.c
+++ b/mentos/src/fs/procfs.c
@@ -32,7 +32,7 @@
 // ============================================================================
 
 /// @brief Information concerning a file.
-typedef struct procfs_file_t {
+typedef struct procfs_file {
     /// Number used as delimiter, it must be set to 0xBF.
     int magic;
     /// The file inode.
@@ -63,7 +63,7 @@ typedef struct procfs_file_t {
 
 /// @brief The details regarding the filesystem.
 /// @brief Contains the number of files inside the procfs filesystem.
-typedef struct procfs_t {
+typedef struct procfs {
     /// Number of files.
     unsigned int nfiles;
     /// List of headers.
@@ -876,7 +876,7 @@ static file_system_type_t procfs_file_system_type = {.name = "procfs", .fs_flags
 int procfs_module_init(void)
 {
     // Initialize the procfs.
-    memset(&fs, 0, sizeof(struct procfs_t));
+    memset(&fs, 0, sizeof(procfs_t));
     // Initialize the cache.
     fs.procfs_file_cache = KMEM_CREATE(procfs_file_t);
     // Initialize the list of procfs files.

--- a/mentos/src/io/video.c
+++ b/mentos/src/io/video.c
@@ -25,7 +25,7 @@
 #define STORED_PAGES 10                   ///< The number of stored pages.
 
 /// @brief Stores the association between ANSI colors and pure VIDEO colors.
-struct ansi_color_map_t {
+struct ansi_color_map {
     /// The ANSI color number.
     uint8_t ansi_color;
     /// The VIDEO color number.

--- a/mentos/src/klib/rbtree.c
+++ b/mentos/src/klib/rbtree.c
@@ -10,7 +10,7 @@
 #include "mem/slab.h"
 
 /// @brief Stores information of a node.
-struct rbtree_node_t {
+struct rbtree_node {
     /// Color red (1), black (0)
     int red;
     /// Link left [0] and right [1]
@@ -20,7 +20,7 @@ struct rbtree_node_t {
 };
 
 /// @brief Stores information of a rbtree.
-struct rbtree_t {
+struct rbtree {
     /// Root of the tree.
     rbtree_node_t *root;
     /// Comparison function for insertion.
@@ -30,7 +30,7 @@ struct rbtree_t {
 };
 
 /// @brief Stores information for iterating a rbtree.
-struct rbtree_iter_t {
+struct rbtree_iter {
     /// Pointer to the tree itself.
     rbtree_t *tree;
     /// Current node

--- a/mentos/src/mem/kheap.c
+++ b/mentos/src/mem/kheap.c
@@ -34,9 +34,9 @@
 /// This address marks the endpoint of the heap, ensuring no overlap with other memory regions.
 #define HEAP_VM_UB 0x50000000
 
-/// @brief The overhead introduced by the block_t structure itself.
+/// @brief The overhead introduced by the kheap_block_t structure itself.
 /// This is used for memory management and bookkeeping.
-#define OVERHEAD sizeof(block_t)
+#define OVERHEAD sizeof(kheap_block_t)
 
 /// @brief Aligns the given address to the nearest upper page boundary.
 /// The address will be aligned to 4096 bytes (0x1000).
@@ -51,7 +51,7 @@
 
 /// @brief Represents a block of memory within the heap.
 /// This structure includes metadata for managing memory allocation and free status.
-typedef struct block_t {
+typedef struct kheap_block {
     /// @brief A single bit indicating if the block is free (1) or allocated (0).
     unsigned int is_free : 1;
 
@@ -64,7 +64,7 @@ typedef struct block_t {
 
     /// @brief Entry in the list of free blocks.
     list_head_t free;
-} block_t;
+} kheap_block_t;
 
 /// @brief Maps the heap memory to easily accessible values.
 /// This structure contains pointers to the list of all blocks and the list of free blocks.
@@ -88,7 +88,7 @@ static inline uint32_t __blkmngr_get_rounded_size(uint32_t size) { return round_
 /// @param block The given block to check. Must not be NULL.
 /// @param size  The size to check against the block's size.
 /// @return 1 if the size fits within the block, -1 if the block is NULL.
-static inline int __blkmngr_does_it_fit(block_t *block, uint32_t size)
+static inline int __blkmngr_does_it_fit(kheap_block_t *block, uint32_t size)
 {
     // Check for a null block pointer to avoid dereferencing a null pointer
     if (!block) {
@@ -104,7 +104,7 @@ static inline int __blkmngr_does_it_fit(block_t *block, uint32_t size)
 /// the information of the specified block into a human-readable string.
 /// @param block The block to represent. Can be NULL.
 /// @return A string containing the block's address, size, and free status.
-static inline const char *__block_to_string(block_t *block)
+static inline const char *__block_to_string(kheap_block_t *block)
 {
     // Static buffer to hold the string representation of the block.
     static char buffer[256];
@@ -134,19 +134,19 @@ static inline void __blkmngr_dump(int log_level, heap_header_t *header)
     // Get the current process.
     task_struct *task = scheduler_get_current_process();
     assert(task && "There is no current task!\n");
-    block_t *block;
+    kheap_block_t *block;
     pr_log(log_level, "[%s] LIST (0x%p):\n", task->name, &header->list);
     list_for_each_decl (it, &header->list) {
-        block = list_entry(it, block_t, list);
+        block = list_entry(it, kheap_block_t, list);
         pr_log(log_level, "[%s]     %s{", task->name, __block_to_string(block));
         if (it->prev != &header->list) {
-            pr_log(log_level, "0x%p", list_entry(it->prev, block_t, list));
+            pr_log(log_level, "0x%p", list_entry(it->prev, kheap_block_t, list));
         } else {
             pr_log(log_level, "   HEAD   ");
         }
         pr_log(log_level, ", ");
         if (it->next != &header->list) {
-            pr_log(log_level, "0x%p", list_entry(it->next, block_t, list));
+            pr_log(log_level, "0x%p", list_entry(it->next, kheap_block_t, list));
         } else {
             pr_log(log_level, "   HEAD   ");
         }
@@ -154,16 +154,16 @@ static inline void __blkmngr_dump(int log_level, heap_header_t *header)
     }
     pr_log(log_level, "[%s] FREE (0x%p):\n", task->name, &header->free);
     list_for_each_decl (it, &header->free) {
-        block = list_entry(it, block_t, free);
+        block = list_entry(it, kheap_block_t, free);
         pr_log(log_level, "[%s]     %s{", task->name, __block_to_string(block));
         if (it->prev != &header->free) {
-            pr_log(log_level, "0x%p", list_entry(it->prev, block_t, free));
+            pr_log(log_level, "0x%p", list_entry(it->prev, kheap_block_t, free));
         } else {
             pr_log(log_level, "   HEAD   ");
         }
         pr_log(log_level, ", ");
         if (it->next != &header->free) {
-            pr_log(log_level, "0x%p", list_entry(it->next, block_t, free));
+            pr_log(log_level, "0x%p", list_entry(it->next, kheap_block_t, free));
         } else {
             pr_log(log_level, "   HEAD   ");
         }
@@ -176,7 +176,7 @@ static inline void __blkmngr_dump(int log_level, heap_header_t *header)
 /// @param header header describing the heap.
 /// @param size the size we want.
 /// @return a block that should fit our needs.
-static inline block_t *__blkmngr_find_best_fitting(heap_header_t *header, uint32_t size)
+static inline kheap_block_t *__blkmngr_find_best_fitting(heap_header_t *header, uint32_t size)
 {
     // Check if the header is NULL, log an error and return NULL
     if (!header) {
@@ -184,13 +184,13 @@ static inline block_t *__blkmngr_find_best_fitting(heap_header_t *header, uint32
         return NULL; // Return NULL to indicate failure.
     }
 
-    block_t *best_fitting = NULL; // Initialize the best fitting block to NULL.
-    block_t *block;               // Declare a pointer for the current block.
+    kheap_block_t *best_fitting = NULL; // Initialize the best fitting block to NULL.
+    kheap_block_t *block;               // Declare a pointer for the current block.
 
     // Iterate over the list of free blocks.
     list_for_each_decl (it, &header->free) {
         // Get the current block from the list.
-        block = list_entry(it, block_t, free);
+        block = list_entry(it, kheap_block_t, free);
 
         // Skip if the block is not free.
         if (!block->is_free) {
@@ -217,7 +217,7 @@ static inline block_t *__blkmngr_find_best_fitting(heap_header_t *header, uint32
 /// @param header the heap header.
 /// @param block the block.
 /// @return a pointer to the previous block or NULL if an error occurs.
-static inline block_t *__blkmngr_get_previous_block(heap_header_t *header, block_t *block)
+static inline kheap_block_t *__blkmngr_get_previous_block(heap_header_t *header, kheap_block_t *block)
 {
     // Check if the heap header is valid.
     if (!header) {
@@ -237,14 +237,14 @@ static inline block_t *__blkmngr_get_previous_block(heap_header_t *header, block
     }
 
     // Return the previous block by accessing the list entry.
-    return list_entry(block->list.prev, block_t, list);
+    return list_entry(block->list.prev, kheap_block_t, list);
 }
 
 /// @brief Given a block, finds its next block in the memory pool.
 /// @param header The heap header containing information about the heap.
 /// @param block The current block for which the next block is to be found.
 /// @return A pointer to the next block if it exists, or NULL if an error occurs or if the block is the last one.
-static inline block_t *__blkmngr_get_next_block(heap_header_t *header, block_t *block)
+static inline kheap_block_t *__blkmngr_get_next_block(heap_header_t *header, kheap_block_t *block)
 {
     // Check if the heap header is valid.
     if (!header) {
@@ -264,7 +264,7 @@ static inline block_t *__blkmngr_get_next_block(heap_header_t *header, block_t *
     }
 
     // Return the next block by accessing the list entry.
-    return list_entry(block->list.next, block_t, list);
+    return list_entry(block->list.next, kheap_block_t, list);
 }
 
 /// @brief Checks if the given `previous` block is actually the block that comes
@@ -273,7 +273,7 @@ static inline block_t *__blkmngr_get_next_block(heap_header_t *header, block_t *
 /// @param previous The block that is supposedly the previous block.
 /// @return 1 if `previous` is the actual previous block of `block`, 0
 /// otherwise. Returns -1 on error.
-static inline int __blkmngr_is_previous_block(block_t *block, block_t *previous)
+static inline int __blkmngr_is_previous_block(kheap_block_t *block, kheap_block_t *previous)
 {
     // Check if the current block is valid.
     if (!block) {
@@ -298,7 +298,7 @@ static inline int __blkmngr_is_previous_block(block_t *block, block_t *previous)
 /// @param next The block that is supposedly the next block.
 /// @return 1 if `next` is the actual next block of `block`, 0 otherwise.
 /// Returns -1 on error.
-static inline int __blkmngr_is_next_block(block_t *block, block_t *next)
+static inline int __blkmngr_is_next_block(kheap_block_t *block, kheap_block_t *next)
 {
     // Check if the current block is valid.
     if (!block) {
@@ -322,7 +322,7 @@ static inline int __blkmngr_is_next_block(block_t *block, block_t *next)
 /// @param block The block to be split, which must be free.
 /// @param size The size of the first of the two new blocks. Must be less than the original block's size minus overhead.
 /// @return 0 on success, -1 on error.
-static inline int __blkmngr_split_block(heap_header_t *header, block_t *block, uint32_t size)
+static inline int __blkmngr_split_block(heap_header_t *header, kheap_block_t *block, uint32_t size)
 {
     // Check if the block is valid.
     if (!block) {
@@ -346,7 +346,7 @@ static inline int __blkmngr_split_block(heap_header_t *header, block_t *block, u
     pr_debug("Splitting %s\n", __block_to_string(block));
 
     // Create the new block by calculating its address based on the original block and the specified size.
-    block_t *split = (block_t *)((char *)block + OVERHEAD + size);
+    kheap_block_t *split = (kheap_block_t *)((char *)block + OVERHEAD + size);
 
     // Insert the new block into the main list after the current block.
     list_head_insert_after(&split->list, &block->list);
@@ -375,7 +375,7 @@ static inline int __blkmngr_split_block(heap_header_t *header, block_t *block, u
 /// @param block The first block that will be expanded.
 /// @param other The second block that will be merged into the first block, becoming invalid in the process.
 /// @return 0 on success, -1 on error.
-static inline int __blkmngr_merge_blocks(heap_header_t *header, block_t *block, block_t *other)
+static inline int __blkmngr_merge_blocks(heap_header_t *header, kheap_block_t *block, kheap_block_t *other)
 {
     // Check if the first block is valid.
     if (!block) {
@@ -507,7 +507,7 @@ static void *__do_malloc(vm_area_struct_t *heap, size_t size)
     pr_debug("Searching for a block of size: %s\n", to_human_size(rounded_size));
 
     // Find the best fitting block in the heap.
-    block_t *block = __blkmngr_find_best_fitting(header, rounded_size);
+    kheap_block_t *block = __blkmngr_find_best_fitting(header, rounded_size);
 
     // If a suitable block is found, either split it or use it directly.
     if (block) {
@@ -527,7 +527,7 @@ static void *__do_malloc(vm_area_struct_t *heap, size_t size)
     } else {
         pr_debug("Failed to find a suitable block; creating a new one.\n");
 
-        // We need more space, specifically the size of the block plus the size of the block_t structure.
+        // We need more space, specifically the size of the block plus the size of the kheap_block_t structure.
         block = __do_brk(heap, actual_size);
         // Check if the block allocation was successful.
         if (!block) {
@@ -581,15 +581,15 @@ static int __do_free(vm_area_struct_t *heap, void *ptr)
     }
 
     // Calculate the block pointer from the provided pointer.
-    block_t *block = (block_t *)((char *)ptr - OVERHEAD);
+    kheap_block_t *block = (kheap_block_t *)((char *)ptr - OVERHEAD);
     if (!block) {
         pr_err("Calculated block pointer is NULL.\n");
         return -1; // Safety check; should not happen.
     }
 
     // Get the previous and next blocks for merging purposes.
-    block_t *prev = __blkmngr_get_previous_block(header, block);
-    block_t *next = __blkmngr_get_next_block(header, block);
+    kheap_block_t *prev = __blkmngr_get_previous_block(header, block);
+    kheap_block_t *next = __blkmngr_get_next_block(header, block);
 
     pr_debug("Freeing block %s\n", __block_to_string(block));
 
@@ -655,7 +655,7 @@ void *sys_brk(void *addr)
         size_t heap_size = HEAP_SIZE;
 
         // Calculate the total segment size needed (header + initial block).
-        size_t segment_size = heap_size + sizeof(heap_header_t) + sizeof(block_t);
+        size_t segment_size = heap_size + sizeof(heap_header_t) + sizeof(kheap_block_t);
 
         // Create the virtual memory area, we are goin to place the area between
         // 0x40000000 and 0x50000000, which surely is below the stack. The VM
@@ -684,8 +684,8 @@ void *sys_brk(void *addr)
         list_head_init(&header->free);
 
         // Prepare the first block of memory.
-        block_t *block = (block_t *)((char *)header + sizeof(heap_header_t));
-        block->size    = K; // Start with a block of 1 KB.
+        kheap_block_t *block = (kheap_block_t *)((char *)header + sizeof(heap_header_t));
+        block->size          = K; // Start with a block of 1 KB.
         list_head_init(&block->list);
         list_head_init(&block->free);
 

--- a/mentos/src/system/signal.c
+++ b/mentos/src/system/signal.c
@@ -387,11 +387,11 @@ static int __notify_parent(struct task_struct *current, int signr)
 /// @param q pensing signals.
 static void __rm_from_queue(sigset_t *mask, sigpending_t *q)
 {
-    struct sigqueue_t *entry;
+    sigqueue_t *entry;
     list_for_each_safe_decl(it, tmp, &q->list)
     {
         // Get the entry.
-        entry = list_entry(it, struct sigqueue_t, list);
+        entry = list_entry(it, sigqueue_t, list);
         // Remove the signal.
         if (sigismember(mask, entry->info.si_signo)) {
             list_head_remove(it);


### PR DESCRIPTION
Dropped the `_t` from the struct name while keepin’ it in the typedef, so there’s no more identity crisis between the two.