### PR TITLE
Fix scanf and fgets behavior on stdin

### DIFF
--- a/libc/src/stdio.c
+++ b/libc/src/stdio.c
@@ -208,38 +208,31 @@ int fgetc(int fd)
 
 char *fgets(char *buf, int n, int fd)
 {
-    int c;
     char *p   = buf;
     int count = n - 1; // Leave space for null terminator
 
-    // Read characters until reaching the limit or newline
     while (count > 0) {
-        ssize_t bytes_read = read(fd, &c, 1); // Read one character
+        char ch;
+        ssize_t bytes_read = read(fd, &ch, 1);
 
         if (bytes_read < 0) {
-            perror("Error reading from file descriptor");
-            return NULL; // Return NULL on error
+            return NULL; // Read error
         }
         if (bytes_read == 0) {
-            // End of file
-            break;
+            break; // EOF
         }
 
-        *p++ = (char)c; // Store the character in the buffer
+        *p++ = ch;
 
-        if (c == '\n') {
-            break; // Stop if we reach a newline
+        if (ch == '\n') {
+            break; // Line complete
         }
+
         count--;
     }
 
-    *p = '\0'; // Null-terminate the string
-
-    if (p == buf || c == EOF) {
-        return NULL; // Return NULL if no characters were read or EOF was reached
-    }
-
-    return buf; // Return the buffer
+    *p = '\0';
+    return (p == buf) ? NULL : buf;
 }
 
 void perror(const char *s)

--- a/libc/src/vscanf.c
+++ b/libc/src/vscanf.c
@@ -7,47 +7,53 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-
-/// @brief Read formatted data from string.
-/// @param str String processed as source to retrieve the data.
-/// @param s Format string, following the same specifications as printf.
-/// @param ap The list of arguments where the values are stored.
-/// @return On success, the function returns the number of items of the
-///         argument list successfully filled. EOF otherwise.
+/// @brief Read formatted data from a string buffer.
+/// @param str The input string to parse.
+/// @param s The format string, like in printf/scanf.
+/// @param ap The list of output arguments.
+/// @return Number of successful assignments, or EOF (-1) on failure.
 static int __vsscanf(const char *str, const char *s, va_list ap)
 {
-    int count    = 0;
-    int noassign = 0;
-    int width    = 0;
-    int base     = 0;
+    int count    = 0; // Successful conversions
+    int noassign = 0; // If '*' is used to skip assignment
+    int width    = 0; // Max characters to process
+    int base     = 0; // Numeric base
     const char *tc;
     char tmp[BUFSIZ];
 
     while (*s && *str) {
-        while (isspace(*s)) {
-            ++s;
+        // Match format whitespace to input whitespace (POSIX rule)
+        if (isspace(*s)) {
+            while (isspace(*s))
+                ++s;
+            while (isspace(*str))
+                ++str;
+            continue;
         }
+
         if (*s == '%') {
             ++s;
+
+            // Parse optional assignment suppression and width
             for (; *s; ++s) {
-                if (strchr("dibouxcsefg%", *s)) {
-                    break;
-                }
+                if (strchr("dibouxcs", *s))
+                    break; // supported specifiers
                 if (*s == '*') {
                     noassign = 1;
                 } else if (isdigit(*s)) {
-                    for (tc = s; isdigit(*s); ++s) {
-                    }
+                    for (tc = s; isdigit(*s); ++s)
+                        ;
                     strncpy(tmp, tc, s - tc);
                     tmp[s - tc] = '\0';
                     width       = strtol(tmp, NULL, 10);
-                    --s;
+                    --s; // step back so loop resumes at specifier
                 }
             }
+
+            // Handle string specifier: %s
             if (*s == 's') {
-                while (isspace(*str)) {
+                while (isspace(*str))
                     ++str;
-                }
                 if (!width) {
                     width = strcspn(str, " \t\n\r\f\v");
                 }
@@ -57,87 +63,126 @@ static int __vsscanf(const char *str, const char *s, va_list ap)
                     string[width] = '\0';
                 }
                 str += width;
-            } else if (*s == 'c') {
-                while (isspace(*str)) {
-                    ++str;
-                }
-                if (!width) {
+            }
+
+            // Handle character specifier: %c
+            else if (*s == 'c') {
+                // Note: unlike other specifiers, %c does NOT skip whitespace
+                if (!width)
                     width = 1;
-                }
                 if (!noassign) {
-                    strncpy(va_arg(ap, char *), str, width);
+                    char *dst = va_arg(ap, char *);
+                    strncpy(dst, str, width);
                 }
                 str += width;
-            } else if (strchr("duxob", *s)) {
-                while (isspace(*str)) {
+            }
+
+            // Handle numeric specifiers: %d %u %x %o %b
+            else if (strchr("duxob", *s)) {
+                while (isspace(*str))
                     ++str;
-                }
-                if (*s == 'd' || *s == 'u') {
+
+                // Determine base
+                switch (*s) {
+                case 'd':
+                case 'u':
                     base = 10;
-                } else if (*s == 'x') {
+                    break;
+                case 'x':
                     base = 16;
-                } else if (*s == 'o') {
+                    break;
+                case 'o':
                     base = 8;
-                } else if (*s == 'b') {
+                    break;
+                case 'b':
                     base = 2;
+                    break;
                 }
+
+                // Calculate width if unspecified
                 if (!width) {
-                    if (isspace(*(s + 1)) || *(s + 1) == 0) {
+                    char next = *(s + 1);
+                    if (isspace(next) || next == '\0') {
                         width = strcspn(str, " \t\n\r\f\v");
                     } else {
-                        width = strchr(str, *(s + 1)) - str;
+                        char *next_sep = strchr(str, next);
+                        width          = next_sep ? (next_sep - str) : strcspn(str, " \t\n\r\f\v");
                     }
                 }
+
                 strncpy(tmp, str, width);
                 tmp[width] = '\0';
                 str += width;
+
                 if (!noassign) {
                     *va_arg(ap, unsigned int *) = strtol(tmp, NULL, base);
                 }
             }
-            if (!noassign) {
+
+            // Increment successful assignment count
+            if (!noassign)
                 ++count;
-            }
+            // Reset flags for next format
             width = noassign = 0;
             ++s;
-        } else {
-            while (isspace(*str)) {
+        }
+
+        // Match literal characters (outside of '%')
+        else {
+            while (isspace(*str))
                 ++str;
-            }
-            if (*s != *str) {
+            if (*s != *str)
                 break;
-            }
-            ++s, ++str;
+            ++s;
+            ++str;
         }
     }
-    return (count);
+    return count;
 }
 
 /// @brief Read formatted data from file.
 /// @param fd the file descriptor associated with the file.
 /// @param format format string, following the same specifications as printf.
 /// @param ap the list of arguments where the values are stored.
+/// @param blocking if 0, the function will return immediately if no data is
 /// @return On success, the function returns the number of items of the
 ///         argument list successfully filled. EOF otherwise.
-static int __vfscanf(int fd, const char *format, va_list ap)
+static int __vfscanf(int fd, const char *format, va_list ap, int blocking)
 {
-    int count;
-    char str[BUFSIZ + 1];
-
-    if (fgets(str, BUFSIZ, fd) == 0) {
-        return (-1);
+    if (fd < 0 || format == NULL) {
+        return -1;
     }
-    count = __vsscanf(str, format, ap);
-    return (count);
+    char str[BUFSIZ + 1] = {0};
+    ssize_t idx          = 0;
+    while (idx < BUFSIZ) {
+        char c;
+        ssize_t res = read(fd, &c, 1);
+        if (res == 0) {
+            // Wait for data.
+            if (blocking) {
+                continue;
+            }
+            // Return what we have so far.
+            break;
+        }
+        if (res < 0) {
+            return -1;
+        }
+        if (c == '\n') {
+            break;
+        }
+        str[idx++] = c;
+    }
+    str[idx] = '\0';
+    return __vsscanf(str, format, ap);
 }
 
 int scanf(const char *format, ...)
 {
     int count;
     va_list ap;
-
     va_start(ap, format);
-    count = __vfscanf(STDIN_FILENO, format, ap);
+    count = __vfscanf(STDIN_FILENO, format, ap, 1);
     va_end(ap);
     return (count);
 }
@@ -148,7 +193,7 @@ int fscanf(int fd, const char *format, ...)
     va_list ap;
 
     va_start(ap, format);
-    count = __vfscanf(fd, format, ap);
+    count = __vfscanf(fd, format, ap, 0);
     va_end(ap);
     return (count);
 }

--- a/mentos/src/io/proc_video.c
+++ b/mentos/src/io/proc_video.c
@@ -4,10 +4,10 @@
 /// See LICENSE.md for details.
 
 // Setup the logging for this file (do this before any other include).
-#include "sys/kernel_levels.h"           // Include kernel log levels.
-#define __DEBUG_HEADER__ "[PROCV ]"      ///< Change header.
-#define __DEBUG_LEVEL__  LOGLEVEL_NOTICE ///< Set log level.
-#include "io/debug.h"                    // Include debugging functions.
+#include "sys/kernel_levels.h"          // Include kernel log levels.
+#define __DEBUG_HEADER__ "[PROCV ]"     ///< Change header.
+#define __DEBUG_LEVEL__  LOGLEVEL_DEBUG ///< Set log level.
+#include "io/debug.h"                   // Include debugging functions.
 
 #include "bits/ioctls.h"
 #include "bits/termios-struct.h"
@@ -21,6 +21,14 @@
 #include "io/video.h"
 #include "process/scheduler.h"
 #include "sys/bitops.h"
+
+#define DISPLAY_CHAR(c) (iscntrl(c) ? ' ' : (c))
+#define ERASE_CHAR()                                                                                                   \
+    do {                                                                                                               \
+        video_putc('\b');                                                                                              \
+        video_putc(' ');                                                                                               \
+        video_putc('\b');                                                                                              \
+    } while (0)
 
 /// @brief Prints the ring-buffer.
 /// @param rb the ring-buffer to print.
@@ -52,17 +60,25 @@ static ssize_t procv_read(vfs_file_t *file, char *buf, off_t offset, size_t nbyt
     rb_keybuffer_t *rb   = &process->keyboard_rb;
 
     // Pre-check the terminal flags.
-    bool_t flg_icanon = bitmask_check(process->termios.c_lflag, ICANON) == ICANON;
-    bool_t flg_echoe  = bitmask_check(process->termios.c_lflag, ECHOE) == ECHOE;
-    bool_t flg_echo   = bitmask_check(process->termios.c_lflag, ECHO) == ECHO;
-    bool_t flg_isig   = bitmask_check(process->termios.c_lflag, ISIG) == ISIG;
+    bool_t flg_icanon  = (process->termios.c_lflag & ICANON) == ICANON;
+    bool_t flg_echoe   = (process->termios.c_lflag & ECHOE) == ECHOE;
+    bool_t flg_echonl  = (process->termios.c_lflag & ECHONL) == ECHONL;
+    bool_t flg_echoctl = (process->termios.c_lflag & ECHOCTL) == ECHOCTL;
+    bool_t flg_echo    = (process->termios.c_lflag & ECHO) == ECHO;
+    bool_t flg_isig    = (process->termios.c_lflag & ISIG) == ISIG;
+    // Not implemented yet.
+    bool_t flg_echok   = (process->termios.c_lflag & ECHOK) == ECHOK;
+    bool_t flg_echoke  = (process->termios.c_lflag & ECHOKE) == ECHOKE;
+    bool_t flg_noflsh  = (process->termios.c_lflag & NOFLSH) == NOFLSH;
+    bool_t flg_tostop  = (process->termios.c_lflag & TOSTOP) == TOSTOP;
+    bool_t flg_iexten  = (process->termios.c_lflag & IEXTEN) == IEXTEN;
 
     // If we are in canonical mode and the last inserted element is a newline,
     // pop the buffer until it's empty.
     if (!rb_keybuffer_is_empty(rb) && (!flg_icanon || (rb_keybuffer_peek_front(rb) == '\n'))) {
         // Return the newline character.
-        rb_keybuffer_print(rb);
         *(buf) = rb_keybuffer_pop_back(rb) & 0x00FF;
+        pr_debug("POP BUFFER  [%c](%d)\n", DISPLAY_CHAR(*buf), (*buf));
         // Indicate a character has been returned.
         return 1;
     }
@@ -78,88 +94,123 @@ static ssize_t procv_read(vfs_file_t *file, char *buf, off_t offset, size_t nbyt
     // Keep only the character, not the scancode.
     c &= 0x00FF;
 
-    if (iscntrl(c)) {
-        pr_debug("[ ](%d)\n", c);
-    } else {
-        pr_debug("[%c](%d)\n", c, c);
-    }
-
     // Handle special characters.
     switch (c) {
-    case '\n':
     case '\t':
-        // Optionally display the character if echo is enabled.
         if (flg_echo) {
-            video_putc(c);
+            for (int i = 0; i < 4; ++i) {
+                video_putc(' ');
+            }
         }
-        // Return the character.
         *(buf) = c;
+        pr_debug("RETURN      [%c](%d)\n", DISPLAY_CHAR(*buf), *buf);
         return 1;
 
-    case '\b':
-        // Handle backspace.
-        if (!flg_echoe && flg_echo) {
-            video_puts("^?");
+    case '\n':
+        if (flg_echo || (flg_icanon && flg_echonl)) {
+            video_putc(c);
         }
         if (flg_icanon) {
-            // Canonical mode: Remove the last character from the buffer.
+            rb_keybuffer_push_front(rb, c);
+            pr_debug("PUSH BUFFER [%c](%d) (Trigger consumption of the buffer)\n", DISPLAY_CHAR(c), c);
+            return 0;
+        }
+        *(buf) = c;
+        pr_debug("RETURN      [%c](%d)\n", DISPLAY_CHAR(*buf), *buf);
+        return 1;
+
+    case 0x15: // ^U (KILL)
+        if (flg_icanon) {
+            // Flush entire line buffer
+            while (!rb_keybuffer_is_empty(rb)) {
+                rb_keybuffer_pop_front(rb);
+                if (flg_echoke) {
+                    // Visually erase characters if ECHOKE is set
+                    ERASE_CHAR();
+                }
+            }
+
+            if (flg_echok) {
+                // Print newline after KILL if ECHOK is set
+                video_putc('\n');
+            }
+
+            return 0;
+        }
+
+    case '\b':
+    case 127:
+        if (flg_icanon) {
+            // Canonical mode: erase last character in buffer
             if (!rb_keybuffer_is_empty(rb)) {
                 rb_keybuffer_pop_front(rb);
                 if (flg_echoe) {
-                    video_putc(c);
+                    // Visually erase the character.
+                    ERASE_CHAR();
+                } else if (flg_echo) {
+                    // Fallback echo for ECHO without ECHOE
+                    video_puts("^?");
                 }
             }
-            return 0; // No character returned for backspace.
-        } // Non-canonical mode: Add backspace to the buffer and return it.
-        rb_keybuffer_push_front(rb, c);
-        *(buf) = rb_keybuffer_pop_back(rb) & 0x00FF;
-        return 1;
+            return 0; // No char returned
+        }
 
-    case 127: // Delete key.
-        // Optionally display the character if echo is enabled.
+        // Non-canonical: treat as input
         if (flg_echo) {
             video_putc(c);
         }
-        // Return the character.
-        *(buf) = c;
+        rb_keybuffer_push_front(rb, c);
+        *(buf) = rb_keybuffer_pop_back(rb) & 0x00FF;
+        pr_debug("RETURN      [%c](%d)\n", DISPLAY_CHAR(*buf), (*buf));
         return 1;
 
     default:
         if (iscntrl(c)) {
-            // Handle control characters in both canonical and non-canonical modes.
+            // Handle signal-generating control characters
             if (flg_isig) {
-                if (c == 0x03) {
-                    // Send SIGTERM on Ctrl+C.
+                if (c == 0x03) { // Ctrl+C
                     sys_kill(process->pid, SIGTERM);
                     return 0;
                 }
-                if (c == 0x1A) {
-                    // Send SIGSTOP on Ctrl+Z.
+                if (c == 0x1A) { // Ctrl+Z
                     sys_kill(process->pid, SIGSTOP);
                     return 0;
                 }
             }
-            if (isalpha('A' + (c - 1))) {
-                // Display control character representation (e.g., ^A).
-                if (flg_echo) {
+
+            // Echo control characters as ^X if ECHOCTL is set
+            if (flg_echo && flg_echoctl) {
+                if (c == '\n') {
+                    if (flg_echo || (flg_icanon && flg_echonl)) {
+                        video_putc('\n');
+                    }
+                } else {
                     video_putc('^');
-                    video_putc('A' + (c - 1));
+                    video_putc(c + '@'); // e.g., Ctrl+C → ^C
+                }
+            } else if (flg_echo && c == '\n') {
+                // ECHOCTL not set: echo newline only if allowed
+                if (flg_echo || (flg_icanon && flg_echonl)) {
+                    video_putc('\n');
                 }
             }
+        } else if (flg_echo) {
+            // Printable character
+            video_putc(c);
         }
+        break;
     }
-
-    // Add the character to the buffer.
-    rb_keybuffer_push_front(rb, c);
-
-    // If not in canonical mode, return the character immediately.
-    if (!flg_icanon) {
-        *(buf) = rb_keybuffer_pop_back(rb) & 0x00FF;
-        return 1;
+    // If in canonical mode, push the character to the ring buffer.
+    if (flg_icanon) {
+        // Add the character to the ring buffer.
+        rb_keybuffer_push_front(rb, c);
+        pr_debug("PUSH BUFFER [%c](%d)\n", (iscntrl(c) ? ' ' : c), c);
+        return 0;
     }
-
-    // Default return indicating no character was processed.
-    return 0;
+    // If NOT in canonical mode, return the character.
+    *(buf) = c & 0x00FF;
+    pr_debug("RETURN      [%c](%d)\n", DISPLAY_CHAR(*buf), (*buf));
+    return 1;
 }
 
 /// @brief Writes data to the video output by sending each character from the buffer to the video output.

--- a/mentos/src/process/process.c
+++ b/mentos/src/process/process.c
@@ -320,7 +320,11 @@ static inline task_struct *__alloc_task(task_struct *source, task_struct *parent
 
     // Set the default terminal options.
     proc->termios = (termios_t){
-        .c_cflag = 0, .c_lflag = (ICANON | ECHO | ECHOE | ECHOK | ECHONL | ISIG), .c_oflag = 0, .c_iflag = 0};
+        .c_cflag = 0,
+        .c_lflag = (ICANON | ECHO | ECHOE | ECHOK | ECHONL | ISIG),
+        .c_oflag = 0,
+        .c_iflag = 0,
+    };
     // Initialize the ringbuffer.
     rb_keybuffer_init(&proc->keyboard_rb);
 

--- a/programs/tests/CMakeLists.txt
+++ b/programs/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ set(TEST_LIST
     t_ndtree.c
     t_list.c
     t_hashmap.c
+    t_scanf.c
 )
 
 # Set the directory where the compiled binaries will be placed.

--- a/programs/tests/t_scanf.c
+++ b/programs/tests/t_scanf.c
@@ -1,0 +1,27 @@
+/// @file t_scanf.c
+/// @brief Test the scanf function.
+/// @copyright (c) 2024 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <stdio.h>
+
+int main(void)
+{
+    int number;
+    char name[100];
+
+    printf("Enter a number: ");
+    if (scanf("%d", &number) != 1) {
+        printf("Failed to read number.\n");
+        return 1;
+    }
+
+    printf("Enter your name: ");
+    if (scanf("%99s", name) != 1) { // %99s to prevent buffer overflow
+        printf("Failed to read name.\n");
+        return 1;
+    }
+
+    printf("Hello, %s! You entered %d.\n", name, number);
+    return 0;
+}


### PR DESCRIPTION
- Ensure newline is excluded from buffer in __vfscanf
- Prevent %s from capturing trailing newline in __vsscanf
- Correct fgets to avoid reading past newline
- Add proper handling for ECHONL and ECHOCTL only in canonical mode
- Clarify termios flag use and improve input echo behavior