### PR TITLE
fix(shell): correctly handle repeated commands in history

### DIFF
--- a/userspace/bin/shell.c
+++ b/userspace/bin/shell.c
@@ -527,6 +527,8 @@ static inline int __history_push(rb_history_entry_t *entry)
     if (!rb_history_peek_back(&history, &previous_entry)) {
         // Compare the new entry with the last entry to avoid duplicates.
         if (strcmp(entry->buffer, previous_entry.buffer) == 0) {
+            // Set the history index to the current count, pointing to the end.
+            history_index = history.count;
             // Return 0 if the new entry is the same as the previous one (duplicate).
             return 0;
         }


### PR DESCRIPTION
## Description
This PR fixes a bug that causes the history index to have the wrong value if the command that was just executed is identical to the last entry in history. To reproduce:
1. run `ls`
2. run `id`
3. use up arrow and run `id`
4. use up arrow - the command that gets autofilled should be `id` but is `ls`

## Related Issues
-

## Changes Made
- Fixed a bug related to the history feature in shell

## Testing Performed
- Built successfully on Debian 13
- Tested manually with `make qemu`
- Ran test suite with `make qemu-test`
- All tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Comments added for complex logic
- [x] Builds without warnings
- [x] Tested on QEMU