### PR TITLE
security(kernel): fix buffer overflows in process.c

### DIFF
--- a/kernel/inc/process/process.h
+++ b/kernel/inc/process/process.h
@@ -13,7 +13,7 @@
 #include "system/signal.h"
 
 /// The maximum length of a name for a task_struct.
-#define TASK_NAME_MAX_LENGTH 100
+#define TASK_NAME_MAX_LENGTH NAME_MAX
 
 /// The default dimension of the stack of a process (1 MByte).
 #define DEFAULT_STACK_SIZE (1 * M)

--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -290,7 +290,7 @@ static inline task_struct *__alloc_task(task_struct *source, task_struct *parent
     proc->exit_code             = 0;
     // Copy the name.
     if (name) {
-        strcpy(proc->name, name);
+        strncpy(proc->name, name, TASK_NAME_MAX_LENGTH);
     }
     // Do not touch the task's segments.
     proc->mm       = NULL;
@@ -298,9 +298,9 @@ static inline task_struct *__alloc_task(task_struct *source, task_struct *parent
     proc->error_no = 0;
     // Initialize the current working directory.
     if (source) {
-        strcpy(proc->cwd, source->cwd);
+        strncpy(proc->cwd, source->cwd, PATH_MAX);
     } else {
-        strcpy(proc->cwd, "/");
+        strncpy(proc->cwd, "/", PATH_MAX);
     }
     // Clear the signal handler.
     memset(&proc->sighand, 0x00, sizeof(sighand_t));
@@ -463,7 +463,7 @@ int sys_chdir(char const *path)
     // Check that the directory exists.
     vfs_file_t *dir = vfs_open(absolute_path, O_RDONLY | O_DIRECTORY, S_IXUSR);
     if (dir) {
-        strcpy(current->cwd, absolute_path);
+        strncpy(current->cwd, absolute_path, PATH_MAX);
         vfs_close(dir);
         return 0;
     }
@@ -495,7 +495,7 @@ int sys_fchdir(int fd)
         pr_err("Cannot get the absolute path for path `%s`.\n", vfd->file_struct->name);
         return -ENOENT;
     }
-    strcpy(current->cwd, absolute_path);
+    strncpy(current->cwd, absolute_path, PATH_MAX);
     return 0;
 }
 
@@ -587,9 +587,9 @@ int sys_execve(pt_regs_t *f)
     }
 
     // Save the name of the process.
-    strcpy(name_buffer, origin_argv[0]);
+    strncpy(name_buffer, origin_argv[0], NAME_MAX);
     // Save the filename.
-    strcpy(saved_filename, filename);
+    strncpy(saved_filename, filename, PATH_MAX);
 
     // == COPY PROGRAM ARGUMENTS ==============================================
     // Copy argv and envp to kernel memory, because all the old process memory will be discarded.
@@ -694,7 +694,7 @@ int sys_execve(pt_regs_t *f)
     // ------------------------------------------------------------------------
 
     // Change the name of the process.
-    strcpy(current->name, name_buffer);
+    strncpy(current->name, name_buffer, TASK_NAME_MAX_LENGTH);
 
     // Free the temporary args memory.
     kfree(args_mem);


### PR DESCRIPTION
## Description
`kernel/src/process/process.c` is riddled with unsafe calls to `strcpy` that can potentially lead to buffer overflows. This PR replaces all of them (even the ones that are definitely safe, for consistency) with `strncpy` which protects against that. As an example, the following piece of code triggers a stack buffer overflow in `sys_execve` which can be used for arbitrary code execution (the OS crashes with EIP 0xdeadbeef which proves that it's possible to gain control over code execution this way):
```c
#include <stdint.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

char buf[512];

#define NAME_BUF_SIZE 255
#define PAD_SIZE 0x58

int main(void) {
    memset(buf, 'A', NAME_BUF_SIZE);
    memset(buf + NAME_BUF_SIZE, 'B', PAD_SIZE);

    char* argv[] = { buf, NULL };
    char* envp[] = { NULL };

    *(uint32_t*)(buf + NAME_BUF_SIZE + PAD_SIZE) = 0xdeadbeef; // eip
    // overwrite some pointers on the stack of `sys_execve` so that the kernel doesn't crash before returning from the function
    *(uint32_t*)(buf + NAME_BUF_SIZE + 0x28) = (uint32_t)argv; // char** origin_argv
    *(uint32_t*)(buf + NAME_BUF_SIZE + 0x2c) = (uint32_t)envp; // char* filename
    *(uint32_t*)(buf + NAME_BUF_SIZE + 0x30) = (uint32_t)envp; // task_struct* current
    *(uint32_t*)(buf + NAME_BUF_SIZE + 0x44) = (uint32_t)envp; // char** origin_envp

    execve("noent", argv, envp);

    return 0;
}
``` 

## Related Issues
-

## Changes Made
- Replaced calls to `strcpy` with calls to `strncpy` with appropriate bounds in `kernel/src/process/process.c`
- Changed `TASK_NAME_MAX_LENGTH` to `NAME_MAX`

## Testing Performed
- Built successfully on Debian 13
- Tested manually with `make qemu`
- Ran test suite with `make qemu-test`
- All tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] Tests added/updated (if applicable)
- [x] Builds without warnings
- [x] Tested on QEMU