### PR TITLE
docs: add maintainer knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md — operational index
+
+Coding style, commit format, and branch/release workflow:
+`.github/copilot-instructions.md`. Deep subsystem knowledge:
+`docs/maintainer/` (see map below).
+
+## Repository map
+
+| Path | Contents |
+|---|---|
+| `kernel/src/fs/` | VFS core (vfs.c), ext2, procfs, pipe, open/close/read/write |
+| `kernel/src/process/` | process.c (alloc/fork/execve), scheduler.c (waitpid/exit), wait.c |
+| `kernel/src/mem/` | paging, page_fault, mm, slab/buddy/zone allocators |
+| `kernel/src/elf/` | ELF loader |
+| `kernel/src/io/` | console + `/proc` module generators (proc_running.c etc.) |
+| `kernel/src/system/` | syscall dispatch, signals, panic, printk |
+| `lib/` | shared freestanding libc (kernel AND userspace) |
+| `userspace/bin/` | shell, init, runtests.c (test driver), utilities |
+| `userspace/tests/` | t_*.c; built INTO `filesystem/bin/tests` (build dirties the tree) |
+| `filesystem/` | rootfs staging tree → rootfs.img via mke2fs |
+| `scripts/` | run-qemu-test, tapview |
+| `.github/workflows/` | ubuntu.yml (build + test), macos.yml |
+
+## Essential commands
+
+```
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+make -C build -j$(nproc)          # everything (tests land in filesystem/bin/tests)
+make -C build kernel.bin          # kernel only
+make -C build qemu-test           # guest test run (WARNING: see below)
+make -C build filesystem          # rebuild pristine rootfs.img (QEMU writes to it)
+```
+
+## Critical invariants — respect in every change
+
+1. **fd reference invariant**: every `fd_list` slot holds exactly one
+   `file->count` reference; removal always goes through `close_f`.
+   → `docs/maintainer/vfs-and-fd-lifetime.md`
+2. **`close_f` owns count decrements** — callers must never pre-decrement
+   (the pre-#189 `vfs_destroy_task` bug).
+3. **`do_exit` does NOT close fds** — zombie fds are closed by the reaper
+   via `vfs_destroy_task`.
+4. **Never trust syscall user pointers or lengths**: no validation layer
+   exists (issue #191). No `strcpy`/`strlen`/unbounded walks on user
+   memory; bound every copy and force NUL termination
+   (`strncpy(dst, src, sizeof(dst)-1); dst[sizeof(dst)-1]=0;`); write at
+   most `nbyte` to user buffers; enforce an ARG_MAX with `-E2BIG`.
+   → `docs/maintainer/syscall-boundaries.md`, `execve.md`
+5. **ext2 block index 0** is a valid sparse hole inside `i_size` (must read
+   as zeros) — only invalid for metadata paths (issue #192).
+   → `docs/maintainer/ext2.md`
+
+## Test-harness warnings
+
+- **`make qemu-test` exit code 0 does NOT prove the guest tests completed.**
+  A kernel panic shuts QEMU down cleanly (exit 0); the CMake target ignores
+  exit codes; CI swallows the TAP viewer's failure (issue #193). Currently
+  main panics at test 10/39 — t_gid (issue #192). ALWAYS check the serial
+  log: `grep -c PANIC` and the last `Running test (n/39)` counter.
+- In-guest test output: use `syslog()` (serial); `printf` is VGA-only.
+- New tests need BOTH `userspace/tests/CMakeLists.txt` (TEST_LIST) and
+  `userspace/bin/runtests.c` (`all_tests[]`).
+  → `docs/maintainer/testing-and-ci.md`
+
+## Consult before changing a subsystem
+
+| Changing... | Read first |
+|---|---|
+| task/fork/exit/waitpid | `docs/maintainer/process-lifecycle.md` |
+| execve / ELF / argv | `docs/maintainer/execve.md` |
+| fd lists, open/close/dup, file lifetime | `docs/maintainer/vfs-and-fd-lifetime.md` |
+| ext2 or the disk image | `docs/maintainer/ext2.md` |
+| /proc generation or read handlers | `docs/maintainer/procfs.md` |
+| pipes | `docs/maintainer/pipes.md` |
+| allocators, UAF/double-free analysis | `docs/maintainer/memory-management.md` |
+| any syscall | `docs/maintainer/syscall-boundaries.md` |
+| CI / tests | `docs/maintainer/testing-and-ci.md` |
+| anything security-relevant | `docs/maintainer/security-model.md` + `known-bugs.md` |
+| reproducing anything | `docs/maintainer/debugging-playbook.md` |
+
+Before fixing anything, check `docs/maintainer/known-bugs.md` (open issues
+#190–#196) and `false-positives-and-dismissed-findings.md` (already-investigated
+non-bugs — do not re-report).

--- a/docs/maintainer/README.md
+++ b/docs/maintainer/README.md
@@ -1,0 +1,66 @@
+# MentOS Maintainer Knowledge Base
+
+Durable, maintainer-grade documentation of architecture, invariants, failure
+modes, and debugging knowledge accumulated during a deep security review of
+PRs #188–#190 and the follow-up pre-existing-bug investigation (which produced
+issues #192–#196).
+
+**Verification baseline commits** (all observations are recorded against one of
+these unless stated otherwise):
+
+| Label | SHA | What it is |
+|---|---|---|
+| `BASE`  | `82f4314` | `main` at the time PRs #188/#189/#190 were reviewed (their common merge-base) |
+| `MAIN`  | `62c638a` | `main` after #188 and #189 were merged; the baseline for issues #192–#196 |
+| `DEV`   | `9311863` | local `develop` checkout at documentation time (differs from `MAIN`; see investigation-history.md) |
+
+Line numbers cited as `file.c:NNN` are valid **only for the stated commit** and
+will drift; function names and call-path descriptions are the stable
+references.
+
+## Document index
+
+| Document | Read before / when |
+|---|---|
+| [architecture.md](architecture.md) | Touching any kernel subsystem; orientation for new agents |
+| [process-lifecycle.md](process-lifecycle.md) | Changing task creation, fork, exit, waitpid, zombie reaping |
+| [execve.md](execve.md) | Changing `sys_execve`, ELF loading, interpreter handling, argv/env |
+| [vfs-and-fd-lifetime.md](vfs-and-fd-lifetime.md) | Changing fd lists, `vfs_file_t` lifetime, open/close/dup/destroy paths |
+| [ext2.md](ext2.md) | Changing ext2 inode/block read/write, the image build, or file caching |
+| [procfs.md](procfs.md) | Changing `/proc` generation or any proc-module read handler |
+| [pipes.md](pipes.md) | Changing `sys_pipe`, `pipe_close`, pipe create/unlink error paths |
+| [memory-management.md](memory-management.md) | Reasoning about kmalloc/kfree/slab, UAF/double-free analysis |
+| [syscall-boundaries.md](syscall-boundaries.md) | Adding or modifying ANY syscall that takes user pointers |
+| [testing-and-ci.md](testing-and-ci.md) | Running, extending, or trusting the test suite; CI work |
+| [security-model.md](security-model.md) | Any security-relevant change; triaging #191-class reports |
+| [debugging-playbook.md](debugging-playbook.md) | Before reproducing anything in QEMU; host-side analysis techniques |
+| [known-bugs.md](known-bugs.md) | Before fixing anything — check the open-issue landscape first |
+| [investigation-history.md](investigation-history.md) | Understanding how the current findings were established |
+| [false-positives-and-dismissed-findings.md](false-positives-and-dismissed-findings.md) | Before re-reporting something already investigated |
+
+## Most important global invariants (short list)
+
+1. **fd reference invariant** — every `fd_list` slot referencing a
+   `vfs_file_t` holds exactly one increment of `file->count`. Producers:
+   `sys_open`, `sys_creat`, `sys_dup`, `vfs_dup_task` (fork),
+   `create_pipe_fd`, init stdio setup. See vfs-and-fd-lifetime.md.
+2. **`close_f` owns decrements** — every filesystem `close_f` decrements
+   `file->count` itself and frees at zero. Callers must never pre-decrement
+   (the pre-#189 `vfs_destroy_task` bug did exactly this).
+3. **`vfs_destroy_task` is the catch-all fd close** — `do_exit` does NOT close
+   fds; the reaper in `sys_waitpid` does, via `vfs_destroy_task`.
+4. **Kernel trusts syscall user pointers completely** (VERIFIED: no
+   validation layer exists — issue #191). Never add code that dereferences
+   user pointers "just a little more" without bounding it.
+5. **A `qemu-test` exit code of 0 proves nothing** about guest test
+   completion (issue #193). Always check the serial log.
+6. **`ext2_read_block`/`ext2_write_block` reject block index 0** — but block
+   0 inside `i_size` is a legal sparse hole (issue #192). Metadata paths may
+   rely on the check; data paths must treat 0-in-`i_size` as a zero-filled
+   hole.
+
+## Related pre-existing documentation
+
+- `.github/copilot-instructions.md` — C coding guidelines, conventional-commit
+  format, branch/release workflow. This knowledge base does not duplicate it.
+- `README.md` — basic build instructions (cmake + make).

--- a/docs/maintainer/architecture.md
+++ b/docs/maintainer/architecture.md
@@ -1,0 +1,118 @@
+# Architecture
+
+Verified against `BASE` = `82f4314` and `MAIN` = `62c638a` unless noted.
+
+## Layout
+
+```
+boot/        multiboot boot code, linker scripts (boot.lds, kernel.lds), boot.S/boot.c
+kernel/
+  inc/       kernel headers mirrored per-subsystem (process/, fs/, mem/, ...)
+  src/
+    kernel.c / kernel.c? kmain                     — init flow (kmain in kernel/src/kernel.c)
+    process/ process.c, scheduler.c, wait.c, pid_manager.c,
+             scheduler_algorithm.c, scheduler_feedback.c
+    fs/      vfs.c, ext2.c, procfs.c, pipe.c, open.c, namei.c, read_write.c,
+             readdir.c, stat.c, attr.c, fcntl.c, ioctl.c, sync.c, fhs.c
+    mem/     paging.c, page_fault.c, mm/mm.c, vm_area.c, vmem.c,
+             alloc/{slab.c, buddy_system.c, zone_allocator.c, heap.c}
+    elf/     elf.c (ELF loader)
+    io/      video.c, proc_running.c, proc_system.c, proc_ipc.c,
+             proc_video.c, proc_feedback.c, debug.c
+    drivers/ ata.c, mem.c, ps2.c, keyboard/, mouse.c, rtc.c, fdc.c
+    system/  syscall.c (dispatch table), signal.c, panic.c, printk.c, errno.c
+    ipc/     ipc.c, msg.c, sem.c, shm.c            (not investigated in depth)
+lib/         freestanding libc used by kernel AND userspace
+             (inc/limits.h: NAME_MAX 255, PATH_MAX 4096; inc/stddef.h: BUFSIZ 512;
+              inc/ring_buffer.h: generic ring-buffer macros)
+userspace/
+  bin/       shell.c, runtests.c, init.c, and the standard utilities
+  tests/     t_*.c test programs (built INTO the source tree, see testing-and-ci.md)
+filesystem/  the rootfs staging tree — binaries are copied here by the build;
+             mke2fs turns it into rootfs.img
+iso/         grub cfg for boot/test ISOs (grub.cfg, grub.cfg.runtests)
+scripts/     run-qemu-test, tapview
+tools/       toolchain-i686-elf.cmake (cross-compiler settings; the observed
+             workspace builds used host gcc -m32 instead)
+```
+
+## Subsystems and ownership boundaries (VERIFIED FACTS from call-path tracing)
+
+- **Process/scheduler** owns `task_struct` allocation (`task_struct_cache`
+  slab), runqueue, zombie state, wait queues. `do_exit` marks zombie + moves
+  children to init + `mm_destroy` — it does NOT close fds.
+- **VFS** owns `fd_list` arrays and the `vfs_file_t` cache; dispatches to
+  filesystem `fs_operations`/`sys_operations` vtables. Superblock registry
+  (`vfs_super_blocks` list) maps path prefixes to mounted filesystems.
+- **Filesystems** (ext2, procfs, pipe) own file content and the meaning of
+  `close_f`; each maintains its own opened-file bookkeeping (ext2 keeps a
+  per-inode cache list `fs->opened_files`; procfs keeps per-entry lists).
+- **MM** owns page tables (`pgd`), `mm_struct` per process, slab/buddy
+  allocators. `paging_switch_pgd` is used during exec and init creation.
+- **Syscall layer** (`kernel/src/system/syscall.c`) populates
+  `sys_call_table[]` and dispatches; handlers receive `pt_regs_t *` with raw
+  user arguments in ebx/ecx/edx — no pointer validation anywhere
+  (VERIFIED; issue #191).
+
+## Initialization flow (traced during PR review)
+
+`kmain` (kernel/src/kernel.c) → caches/zones → VFS init (`vfs_init` creates
+`vfs_superblock_cache`, `vfs_file_cache`) → mount root (ext2 via
+`ext2_mount`) → proc modules (`procv_module_init` creates `/proc/video`, ...)
+→ `process_create_init`:
+- `__alloc_task(NULL, NULL, "init")`
+- stdio: `vfs_open("/proc/video", ...)` three times with an extra explicit
+  `count++` each, installed into fd 0/1/2 (VERIFIED at `BASE`
+  kernel/src/process/process.c:362-378).
+- `__load_executable("/bin/init", ...)`; args/envp pushed onto the new stack;
+  jump to init.
+
+Init runs `/bin/init`, which execs `/bin/login` → shell → runtests (in test
+builds, driven by `grub.cfg.runtests`).
+
+## Major call paths established during this investigation
+
+- `sys_open` → `get_unused_fd` → `vfs_open` → `resolve_path` →
+  `vfs_open_abspath` → `sb->root->fs_operations->open_f` →
+  `file->count += 1` → slot installed.
+- `sys_close` → NULL slot → `vfs_close` → `close_f` (decrements count, frees
+  at 0).
+- `sys_execve` → save name/filename (raw `strcpy`, bounded by PR #190) →
+  `__count_args`/`__count_args_bytes`/`__push_args_on_stack` on RAW user
+  vectors → `__load_executable` → `vfs_open` → permission checks →
+  `mm_destroy(old)` → `__reset_process` → `elf_load_file` (fstat → kmalloc →
+  `vfs_read` full file) → segment mapping → shebang interpreter loop →
+  `paging_switch_pgd` → push args → set `eip`/`useresp` → copy name.
+- `do_exit` → zombie + SIGCHLD + wake parent → (later) `sys_waitpid` →
+  `vfs_destroy_task(child)` (closes remaining fds via `close_f`) →
+  `kmem_cache_free(child)`.
+- `sys_read`/`sys_write` → per-fd `flags_mask` check (write only) →
+  `vfs_read`/`vfs_write` → filesystem op copies to/from the RAW user buffer.
+- Read path for `/proc/<pid>/stat`: `sys_read` → `vfs_read` →
+  `procfs_read` → module dispatch → `__procr_read` (builds
+  `support[BUFSIZ]`, then `strcpy`s the whole thing to the user buffer —
+  issue #194).
+
+## Surprising implementation details a future agent will misunderstand
+
+- **The kernel and userspace share one libc tree** (`lib/`). Changing
+  `lib/inc/limits.h` etc. affects both.
+- **Tests build in-tree**: `userspace/tests/CMakeLists.txt` copies test
+  binaries to `${CMAKE_SOURCE_DIR}/filesystem/bin/tests`, i.e. the source
+  tree is dirtied by building tests. Do not commit those binaries (they are
+  presumably gitignored, but be deliberate).
+- **`vfs_file_t` structs are shared per-inode in ext2** — two `open()`s of
+  the same file return the SAME struct with `count == 2` (cache in
+  `ext2_open` via `ext2_find_vfs_file_with_inode`). This makes refcount
+  bugs privilege-escalation bugs (see vfs-and-fd-lifetime.md, security-model.md).
+- **`kfree()` is safe on slab objects** — it routes via page metadata
+  (`page->container.slab_main_page`). See memory-management.md; do not
+  "fix" call sites that kfree cache objects.
+- **`qemu-test` target does not use `scripts/run-qemu-test`** and a kernel
+  panic shuts QEMU down cleanly (exit 0). See testing-and-ci.md.
+- **`mke2fs` makes sparse holes for all-zero blocks** in the build image —
+  the root cause of the long-standing t_gid/t_alarm load failures
+  (ext2.md, issue #192).
+- Local `develop` and GitHub `main` have diverged historically; when
+  reviewing PRs, always compute the PR's true base (merge-base with its
+  head), never trust the local checkout (see investigation-history.md).

--- a/docs/maintainer/debugging-playbook.md
+++ b/docs/maintainer/debugging-playbook.md
@@ -1,0 +1,118 @@
+# Debugging playbook
+
+Workflows actually used during this investigation (all verified working on
+Ubuntu 24.04 host, Aug 2026). SHAs: `BASE` 82f4314, `MAIN` 62c638a.
+
+## Disposable clone strategy (keeps the real repo clean)
+
+```
+git clone --local . /tmp/opencode/mentos-review
+cd /tmp/opencode/mentos-review
+git remote set-url origin https://github.com/mentos-team/MentOS.git   # if SSH unavailable
+git fetch origin <sha> && git branch prNNN <sha>                      # PR heads
+```
+- PR head SHAs: `gh pr view N --json commits` (also title/body/files).
+- **`gh pr view N` bare fails** with a GraphQL "Projects (classic)
+  deprecated" error — always pass `--json`/`--jq` or `--patch`.
+- Determine a PR's true base: `git merge-base prHead main` + compare with
+  `origin/main` from a FRESH fetch — local remote-tracking refs can be
+  stale (bit us: local origin/main pointed at an ancient release while
+  GitHub main had moved).
+
+## Build (host gcc -m32)
+
+```
+cmake -S . -B /tmp/opencode/build-X -DCMAKE_BUILD_TYPE=Debug
+make -C /tmp/opencode/build-X -j$(nproc)            # everything incl. tests
+make -C /tmp/opencode/build-X kernel.bin            # kernel only
+make -C /tmp/opencode/build-X cdrom_test.iso        # test ISO
+```
+
+## QEMU invocation that works for serial capture
+
+```
+timeout 200 qemu-system-i386 -vga std -m 1096M -nodefaults -serial stdio \
+  -drive file=BUILD/rootfs.img,format=raw,if=ide,index=0,media=disk \
+  -device isa-debug-exit -boot d -cdrom BUILD/cdrom_test.iso -no-reboot \
+  > run.log 2>&1; echo "exit=$?"
+```
+- `-no-reboot` avoids reboot loops after panics.
+- **Exit code 0 does NOT mean success** (panic shuts down cleanly — #193).
+  Always check the log (below).
+- rootfs.img is WRITTEN by runs; rebuild (`make filesystem`) before
+  pristine-image inspection.
+
+## Serial-log analysis
+
+```
+grep -c "PANIC" run.log                 # >0 → guest died
+grep "Running test" run.log | tail -1   # completion counter (n/39)
+grep -E "PG_FLT|ERR\(0\)" run.log       # fault decode ERR(user rw present) as (%d%d%d)
+```
+Kernel-vs-user anchor values seen in repro runs: kernel EIP ~0xc00xxxxx,
+kernel ESP ~0xf75xxxxx, user stack ~0xbfffxxxx. Panic EIPs can be
+symbolized against build kernel.bin with nm/objdump (not yet exercised
+here — noted as available).
+
+## In-guest repro tests (technique)
+
+1. Add `userspace/tests/t_aaa_<name>.c` (names sorting FIRST run before
+   t_gid at position 10 — crucial while #192 lives).
+2. Register in `userspace/tests/CMakeLists.txt` (TEST_LIST) AND
+   `userspace/bin/runtests.c` (`all_tests[]`).
+3. Use `syslog()`, never `printf` (VGA-only) — see testing-and-ci.md.
+4. Rebuild `cdrom_test.iso`, run QEMU as above.
+5. These modifications live only in the disposable clone.
+
+## ext2 image forensics (e2fsprogs)
+
+```
+debugfs -R "stat <70>" rootfs.img      # size + BLOCKS + TOTAL (counts IND block)
+debugfs -R "blocks <70>" rootfs.img
+debugfs -R "dump <70> /tmp/f" rootfs.img && cmp /tmp/f filesystem/bin/tests/t_gid
+debugfs -R "ls -l /bin/tests" rootfs.img
+dumpe2fs -h rootfs.img                  # block size / counts / inode size
+```
+Hole detection rule: `TOTAL` (with IND) vs `ceil(size/4096)` data blocks —
+shortfall ⇒ sparse holes. NOTE: `debugfs dump` reads holes as zeros, so a
+byte-identical dump does NOT disprove a hole — check the block list.
+
+## Isolated mke2fs sparse experiment (proved #192's root cause)
+
+```
+mkdir -p ext && dd if=/dev/zero bs=4096 count=27 | tr '\0' '\253' > ext/f
+printf '\x00\x00\x00\x00' >> ext/f                       # all-zero 4-byte tail
+mke2fs -q -N 0 -d ext -b 4096 -t ext2 -F img 4M
+debugfs -R "stat <12>" img | grep -E "Size|TOTAL|BLOCKS" # 27 data blocks, hole at 27
+```
+
+## Host-side C-semantics validation
+
+- **Ring-buffer logic (PR #188)**: extract the 2D macro block from
+  `lib/inc/ring_buffer.h` (`sed -n '296,427p'` at `BASE`) into a test
+  header, compile a main.c exercising old-vs-new push/fetch — proved the
+  bug and the fix, including full-history wrap-around.
+- **strncpy non-termination (PR #190)**: small program with
+  `char name[255]` inside a struct surrounded by poisoned bytes;
+  `strnlen` shows 255/255 = unterminated; letting strlen walk into nonzero
+  surroundings trips ASan (`-fsanitize=address`) — demonstrating unbounded
+  consumer over-read.
+
+## Comparing a PR against base main
+
+1. Fetch base (`git fetch origin <baseSha>`) and PR head; branch both.
+2. `git diff <base>..<prHead> -- <paths>` for the real diff (ignore
+   GitHub's merge-base guesswork).
+3. Extract base versions of files for line-accurate reference:
+   `git show <base>:kernel/src/fs/vfs.c > /tmp/main_vfs.c`.
+4. Build + qemu-test BOTH base and PR with SEPARATE build dirs; identical
+   failure signatures (same test counter, same panic) ⇒ pre-existing, not
+   PR-caused. This pattern (base/188/189/190 matrix) is how #192 was
+   isolated.
+
+## GitHub hygiene
+
+- `gh issue list --state all --search "..."` (also `gh pr list`) for dup
+  sweeps before filing; `gh issue view N --json ...` for bodies/comments.
+- `gh issue create --repo ... --title ... --body-file file.md` keeps long
+  bodies intact.

--- a/docs/maintainer/execve.md
+++ b/docs/maintainer/execve.md
@@ -1,0 +1,111 @@
+# execve — the complete pipeline
+
+Verified against `BASE` = `82f4314` (PR #190 context) and `MAIN` = `62c638a`.
+Function: `sys_execve(pt_regs_t *f)` in kernel/src/process/process.c
+(`MAIN` process.c:542). Related: PR #190 (open, changes reviewed here),
+issue #196 (argv stack overflow, filed from this investigation).
+
+## Trust boundary (VERIFIED FACT)
+
+`f->ebx` = filename, `f->ecx` = argv, `f->edx` = envp — all raw user
+pointers, used with zero validation. Only NULL checks on filename/argv/
+argv[0]; envp NULL is substituted with a default environment. The libc
+wrapper (`lib/src/unistd/exec.c:61-65`) passes vectors straight through.
+
+## Pipeline in order
+
+1. **Save name/filename** into stack buffers `char name_buffer[NAME_MAX]`
+   (255) and `char saved_filename[PATH_MAX]` (4096):
+   - pre-#190: `strcpy` → kernel stack overflow from user-controlled
+     `argv[0]`/filename. PR #190's own PoC (in its description) demonstrates
+     EIP control (`0xdeadbeef`); build confirmed `-fno-stack-protector`
+     (tools/toolchain-i686-elf.cmake; USERSPACE_CFLAGS).
+   - with #190: `strncpy` bounded to destination size — **but no forced
+     NUL termination** (see below).
+2. **Copy argv/envp to kernel memory**: `argc = __count_args(origin_argv)`,
+   `argv_bytes/__count_args_bytes` (strlen per string), same for envp;
+   `kmalloc(argv_bytes + envp_bytes)`; `__push_args_on_stack` walks the RAW
+   user vectors copying strings and building pointer arrays.
+3. **`__load_executable(filename, current, &eip)`** (process.c:134ff at
+   `BASE`):
+   - `vfs_open(path, O_RDONLY)`; ops presence check;
+     `vfs_valid_exec_permission`; setuid/setgid handling;
+     ELF-vs-shebang detection.
+   - **`mm_destroy(task->mm)` happens HERE — before the new image is
+     loaded** (process.c:175 at `MAIN` numbering).
+   - `__reset_process` builds fresh mm; `elf_load_file` (elf.c):
+     `vfs_fstat` → `kmalloc(st_size)` → `memset 0` →
+     `vfs_read(file, buffer, 0, st_size)` — requires the read to return
+     EXACTLY st_size, else error.
+   - Shebang path: builds `int_argv` (original filename as argv[1]),
+     re-copies args, `goto start` with interpreter-loop guard.
+   - error label `close_and_return` → `vfs_close(file)` and returns < 0.
+4. On success: `paging_switch_pgd(current->mm->pgd)`, push args/env onto new
+   user stack (`__push_args_on_stack` on saved vectors), record
+   arg_start/arg_end/env_start/env_end, push main's argv/envp, set
+   eip/useresp.
+5. `strncpy(current->name, name_buffer, TASK_NAME_MAX_LENGTH)` (post-#190)
+   and `kfree(args_mem)`.
+
+## Error paths and the proven crash chain
+
+VERIFIED (empirically reproduced as part of #192 investigation):
+if step 3 fails AFTER `mm_destroy` (e.g. `vfs_read` short read because of the
+ext2 sparse-hole bug), `sys_execve` returns a negative errno to a process
+whose address space no longer exists → user-stack fetch faults in kernel
+mode → `kernel_panic("Page fault!")`. Signature observed repeatedly:
+`EIP 0xc00026f9, cr2 0xbfffedf8, ESP 0xf75eec48` (kernel stack), panic from
+`page_fault.c`/`panic.c` (kernel EIP not symbolized in this investigation —
+symbolization via `nm`/`objdump` on `kernel.bin` is available but was not
+performed).
+
+Invariant violated: **exec must not destroy the old mm until the new image
+is fully loaded, or must not return to userspace on failure.**
+
+## Known weaknesses
+
+1. **#196 (CODE-PROVEN, not yet executed in-guest)**:
+   `__push_args_on_stack` (process.c:65-90 at `MAIN`) uses fixed
+   `char *args_location[256]` (process.c:70) indexed by user argc → argv/envp
+   with >256 entries overflows the kernel stack with kernel-heap pointers.
+   `__count_args` (process.c:37-44) walks the user vector unbounded until a
+   NULL; `__count_args_bytes` (process.c:49-57) `strlen`s raw user strings.
+   No ARG_MAX exists.
+2. **PR #190 termination gap (EMPIRICALLY DEMONSTRATED on host)**:
+   `strncpy(dst, src, n)` leaves dst unterminated when `strlen(src) >= n`;
+   sources are raw user strings. A ≥255-byte argv[0] leaves
+   `current->name` fully populated with no NUL; consumers over-read:
+   `__procr_do_cmdline` `strcpy(buffer, task->name)` (proc_running.c:60),
+   `__procr_do_stat` `basename(task->name)` (proc_running.c:82), ~15
+   `pr_debug("%s", ...->name)` sites. Host ASan repro confirmed unbounded
+   read past the field when following bytes are nonzero; in practice reads
+   usually stop at adjacent `error_no == 0` — luck, not guarantee.
+   Repo idiom for correct bounded copy: `strncpy(dst, src, sizeof(dst)-1);
+   dst[sizeof(dst)-1] = 0;` (vfs.c superblock registration).
+3. `process.h` defines `TASK_NAME_MAX_LENGTH NAME_MAX` (post-#190) without
+   including a header that defines `NAME_MAX` — compiles only via include
+   order (fragile).
+4. `saved_filename` is later used as `int_argv[1]` in the interpreter path
+   and `strlen`'d by `__count_args_bytes` — an unterminated 4096-byte
+   filename (post-#190, exactly-PATH_MAX source) would over-read (same
+   strncpy issue).
+
+## Termination guarantees that DO hold (VERIFIED)
+
+- `resolve_path` (kernel/src/fs/namei.c) always outputs a NUL-terminated
+  path: internal buffers are zero-initialized, appends guarded by
+  `strlen(buffer) + tokenlen + 1 < buflen`, and the final copy is
+  `strncpy(abspath, buffer, buflen)` from a terminated internal buffer.
+  `task->cwd` (fed exclusively by resolve_path) is therefore always
+  terminated, and the `strncpy(proc->cwd, source->cwd, PATH_MAX)` copies are
+  safe as deployed.
+
+## Relationship to #190 and #196
+
+- PR #190 fixes the write-overflow (name/filename copies) but not
+  termination and not the argv helpers → verdict REQUEST_CHANGES at review
+  time; #196 was filed for the `args_location[256]` + unbounded-walk class.
+- Any fix here should: bound argc/bytes with an ARG_MAX-style limit and
+  `-E2BIG`; replace `args_location[256]` with a sized allocation; use
+  `strnlen` per string; force NUL termination on all copies; include
+  `limits.h` in process.h.

--- a/docs/maintainer/ext2.md
+++ b/docs/maintainer/ext2.md
@@ -1,0 +1,103 @@
+# ext2
+
+Verified against `MAIN` = `62c638a` (line numbers cited are for `MAIN`).
+
+## Image build (root cause context for #192)
+
+- `make filesystem` (CMakeLists.txt:177-182) runs:
+  `mke2fs -L 'rootfs' -N 0 -d filesystem -b 4096 -m 5 -r 1 -t ext2 -v -F
+  ${BUILD}/rootfs.img 32M`.
+- Block size 4096, 8192-block image, inode size 256 (dumpe2fs-verified).
+- **VERIFIED FACT + EMPIRICALLY REPRODUCED**: `mke2fs -d` stores all-zero
+  blocks as sparse holes. Isolated host experiment: 27×4096 bytes of 0xAB
+  plus a 4-zero-byte tail → inode with only 27 data blocks; block index 27
+  is a hole.
+- QEMU attaches rootfs.img as a **rw** IDE disk — the guest writes to the
+  image during runs. For pristine-image forensics, delete and rebuild
+  (`make filesystem`) before inspecting.
+
+## Read path
+
+`sys_read` → `vfs_read` → `ext2_read(file, buffer, f_pos, n)` →
+`ext2_read_inode_data` (ext2.c:1886 @`MAIN`):
+
+- `end_offset = min(inode->size, offset + nbyte)`;
+  `start_block/end_block = offset|end_offset / block_size`;
+  loop `start_block..end_block` inclusive, per block
+  `ext2_read_inode_block(fs, inode, block_index, cache)` → resolves direct /
+  indirect (`ext2_get_real_block_index`) → `ext2_read_block`.
+
+`ext2_read_block` (ext2.c:1044-1048 @`MAIN`) **rejects block_index == 0**
+with `pr_err("You are trying to read an invalid block index (%d)")`.
+
+### The #192 bug (VERIFIED FACT; EMPIRICALLY REPRODUCED)
+
+A hole (block pointer 0) inside `i_size` is legal ext2 and MUST read as
+zeros. MentOS treats it as an error: `ext2_read_inode_data`'s loop includes
+the hole block, resolution yields 0, `ext2_read_block` fails, the whole read
+returns -1. Any file whose size is N full blocks + an all-zero tail gets a
+hole at the last block index; reading the file tail fails.
+
+Observed instance: `/bin/tests/t_gid` — 110596 bytes = 27×4096 + 4;
+inode 70 in the pristine image: `(0-11):2060-2071, (IND):2072,
+(12-26):2073-2087` — 27 data blocks, hole at 27. Consequence chain:
+`elf_load_file`'s exact-size `vfs_read` fails → `sys_execve` error after
+`mm_destroy` → kernel panic (see execve.md). Serial signature:
+
+```
+[ER | ext2.c:1047] You are trying to read an invalid block index (0).
+[ER | ext2.c:1919] Failed to read the inode block   27 of inode   70
+[ER | elf.c:309  ] Failed to read 110592 bytes from the file `t_gid`.
+... page fault → PANIC
+```
+
+Host `debugfs -R "dump <70> ..."` reads the file correctly (holes → zeros),
+proving the image is valid and the defect is in the kernel read path.
+
+### HISTORICAL CONTEXT
+
+Issue #56 (2024): identical failure loading `t_alarm` (86020 bytes = 21
+blocks − 4 … trailing-4-bytes pattern), closed after PR #59 ("Fix ext2 read
+and write") without the sparse root cause being identified; maintainer asked
+for a new issue on recurrence → #192.
+
+## Open path and the per-inode file cache
+
+`ext2_open` (ext2.c:3095 @`MAIN`):
+- `get_ext2_filesystem(path)` → `ext2_resolve_path(fs->root, path, &search)`.
+- O_CREAT → `ext2_creat`; O_DIRECTORY/O_EXCL validation; inode read;
+  `vfs_valid_open_permissions` (root/pid-0 bypass; owner/group/other bits);
+  O_TRUNC on regular files → `ext2_clean_inode_content`.
+- **`ext2_find_vfs_file_with_inode`**: reuse cached `vfs_file_t` for the same
+  inode (shared `count`, `f_pos`); only allocate + `ext2_init_vfs_file` +
+  insert into `fs->opened_files` when not cached.
+- Security relevance: see vfs-and-fd-lifetime.md — shared structs make
+  refcount bugs exploitable (PR #189's pre-fix PoC).
+
+## Close path
+
+`ext2_close` (ext2.c:3286 @`MAIN`): `--count`; at 0: **refuses to free
+`fs->root`** (pr_warning + `-EPERM`, count stays 0), otherwise unlinks from
+`fs->opened_files` and `vfs_dealloc_file`. The root guard is what keeps the
+mount root alive despite reference quirks.
+
+## Untested hypotheses (do not treat as fact)
+
+- **Write-side mirror of #192 (HYPOTHESIS)**: writing into a sparse hole
+  must allocate a block first; `ext2_write_block` rejects block 0 the same
+  way `ext2_read_block` does, so growing/appending into holes likely fails
+  or corrupts. Not exercised during this investigation.
+- ext2 audit tests exist (`t_ext2_audit_*`) but were never reached in our
+  runs (panic at test 10); their coverage quality is unknown to us.
+
+## Forensic quick reference (see debugging-playbook.md for full workflows)
+
+```
+debugfs -R "stat <INO>" rootfs.img        # size + BLOCKS list + TOTAL
+debugfs -R "blocks <INO>" rootfs.img      # flat block list
+debugfs -R "dump <INO> /tmp/out" rootfs.img
+debugfs -R "ls -l /bin/tests" rootfs.img
+dumpe2fs -h rootfs.img                    # block size, counts, inode size
+```
+Rule of thumb: `TOTAL` blocks (debugfs counts the indirect block) vs
+`ceil(size / 4096)` data blocks — a shortfall means holes.

--- a/docs/maintainer/false-positives-and-dismissed-findings.md
+++ b/docs/maintainer/false-positives-and-dismissed-findings.md
@@ -1,0 +1,92 @@
+# False positives and dismissed findings
+
+Everything below was investigated during the #188–#190 review / pre-existing
+bug hunt and consciously NOT promoted to a GitHub issue. Recorded so nobody
+re-investigates (or worse, re-reports) them without new evidence.
+Baselines: `BASE` 82f4314 / `MAIN` 62c638a.
+
+## 1. `sys_waitpid` pid==1 filter quirk
+
+- **Looked suspicious**: `if ((pid > 1) && (child->pid != pid)) continue;`
+  (scheduler.c:554 @`MAIN`) — specific-pid matching only applies when
+  `pid > 1`, so `waitpid(1, ...)` matches ANY zombie child (like -1).
+- **Investigation**: read the full validation block; POSIX says pid>0 waits
+  for that child.
+- **Actually a bug?** Yes, a minor semantic deviation (pid==1 currently
+  behaves like -1).
+- **Why not filed**: negligible user impact (nobody waits on pid 1 in
+  practice), would be issue-noise; better as a drive-by fix in a future
+  syscall-hygiene change. Confidence it's real: 90%; issue-worthiness: 40%.
+
+## 2. `fd_list` initialization and dead extension path
+
+- **Looked suspicious**: `vfs_extend_task_fd_list` memsets only
+  `task->max_fd` (OLD extent) of the NEW array (uninitialized tail beyond
+  copied region); `vfs_init_task`'s initial list comes from `kmalloc`
+  without zeroing; `get_unused_fd` growth branch looked reachable.
+- **Investigation**: `max_fd` starts at `MAX_OPEN_FD` = 16 and fds are
+  capped at 16 in `get_unused_fd`, so `fd == task->max_fd` never triggers
+  extension — the branch is DEAD CODE today (max 13 user fds + 3 stdio).
+  Initial kmalloc'ed list works because boot-time slab pages are zero.
+- **Actually a bug?** Two latent defects (uninitialized new-array tail;
+  reliance on fresh-page zeroing), unreachable at present.
+- **Why not filed**: latent-only; fix opportunistely when/if MAX_OPEN_FD
+  growth is implemented (or file then, with a reproducer).
+
+## 3. `kfree()` on slab-cache objects (pipe_open / pipe_unlink)
+
+- **Looked suspicious**: `kfree(new_file)` on objects from
+  `vfs_alloc_file()` (a kmem_cache).
+- **Investigation**: slab.c `pr_kfree` routes via
+  `page->container.slab_main_page` → `kmem_cache_free` for slab pages,
+  `free_pages_lowmem` otherwise.
+- **Actually a bug?** NO — FALSE POSITIVE (allocator handles both).
+- **Why not recorded as an issue**: not a bug. Do keep the pipe_unlink
+  *bypass of the close_f contract* in mind separately (pipes.md) — that's a
+  consistency observation, not an allocator-safety one.
+
+## 4. shell.c SIGCHLD handler error path: `printf("... (%s) ...", SIGCHLD, ...)`
+
+- **Looked suspicious**: int passed to `%s` (shell.c:1398 @`MAIN`) — UB if
+  executed.
+- **Investigation**: only reachable when `sigaction(SIGCHLD, ...)` fails at
+  shell startup; not observed.
+- **Actually a bug?** Real latent UB in a practically unreachable path
+  (format-string fix is trivial: `("%d")`).
+- **Why not filed**: cosmetic; bundle into any shell cleanup PR.
+
+## 5. `__procr_do_stat` self-referential `sprintf(buffer, "%s ...", buffer, ...)`
+
+- **Looked suspicious**: reading and writing the same buffer in sprintf —
+  undefined behavior per C standard.
+- **Investigation**: pattern used ~30 times in the function; works on the
+  current gcc/i386 toolchain (glibc-style sprintf processes the source
+  before writing); no overflow observed for current stat content lengths.
+- **Actually a bug?** UB-by-standard, benign-by-implementation; also a
+  genuine future-maintenance hazard (buffer growth is unchecked).
+- **Why not filed**: code-quality concern; mention when touching #194 (same
+  function family) rather than as its own issue.
+
+## 6. `sys_close` returns -1 (not -EBADF) for an already-closed fd
+
+- **Looked suspicious**: `return -1;` when `file == NULL` (open.c).
+- **Investigation**: userspace `close()` wrappers don't distinguish; errno
+  untouched.
+- **Actually a bug?** POSIX-deviating errno semantics, cosmetic.
+- **Why not filed**: no observable impact found; trivial drive-by fix.
+
+## 7. Tests skipped in runtests / TEST_LIST
+
+- `t_big_write`, `t_periodic1/2/3` commented out of `all_tests[]`;
+  `t_time` disabled in CMake TEST_LIST.
+- **Verdict**: INTENTIONAL (explicit comments), not infrastructure rot.
+  Do not "fix" silently; re-enabling changes CI meaning (and t_big_write
+  predates the #192 panic boundary anyway — it sorts after t_gid).
+
+## 8. Byte-identical `debugfs dump` of t_gid "disproving" the hole
+
+- **Methodology trap hit during #192**: dumping the inode yields a file
+  identical to the original BECAUSE holes read as zeros and t_gid's tail
+  bytes ARE zeros. The BLOCKS list, not the dump, exposes the hole.
+- Recorded here so the next investigator doesn't re-derive the wrong
+  conclusion from the same experiment.

--- a/docs/maintainer/investigation-history.md
+++ b/docs/maintainer/investigation-history.md
@@ -1,0 +1,101 @@
+# Investigation history (chronological)
+
+Session of Aug 17, 2026 (host: Ubuntu 24.04, gcc 13.3, qemu-system-i386).
+Reviewer: coding agent acting as senior maintainer/security reviewer.
+
+## Phase 0 — orientation
+
+- Local checkout was on `develop` (`9311863`), clean. Discovered later that
+  local remote-tracking refs were stale — GitHub `main` had moved to
+  `62c638a` (post-#188/#189 merges). All conclusions re-verified against
+  explicit SHAs thereafter. Lesson recorded in debugging-playbook.md.
+
+## Phase 1 — review of PRs #188/#189/#190 (base `82f4314`)
+
+- **#188 (shell history duplicate handling)**: bug EMPIRICALLY proven with
+  a host unit test linking main's actual `lib/inc/ring_buffer.h` macro
+  (old push shows `ls` where `id` expected; fixed push correct); wrap-around
+  (>10 entries) re-verified. Verdict MERGE (93%). Merged as `276496a`.
+- **#189 (vfs_destroy_task double decrement)**: root cause verified by
+  enumerating every `close_f` (all decrement internally) and every fd_list
+  producer (all increment once). Exploit mechanism (ext2 per-inode struct
+  cache + per-fd-only write authorization) verified line-by-line; author's
+  PoC not re-run. Verdict MERGE (85%). Merged as `62c638a`.
+- **#190 (strncpy bounds in process.c)**: write overflows real (author PoC:
+  EIP control; `-fno-stack-protector` confirmed). Found the fix
+  incomplete: `strncpy` without forced termination → consumer over-reads
+  (host ASan demo); `process.h` include-order fragility for NAME_MAX.
+  Verdict REQUEST_CHANGES (88%). Still open.
+- Incidental discovery: `make qemu-test` panics at test 10/39 (t_gid) on
+  BASE and on ALL three PR heads with identical signatures, and exits 0 →
+  pre-existing, and the harness masks it. Tests 1–9 pass.
+
+## Phase 2 — pre-existing-bug investigation (base `MAIN` = `62c638a`)
+
+Re-verified every candidate from scratch on `MAIN`; 12 candidates → 5
+issues + 7 dismissed.
+
+Investigations performed:
+- **t_gid panic**: serial capture; pristine vs post-run rootfs.img compared
+  with debugfs (both showed 27 data blocks for a 28-block size → not guest
+  corruption); byte-identical `debugfs dump` initially masked the hole
+  (holes dump as zeros) — resolved by reading the BLOCKS list; isolated
+  mke2fs experiment proved all-zero tails become holes; read the kernel
+  read path (`ext2_read_block` rejecting 0; loop bound in
+  `ext2_read_inode_data`); traced crash propagation through
+  `elf_load_file` exact-size read and `mm_destroy`-before-load in
+  `__load_executable`. Filed **#192**.
+- **Harness green-on-panic**: read panic.c (port 0x604), CMake qemu-test
+  target, scripts/run-qemu-test exit logic, ubuntu.yml tapview step;
+  reproduced exit-0 five times. Filed **#193**.
+- **procfs read overflow**: wrote in-guest repro `t_aaa_procfs`
+  (syslog-based); observed return 4 + reader SIGSEGV (user-mode fault
+  ERR(100)); first attempt with printf produced no serial output (VGA-only)
+  — documented. Filed **#194**.
+- **sys_pipe multi-free**: wrote in-guest repro `t_aab_pipe` (fd exhaustion
+  via repeated `open("/")` — 12 opens then EMFILE; then `pipe()`); captured
+  the exact double-close log chain; read create_pipe_fd/pipe_close/sys_pipe
+  to establish up-to-3 frees. Filed **#195**.
+- **execve argv**: static proof of `args_location[256]` overflow and
+  unbounded walks; verified libc passes vectors through; verified #190
+  does not touch these helpers. Filed **#196** (in-guest execution of the
+  300-argv PoC deliberately deferred — code path unambiguous).
+- **kfree-on-slab concern**: read slab.c `pr_kfree` — routes via page
+  metadata; FALSE POSITIVE, dismissed.
+- **waitpid pid==1 filter, fd_list init/dead extension, shell printf
+  format bug, self-referential sprintf, sys_close errno**: investigated,
+  classified real-but-minor or latent-unreachable; dismissed from filing
+  (rationales in false-positives-and-dismissed-findings.md).
+
+Dup sweeps: `gh issue/pr list --state all --search ...` per finding; #56
+identified as the 2024 precursor of #192 (closed with an invitation to
+reopen on recurrence); #191/#121 identified as umbrellas to cross-reference;
+no duplicates for #193–#196.
+
+## Phase 3 — issue filing
+
+Filed one at a time with final dup sweeps: #192, #193, #194, #195, #196
+(titles/bodies preserved in the issues themselves; bodies drafted in
+`/tmp/opencode/issue-bodies/`, transient).
+
+## Phase 4 — this knowledge base
+
+Written on the `develop` working tree (untracked files only; no commits,
+branches, or pushes; no source modified). Baselines stated per file.
+
+## What was NOT pursued, and why
+
+- **In-guest run of #196's 300-argv PoC** — code-proven; deferred to keep
+  the investigation read-only and because the crash location (kernel stack
+  smash) could wedge the disposable VM unpredictably.
+- **Write-side sparse-hole test** — requires guest-side file writes into
+  holes; left as a recorded hypothesis in #192/ext2.md.
+- **Symbolizing panic EIP 0xc00026f9** — nm/objdump on kernel.bin noted as
+  available; the code-level chain was already fully established.
+- **IPC, signals detail, keyboard/tty, scheduler algorithms** — out of
+  scope of the findings; no observations recorded beyond architecture.md.
+- **Why exactly 12 fd opens (not 13) exhausted the table** — expected
+  16−3 stdio = 13; one slot unaccounted (possibly an open runtests/cwd fd);
+  not chased; does not affect #195's chain (EMFILE is what matters).
+- **The 2-D ring buffer `rb_history_get` returning 1/0 vs success** —
+  reviewed only as far as #188 required.

--- a/docs/maintainer/known-bugs.md
+++ b/docs/maintainer/known-bugs.md
@@ -1,0 +1,84 @@
+# Known bugs — status ledger
+
+Baselines: issues #192–#196 verified against `MAIN` = `62c638a`. PR #190
+reviewed against `BASE` = `82f4314`.
+
+## Open issues filed from this investigation
+
+### #192 — ext2 sparse holes fail to read; qemu-test panic at t_gid
+- **Status**: open. **Severity**: high. **Subsystem**: kernel/src/fs/ext2.c.
+- **Proven root cause**: `mke2fs` writes all-zero tail blocks as holes;
+  `ext2_read_inode_data` includes the hole block;
+  `ext2_read_block` rejects block 0 → whole read fails. Secondary: failed
+  exec after `mm_destroy` → kernel panic (see execve.md).
+- **Reproduction**: deterministic; `make qemu-test` panics at test 10/39
+  (EMPIRICALLY REPRODUCED on 5 builds). Isolated mke2fs experiment proves
+  the image side.
+- **Related**: #56 (2024 same bug, t_alarm; closed unresolved-root-cause),
+  PR #59 (partial fix), #121 (likely same panic class), #193 (masks it),
+  #192↔#194/#195 repro placement (t_gid blocks 30 tests).
+- **Outstanding hypotheses**: write-side mirror (writing into a hole needs
+  block alloc; `ext2_write_block` also rejects 0) — untested. Panic EIP
+  0xc00026f9 not symbolized.
+
+### #193 — qemu-test/CI green on kernel panic
+- **Status**: open. **Severity**: high (developer/CI).
+- **Proven root cause**: four stacked defects — panic.c clean QEMU shutdown
+  (port 0x604) when `runtests`; CMake qemu-test target runs QEMU directly;
+  run-qemu-test accepts exit {0,1}; CI swallows tapview exit
+  (ubuntu.yml:101). All four verified in code; behavior EMPIRICALLY
+  REPRODUCED (exit 0 on panic, 5/5 runs).
+- **Related**: #192 (the masked regression), PR #46 (test-runner origin).
+- **Outstanding hypotheses**: none; fix directions recorded in the issue.
+
+### #194 — procfs read ignores nbyte (kernel→user overflow)
+- **Status**: open. **Severity**: medium-high (security).
+- **Proven root cause**: `__procr_read` `strcpy(buffer, support+offset)`
+  after computing a correct `bytes_to_read` (proc_running.c:416-419 @`MAIN`).
+- **Reproduction**: EMPIRICAL — `read(fd, char[8], 4)` on `/proc/<pid>/stat`
+  returns 4, reader killed by SIGSEGV (user-mode fault).
+- **Related**: #191 (umbrella), procfs.md (sibling modules unaudited for
+  the same pattern).
+
+### #195 — sys_pipe error path multi-frees pipe_inode_info
+- **Status**: open. **Severity**: medium-high (security).
+- **Proven root cause**: readers/writers set only after both fds succeed;
+  `pipe_close` during creation frees pipe_info; sys_pipe error path frees
+  again (+sys_close partial path). Up to 3 frees (pipes.md has the exact
+  chain).
+- **Reproduction**: EMPIRICAL — fd exhaustion + pipe(); serial signature
+  captured (two "already zero" warnings = double pipe_close on freed
+  pipe_info). Freelist-aliasing impact is INFERENCE, not observed.
+- **Related**: allocator mechanics in memory-management.md.
+
+### #196 — sys_execve argv >256 entries overflows kernel stack; unbounded
+user-string walks
+- **Status**: open. **Severity**: high (security).
+- **Proven root cause (CODE-PROVEN)**: `char *args_location[256]` indexed
+  by user argc (`__push_args_on_stack`, process.c:70/75 @`MAIN`);
+  `__count_args` unbounded walk; `__count_args_bytes` raw `strlen`s.
+- **Reproduction**: NOT yet executed in-guest (test sketch in the issue);
+  code path is unambiguous. Host libc passes vectors through unvalidated.
+- **Related**: #190 (complementary, same function), #191, #121.
+
+## Open PR
+
+### PR #190 — security(kernel): strncpy bounds in process.c
+- **Status**: open; review verdict REQUEST_CHANGES (88% confidence).
+- Fixes the write overflows (bounds match destinations; NAME_MAX resize
+  consistent — verified). Blocking: no forced NUL termination (host-ASan
+  demo of consumer over-read); `process.h` missing `limits.h` include.
+- Non-blocking: add long-name/long-path execve tests; note pre-existing
+  qemu-test red (its "all tests pass" claim was an artifact of #193).
+
+## Relevant older issues
+
+- **#191** (open) — umbrella: no user-pointer validation in syscalls
+  (`sys_read`/`sys_write` arbitrary kernel access). #194/#196 are concrete
+  instances; keep cross-referenced, don't close on partial fixes.
+- **#121** (open) — "crashes with some bad executables": likely the
+  exec-after-mm_destroy panic path (#192 secondary) and/or #190-class
+  overflows. Unconfirmed mapping.
+- **#56** (closed 2024) — original sparse-tail occurrence (t_alarm);
+  historical context for #192.
+- **#124** (open) — macOS M2 build failures; not investigated.

--- a/docs/maintainer/memory-management.md
+++ b/docs/maintainer/memory-management.md
@@ -1,0 +1,76 @@
+# Memory management (as it relates to lifetime/UAF reasoning)
+
+Verified against `MAIN` = `62c638a` unless noted.
+
+## Allocator layers
+
+- Slab caches on top of buddy/zone allocators (kernel/src/mem/alloc/).
+  `KMEM_CREATE(type)` creates typed caches (e.g. `task_struct_cache`,
+  `vfs_file_cache`, `vfs_superblock_cache` in `vfs_init`).
+- `kmem_cache_alloc/kmem_cache_free` for cache objects.
+- `kmalloc/kfree` (slab.c `pr_kmalloc`/`pr_kfree`): kmalloc routes to
+  order-sized generic caches (`malloc_blocks[order]`).
+
+## KEY FACT — `kfree()` is safe on slab objects (FALSE POSITIVE resolved)
+
+`pr_kfree` (slab.c): resolves `get_page_from_virtual_address(ptr)`; if
+`page->container.slab_main_page` is set → `kmem_cache_free(ptr)`, else
+`free_pages_lowmem`. Page metadata distinguishes slab vs raw allocations, so
+call sites like `pipe_open`/`pipe_unlink` doing `kfree(file)` on a
+`vfs_alloc_file()` (cache) object are correct. Do not "fix" these to
+`vfs_dealloc_file` on allocator-safety grounds (a consistency argument is
+separate and was not evaluated).
+
+## Double-free behavior (basis of #195's impact assessment)
+
+`pr_kmem_cache_free` (slab.c): validates pointer/page/cache, runs optional
+dtor, `KMEM_OBJ_FROM_ADDR`, pushes onto the cache freelist. No double-free
+detection (no free-list audit / poisoning observed). CONSEQUENCE (INFERENCE
+from mechanics, not directly observed): freeing the same object 2–3 times
+inserts it 2–3 times into the freelist → subsequent allocations can hand
+one memory region to multiple owners → silent cross-type corruption. This is
+the stated impact model of issue #195.
+
+`kmem_cache_free` failure paths return nonzero with pr_crit (NULL ptr, no
+page, no cache) — they do not abort.
+
+## Allocation zeroing
+
+- `pr_vfs_alloc_file` memsets new `vfs_file_t` to 0 (VERIFIED).
+- `__alloc_task` memsets `task_struct` to 0 (VERIFIED).
+- kmalloc'd buffers are NOT generally zeroed — code must memset (e.g.
+  `__pipe_inode_info_alloc` memsets; `elf_load_file` memsets its read
+  buffer).
+- Boot-time slab pages come up zeroed (this is why the un-zeroed `kmalloc`
+  of the initial `fd_list` in `vfs_init_task` has never misbehaved —
+  see false-positives doc).
+
+## Debug options (observed in code)
+
+`ENABLE_KMEM_TRACE`, `ENABLE_CACHE_TRACE`, `ENABLE_FILE_TRACE` — log
+alloc/free pairs and resource tracking (used by `register_resource` /
+`store_resource_info`). Enable for leak/UAF triage builds.
+
+## mm / paging relationships observed
+
+- `mm_struct` per task: `pgd`, arg/env start/end, code/data/brk extents,
+  `total_vm`. `mm_clone` for fork; `mm_destroy` on `do_exit` and **during
+  exec before the new image is loaded** (process.c:175 @`MAIN`) — the
+  error-path hazard behind #192's panic and likely #121 (see execve.md).
+- `paging_switch_pgd` used when loading init and during exec; user stack
+  pointers (`thread.regs.useresp`) are then re-based by pushing args.
+- Page-fault handler (mem/page_fault.c): prints decode
+  `ERR(user rw present)` as `(%d%d%d)`; user-mode fault with non-present
+  directory entry → SIGSEGV + scheduler_run; kernel-mode fault →
+  `__page_fault_panic` → `kernel_panic`.
+- Kernel heap/virtual layout observations: kernel EIP ~0xc00026f9, kernel
+  ESP ~0xf75eec48, user stack top ~0xbfffxxxx in the repro runs (useful
+  sanity anchors when reading panic logs).
+
+## Knowledge gaps (not verified)
+
+- Buddy/zone internals, dma handling, per-CPU caches if any.
+- Where pipe buffer PAGES are allocated/freed (`__pipe_buffer_init` only
+  zeroes structs; the page lifecycle lives in the read/write/confirm paths —
+  untraced).
+- vmem/vm_area machinery details.

--- a/docs/maintainer/pipes.md
+++ b/docs/maintainer/pipes.md
@@ -1,0 +1,108 @@
+# Pipes
+
+Verified against `MAIN` = `62c638a` (line refs for `MAIN`). Core file:
+kernel/src/fs/pipe.c.
+
+## Structures
+
+- `pipe_inode_info_t` (`pipe_info`): wait queues `read_wait`/`write_wait`,
+  mutex, `numbuf` (= PIPE_NUM_BUFFERS) `pipe_buffer_t`s, read/write indices,
+  `readers`/`writers` counts.
+- `__pipe_inode_info_alloc` (pipe.c:145): kmalloc + memset 0, wait-queue
+  init, buffer structs zero-initialized (`__pipe_buffer_init` sets
+  len/offset/ops; **no pages allocated at init**), `readers = writers = 0`.
+- `__pipe_inode_info_dealloc` (pipe.c:195): `__pipe_buffer_deinit` each buf
+  (resets fields only — page freeing happens elsewhere; not traced in this
+  investigation — see memory-management.md gaps), then `kfree(pipe_info)`.
+
+## File creation
+
+`pipe_create_file_struct` (pipe.c:619): slab-alloc `vfs_file_t` via
+`vfs_alloc_file`, zeroes it, `flags = S_IFIFO | (flags & O_ACCMODE)`,
+`fs_operations = &pipe_fs_operations`, `refcount = 1`, **`count = 1`**
+(pipe.c:664 — the fd reference), name from path (named pipes).
+
+Anonymous: `sys_pipe` (pipe.c:1207) →
+1. `__pipe_inode_info_alloc(&anonymous_pipe_ops)`.
+2. buffer-confirm loop.
+3. `create_pipe_fd(pipe_info, O_RDONLY)` + `create_pipe_fd(O_WRONLY)`
+   (pipe.c:1127): allocates the file, `file->device = pipe_info`,
+   `get_unused_fd()`; on fd failure logs `"Failed to allocate file
+   descriptor."` (pipe.c:1152) and calls **`pipe_close(file)`**.
+4. **Only after both fds succeed**: `pipe_info->readers = 1; writers = 1`
+   (pipe.c:1252-1253).
+
+Named: `pipe_open` (pipe.c:697) — first scans the caller's fd_list for an
+existing FIFO with the same name and access mode and REUSES it (no new
+count); else allocates file + pipe_info. `sys_open` of a named pipe ends
+here via the normal `count += 1` path.
+
+## `pipe_close` (pipe.c:833-898) — the contract
+
+1. Validate file/device.
+2. Decrement `readers` or `writers` by `file->flags & O_ACCMODE` (with
+   already-zero warnings — pipe.c:855/864).
+3. If `writers == 0`: wake readers.
+4. `--file->count`; at 0: if `readers == 0 && writers == 0` →
+   `__pipe_inode_info_dealloc(pipe_info)`; unlink `file->siblings`;
+   `vfs_dealloc_file(file)`.
+
+## Fork interaction
+
+`vfs_dup_task` → `vfs_update_pipe_counts` (pipe.c:1160): for each inherited
+FIFO fd, `++readers` or `++writers` by mode.
+
+## Unlink
+
+`pipe_unlink` (pipe.c ~795-825): scans fd_list by name, and on match:
+`list_head_remove(&file->siblings)`, `__pipe_inode_info_dealloc(device)`,
+`kfree(file)` — bypasses the `close_f` contract entirely (direct kfree of a
+slab object — SAFE per allocator routing, see memory-management.md, but
+leaves accounting to the caller's fd slot clearing). Not deeply audited.
+
+## Issue #195 — the multi-free chain (VERIFIED FACT + EMPIRICALLY
+REPRODUCED)
+
+During `sys_pipe`, `readers == writers == 0` for the whole creation phase
+(they're set last). Therefore any `pipe_close` during creation satisfies the
+`count`-0 AND `readers==0 && writers==0` conditions and frees `pipe_info`.
+
+Failure sequence with the fd table exhausted (`get_unused_fd` → -EMFILE):
+
+1. `create_pipe_fd(O_RDONLY)` fails → `pipe_close(file1)`:
+   readers/writers stay 0, `--count → 0` → **frees pipe_info (#1)**.
+2. `create_pipe_fd(O_WRONLY)` fails → `pipe_close(file2)` on the SAME,
+   already-freed pipe_info (device pointer copied before failure):
+   operates on freed memory, `--count → 0` again → **frees again (#2)**.
+3. `sys_pipe` error path: `sys_close` of any created fd (partial-failure
+   case: another free through pipe_close) plus unconditional
+   `__pipe_inode_info_dealloc(pipe_info)` (pipe.c:1248) → **free #3**.
+
+Reproduction (issue #195, test `t_aab_pipe`): exhaust fds by opening `/`
+repeatedly (observed: 12 opens then errno 24 EMFILE), call `pipe()`.
+Serial signature observed:
+
+```
+[ER | pipe.c:1152] Failed to allocate file descriptor.
+[WR | pipe.c:864 ] Readers count is already zero.
+[ER | pipe.c:1152] Failed to allocate file descriptor.
+[WR | pipe.c:855 ] Writers count is already zero.
+[ER | pipe.c:1241] Failed to create file descriptors.
+```
+
+`pipe()` returns -1 and the kernel survives — the slab freelist now holds
+the object multiple times (aliasing on future allocations is the EXPECTED
+effect; not directly observed — INFERENCE from allocator mechanics).
+
+## Fix direction (recorded in #195)
+
+Make ownership unambiguous: set readers/writers per end as created (not only
+after both succeed), or make creation failure not go through `pipe_close`
+(free the file directly), and drop the unconditional dealloc in `sys_pipe`'s
+error path once close owns the lifetime.
+
+## Not investigated
+
+- Blocking semantics (`pipe_read`/`pipe_write` wait loops, wakeups) beyond
+  what `pipe_close` shows; pipe buffer page alloc/dealloc sites
+  (`pipe_buffer_confirm` etc.).

--- a/docs/maintainer/process-lifecycle.md
+++ b/docs/maintainer/process-lifecycle.md
@@ -1,0 +1,90 @@
+# Process lifecycle
+
+Verified against `BASE` = `82f4314`; spot-rechecked at `MAIN` = `62c638a`
+(where noted).
+
+## Structures
+
+- `task_struct` (kernel/inc/process/process.h) — allocated from
+  `task_struct_cache` (KMEM_CREATE slab) and fully `memset` to 0 at alloc in
+  `__alloc_task` (VERIFIED, process.c). Relevant fields:
+  - `fd_list` (`vfs_file_descriptor_t *`: `{file_struct, flags_mask}`),
+    `max_fd`
+  - `name[TASK_NAME_MAX_LENGTH]` (100 at `BASE`/`MAIN`; PR #190 changes the
+    macro to `NAME_MAX`=255), `cwd[PATH_MAX]`
+  - `mm` (mm_struct), `thread.regs` (eip/useresp/eax/...), `state`,
+    `exit_code`, `parent`, `children`/`sibling` list heads, `run_list`
+  - signal state: `sighand`, `blocked`, `pending`, `waiting_on`
+- `init_process` global; init may not call exit (kernel_panic guard).
+
+## Creation — `__alloc_task(source, parent, name)` (process.c)
+
+1. slab-alloc + zero.
+2. `pid_manager_get_free_pid()`.
+3. fd list: `vfs_dup_task(proc, source)` if `source`, else `vfs_init_task(proc)`.
+4. lists init (`run_list`, `children`, `sibling`), parent linkage.
+5. `strcpy(proc->name, name)` (bounded by PR #190 to TASK_NAME_MAX_LENGTH);
+   `cwd` copied from source or `"/"` (bounded to PATH_MAX by PR #190; source
+   is always `resolve_path` output, which is NUL-terminated by construction —
+   see execve.md "termination guarantees").
+6. `memcpy` of thread context from source if fork.
+
+## Fork — `sys_fork` (process.c)
+
+- `scheduler_store_context(f, current)`; `__alloc_task(current, current,
+  current->name)`; `proc->mm = mm_clone(current->mm)`; child `eax = 0`;
+  inherits sid/pgid/uid/ruid/gid/rgid; `scheduler_enqueue_task(proc)`;
+  parent gets pid.
+- `vfs_dup_task` copies the fd array and does `++file_struct->count` per
+  non-NULL slot, then `procr_create_entry_pid(task)` and
+  `vfs_update_pipe_counts` (increments pipe readers/writers for inherited
+  FIFO fds).
+
+## Exit — `do_exit` (scheduler.c)
+
+VERIFIED at `BASE` (scheduler.c:581) and unchanged in essence at `MAIN`:
+
+1. init guard (kernel_panic).
+2. `exit_code` stored, `state = EXIT_ZOMBIE`.
+3. SIGCHLD to parent + `wake_up_process_on_queue(&waitpid_queue, parent)`.
+4. Children re-parented to init (list splice).
+5. `mm_destroy(runqueue.curr->mm)`.
+6. **Does NOT close fds.** The zombie keeps its `fd_list` until reaping.
+   (This is why `vfs_destroy_task` is the catch-all close path and why the
+   pre-#189 double-decrement fired for every fd left open at exit.)
+
+## Reap — `sys_waitpid` (scheduler.c)
+
+Verified at `MAIN` (scheduler.c:511ff):
+
+- Validates: `pid < -1 || pid == 0` → ESRCH; `pid == self` → ECHILD;
+  options restricted to WNOHANG|WUNTRACED.
+- Scans `children` for `EXIT_ZOMBIE`; matches specific pid only when
+  `pid > 1` (see false-positives doc for the pid==1 quirk).
+- Reap sequence: `pid_manager_mark_free` → `vfs_destroy_task(child)` →
+  unlink from parent's children → dequeue if still on runqueue →
+  `kmem_cache_free(child)`.
+- No zombie + WNOHANG → 0; no zombie otherwise → `sleep_on(&waitpid_queue)`
+  and returns `-EINTR` (userspace must retry).
+- Reaping may also occur in the scheduler when a zombie becomes current
+  (comment at `MAIN`), guarded by `list_head_empty(&child->run_list)`.
+
+## Invariants (INVARIANT)
+
+1. Exactly one `task_struct` per live/zombie pid while in `children` list;
+   freed exactly once, by the reaper.
+2. A zombie's `mm` is destroyed but its fd list and proc entry persist until
+   reap. Any code walking a zombie's fds must therefore be robust to files
+   whose backing was already released elsewhere.
+3. Every fd slot referencing a file holds one `count` reference (see
+   vfs-and-fd-lifetime.md) — `vfs_dup_task` and `vfs_destroy_task` are the
+   fork/destroy pair that must balance.
+4. `task->cwd` is always a NUL-terminated absolute path (producers:
+   `__alloc_task`, `sys_chdir`, `sys_fchdir`, all via `resolve_path`).
+
+## Known issues touching this area
+
+- Pre-#189 `vfs_destroy_task` double-decrement (FIXED by merged PR #189 —
+  verified at `MAIN`).
+- Failed exec destroys `mm` then returns to userspace → kernel panic
+  (issue #192 secondary effect / likely #121). See execve.md.

--- a/docs/maintainer/procfs.md
+++ b/docs/maintainer/procfs.md
@@ -1,0 +1,78 @@
+# procfs
+
+Verified against `MAIN` = `62c638a` (line refs for `MAIN`).
+
+## Structure
+
+- procfs keeps a global list of `procfs_file_t` entries (name, inode, flags,
+  timestamps, `dir_entry` with per-entry `sys_operations`/`fs_operations`,
+  and a list of associated open `vfs_file_t`s).
+- Module entries are registered by `proc_create_entry`/`proc_mkdir` with
+  module-specific ops tables: `proc_running.c` (`/proc/<pid>/{cmdline,stat}`),
+  `proc_system.c`, `proc_ipc.c`, `proc_video.c` (`/proc/video` — the console
+  device used for init stdio), `proc_feedback.c`.
+- **Template tables vs open files (surprising, verified)**: the module
+  `vfs_file_operations_t` tables (procr_/procs_/procipc_/procv_/procfb_)
+  frequently have `.close_f = NULL`, and procr_/procv_ also `open_f = NULL`.
+  These live on the `proc_dir_entry_t` *templates*. When a file is actually
+  opened, `procfs_open` (procfs.c:441 @`MAIN`) wraps it via
+  `procfs_create_file_struct` which assigns `procfs_fs_operations`
+  (`close_f = procfs_close`, valid). Hence NULL `close_f` is unreachable
+  through any `fd_list` today — VERIFIED by enumerating all ops tables and
+  all sites assigning `fs_operations` on `vfs_file_t`.
+
+## Per-process entries
+
+`procr_create_entry_pid(task)` creates `/proc/<pid>/{cmdline,stat}` on task
+creation; `procr_destroy_entry_pid(task)` removes them during reap (called
+from `vfs_destroy_task`). Entry `data` points back at the `task_struct`.
+
+## Read path
+
+`sys_read` → `vfs_read` → `procfs_read` (procfs.c) → looks up the entry by
+inode → dispatches to the module's `dir_entry.fs_operations->read_f` →
+e.g. `__procr_read` (proc_running.c:391-422 @`MAIN`) for cmdline/stat:
+
+1. Builds content into `char support[BUFSIZ]` (512) —
+   `__procr_do_cmdline` (strcpy of `task->name`!) or `__procr_do_stat`.
+2. Computes `bytes_to_read = max(0, min(strlen(support) - offset, nbyte))`
+   — correct arithmetic.
+3. Copies with **`strcpy(buffer, support + offset)`** — writes
+   `strlen(support) - offset + 1` bytes into the raw user `buffer`,
+   ignoring `nbyte`. → **issue #194** (EMPIRICALLY REPRODUCED:
+   `read(fd, char[8], 4)` on `/proc/<pid>/stat` returned 4 and destroyed the
+   caller's stack → user-mode page fault `ERR(0)…(100)` → SIGSEGV).
+
+Correct fix: `memcpy(buffer, support + offset, bytes_to_read)`.
+Audit siblings (`proc_system.c`, `proc_ipc.c`, `proc_video.c`,
+`proc_feedback.c`) for the same pattern before assuming only procr_ is
+affected (pattern presence elsewhere: INFERENCE — not audited file-by-file
+in this investigation).
+
+## `task->name` consumers (relevant to PR #190's termination gap)
+
+- `__procr_do_cmdline` (proc_running.c:58-62 @`MAIN`):
+  `strcpy(buffer, task->name)` — ignores its `bufsize` parameter AND depends
+  on `task->name` being NUL-terminated (not guaranteed post-#190 for
+  ≥255-char names).
+- `__procr_do_stat` (proc_running.c:82): `basename(task->name)` in a
+  `sprintf("%s (%s)")` — same dependence.
+- Plus ~15 `pr_debug`/`pr_info` `%s` sites across scheduler/wait/feedback.
+
+## Related code-quality findings (not filed; see false-positives doc)
+
+- `__procr_do_stat` builds output via repeated self-referential
+  `sprintf(buffer, "%s ...", buffer, ...)` — UB per the C standard, works on
+  the current gcc/i386 toolchain; `strcat(buffer, " 0")` is used elsewhere
+  in the same function.
+- `__procr_read`'s `support` is 512 bytes; a long `task->name` or many stat
+  fields could overflow it via the same strcpy/sprintf patterns — combined
+  risk with #196 (unbounded name length) is theoretical but worth a look
+  when fixing #194 (HYPOTHESIS).
+
+## /proc/video
+
+`procv_module_init` registers the `video` entry with read/write/ioctl ops
+and NULL close_f on the template; init's stdio opens it (wrapped by
+procfs_fs_operations on open files, so closing works). Writes go to the
+console; reads from the keyboard buffer.

--- a/docs/maintainer/security-model.md
+++ b/docs/maintainer/security-model.md
@@ -1,0 +1,70 @@
+# Security model
+
+Verified against `BASE` = `82f4314` / `MAIN` = `62c638a`. This file separates
+**demonstrated** exploitability from **theoretical** impact everywhere.
+
+## Observed trust boundary
+
+- Ring separation with a syscall gate (`int 0x80`-style, dispatch via
+  `sys_call_table`, kernel/src/system/syscall.c). No user-pointer validation
+  anywhere (VERIFIED) → umbrella issue **#191** (open).
+- Permission checks exist at VFS/fs level: `vfs_valid_open_permissions`
+  (root/pid-0 bypass; owner/group/other bits), `vfs_valid_exec_permission`,
+  setuid/setgid on exec. **Per-fd** write authorization is only
+  `flags_mask` stored in the fd slot (read_write.c:63).
+
+## Recurring bug classes found in one review cycle
+
+1. **Raw-user-pointer string handling** — `strcpy`/`strlen`/unbounded walks
+   on syscall inputs (#196; PR #190's original overflows; #191's class).
+2. **Kernel→user overflow** — fs read handlers copying whole content into
+   user buffers (#194).
+3. **Refcount/lifetime violations** — pre-#189 `vfs_destroy_task` double
+   decrement (FIXED); `sys_pipe` multi-free (#195).
+4. **"Validation" that only checks for NULL** — pervasive.
+
+## Why refcount bugs here are privilege escalations (demonstrated chain)
+
+ext2 shares one `vfs_file_t` per inode (`ext2_find_vfs_file_with_inode`).
+Count corruption → premature free or stale struct → slab slot reused by a
+later open of a DIFFERENT file → two fds alias one struct → `sys_write`
+authorizes on the attacker's fd `flags_mask` but writes through the shared
+struct. PR #189's description contains a full working PoC (as `user`,
+writing `PWNED!` into a root-owned 0444 file); the mechanism was verified
+line-by-line at `BASE` (the exploit itself was not re-run by us —
+DEMONSTRATED BY PR AUTHOR, VERIFIED BY CODE ANALYSIS).
+
+## Demonstrated vs theoretical (explicit ledger)
+
+| Issue | Demonstrated | Theoretical/expected |
+|---|---|---|
+| PR #190 pre-fix overflow | Author's PoC: EIP → 0xdeadbeef in sys_execve | — |
+| #192 ext2 sparse read | Kernel panic in CI-run tests; unreadable binary | DoS only; data exposure unlikely |
+| #194 procfs overflow | Reader SIGSEGV; full stat line written past 8-byte buffer | Corrupt adjacent user objects (credentials/heap in reader's space); content kernel-controlled, length bounded by stat line |
+| #195 pipe multi-free | 2–3 frees of pipe_info (log-proven), 2nd pipe_close reads freed memory | Slab freelist aliasing → cross-type corruption (allocator-mechanics INFERENCE, not observed) |
+| #196 argv stack overflow | CODE-PROVEN (array bound vs user argc); not executed in-guest | Kernel stack control-flow hijack; written values are kernel heap pointers to user-controlled strings |
+| #191 arbitrary ptr syscalls | Community-reported read/write of arbitrary kernel addresses via sys_read/sys_write | Full kernel compromise |
+
+## Memory-safety-sensitive APIs/patterns to treat as radioactive
+
+- `strcpy`/`sprintf`/`strcat` on anything user-derived or inter-buffer
+  (see `__procr_read`, `__procr_do_stat`).
+- `strncpy(dst, src, sizeof(dst))` without `dst[sizeof(dst)-1] = 0` —
+  creates non-termination over-reads (PR #190 review finding; repo's correct
+  idiom exists in vfs.c superblock registration).
+- Fixed-size stack arrays filled by counts derived from user data
+  (`args_location[256]`).
+- Manual `--count` before `close_f` (violates the close_f contract —
+  vfs-and-fd-lifetime.md).
+- `kfree` of objects whose backing may already be freed (#195 pattern:
+  error paths stacked on error paths).
+
+## Non-goals / not assessed
+
+- No ASLR/stack-canary expectations: kernel builds `-fno-stack-protector`
+  by design (toolchain file) — assume no compiler hardening.
+- IPC (msg/sem/shm), signals beyond SIGCHLD/SIGSEGV paths, keyboard/tty
+  input handling: not audited.
+- Whether `runtests`'s userspace `outports(0x604, ...)` implies permissive
+  IOPL for all userspace (observed to WORK, mechanism not investigated —
+  flagged as a question, not a finding).

--- a/docs/maintainer/syscall-boundaries.md
+++ b/docs/maintainer/syscall-boundaries.md
@@ -1,0 +1,59 @@
+# Syscall boundaries
+
+Verified against `BASE` = `82f4314` and `MAIN` = `62c638a`.
+
+## The one-sentence reality (VERIFIED FACT)
+
+There is **no user-pointer validation layer**: syscall handlers take raw
+pointers from `pt_regs` (ebx/ecx/edx) and dereference them in kernel space.
+This is the subject of open umbrella issue **#191** ("security: Lack of
+userspace pointer validation in syscalls"), which documents `sys_read`/
+`sys_write` arbitrary kernel memory read/write via malicious pointers.
+
+## Observed patterns per syscall (not exhaustive — audited where the
+investigation touched)
+
+| Syscall | User inputs | Handling |
+|---|---|---|
+| `execve` | filename, argv, envp | NULL checks only; `strcpy`/`strncpy` + unbounded walks (`__count_args`, `__count_args_bytes`, `__push_args_on_stack`) — see execve.md, #196 |
+| `read` | buf | passed to fs `read_f` which copies INTO user memory; procfs overflows it (#194) |
+| `write` | buf | passed to fs `write_f`; authorized by per-fd `flags_mask` ONLY (read_write.c:63) |
+| `pipe` | fds[2] | written directly (kernel writes two ints to user pointer) |
+| `waitpid` | status | `*status = child->exit_code` direct store (not deeply audited) |
+| open/close/chdir/etc. | path strings | `resolve_path` copies into kernel `PATH_MAX` buffers (bounded), but the SOURCE `path` is walked unbounded by tokenizers/strlen inside resolve and fs layers (INFERENCE: same class, not separately reproduced) |
+
+## Contracts a future syscall must NOT assume exist
+
+- No `copy_from_user`/`copy_to_user` with access_ok-style checks.
+- No ARG_MAX: argv/envp size is bounded only by kmalloc success (#196).
+- No guarantee that user buffers are NUL-terminated where the kernel
+  `strlen`s them.
+- No per-fd vs per-file permission reconciliation: authorization uses the
+  fd's stored `flags_mask` while operations act on the possibly-shared
+  `file_struct` (ext2 per-inode cache) — see vfs-and-fd-lifetime.md.
+
+## Buffer-size contracts (VERIFIED VIOLATIONS)
+
+- `/proc/<pid>/{stat,cmdline}` read ignores `nbyte` (`strcpy` instead of
+  bounded memcpy) — **#194**, empirically reproduced.
+- `__procr_do_cmdline(buffer, bufsize, task)` ignores `bufsize`.
+
+## Argument-count considerations (#196, CODE-PROVEN)
+
+- `__push_args_on_stack`: `char *args_location[256]` overflowed by argv/envp
+  with >256 entries (kernel-stack OOB write of heap pointers).
+- `__count_args`: unbounded vector walk until NULL.
+- `__count_args_bytes`: `strlen` on each raw user string.
+- Fix direction: ARG_MAX-style caps + `-E2BIG`; sized allocation instead of
+  the fixed array; `strnlen` with limit.
+
+## Rules for adding/changing syscalls (derived from the above)
+
+1. Never `strcpy`/`strlen` a user pointer; copy bounded (`strnlen` first or
+   byte-counted copy) into a kernel buffer sized to a limit you define.
+2. Never write more to a user buffer than the syscall's size argument.
+3. Reject oversized inputs with a real errno (`-E2BIG`, `-ENAMETOOLONG`)
+   rather than truncating silently — truncation without forced NUL
+   termination creates downstream over-reads (the PR #190 review lesson).
+4. Assume any pointer may be non-canonical, unmapped, or pointing into
+   kernel memory until #191 is fixed.

--- a/docs/maintainer/testing-and-ci.md
+++ b/docs/maintainer/testing-and-ci.md
@@ -1,0 +1,89 @@
+# Testing and CI
+
+Verified against `MAIN` = `62c638a` (line refs for `MAIN` unless noted).
+
+## Build/test architecture
+
+- CMake-only (no top-level Makefile; use `build/` dir + generated make).
+  Typical: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && make -C build -j`.
+- Observed workspace used HOST gcc 13 with `-m32` (CMakeCache
+  `CMAKE_C_COMPILER=/usr/bin/gcc`); `tools/toolchain-i686-elf.cmake` exists
+  for an i686-elf cross toolchain but was not used in our builds.
+- Key targets: `kernel.bin`, `bootloader.bin`, `filesystem` (rootfs.img via
+  mke2fs), `cdrom.iso`, `cdrom_test.iso`, `qemu`, `qemu-test`, `programs`,
+  `tests`, per-program targets (`prog_shell`, `test_t_list`, ...).
+- Host deps used: qemu-system-i386, grub-mkrescue, xorriso, mke2fs,
+  debugfs/dumpe2fs (e2fsprogs), nasm, gcc-multilib.
+- **Tests build INTO the source tree**: `userspace/tests/CMakeLists.txt`
+  installs to `${CMAKE_SOURCE_DIR}/filesystem/bin/tests`
+  (`MENTOS_TESTS_DIR`). Building tests dirties the working tree with
+  binaries.
+
+## Test registration (two places, both required)
+
+1. `userspace/tests/CMakeLists.txt` → `TEST_LIST`.
+2. `userspace/bin/runtests.c` → `all_tests[]` (order = execution order).
+   Intentionally skipped there: `t_big_write`, `t_periodic1/2/3`;
+   `t_time` disabled in CMake TEST_LIST.
+
+## Guest output routing (critical for debugging)
+
+- `printf` goes to the VGA console — INVISIBLE when capturing serial only
+  (`-nographic` + `-serial stdio`).
+- `syslog()` output arrives on the serial console (runtests itself uses
+  `syslog(LOG_INFO, "Running test (%2d/%2d): %s", ...)`). Write in-guest
+  repro/tests with `openlog(..., LOG_CONS|LOG_PID, LOG_USER)` + `syslog`.
+
+## qemu-test behavior — issue #193 (EMPIRICALLY REPRODUCED, 5 runs)
+
+Four independent reasons a kernel panic looks like success:
+
+1. `kernel_panic` (kernel/src/system/panic.c:11,20) writes `0x2000` to port
+   `0x604` (QEMU ACPI shutdown) when `runtests` is set → **clean QEMU exit,
+   host exit code 0**. `runtests` itself shuts down the same way on normal
+   completion (runtests.c:231).
+2. CMake `qemu-test` target (CMakeLists.txt:314-319) runs QEMU DIRECTLY —
+   no timeout, no exit-code interpretation, does not use
+   `scripts/run-qemu-test` at all.
+3. `scripts/run-qemu-test` (line 58) accepts BOTH 0 and 1 as success:
+   `if [ "${EXIT_CODE}" -eq 1 ] || [ "${EXIT_CODE}" -eq 0 ]`.
+4. CI (`.github/workflows/ubuntu.yml:101`) swallows tapview's failure exit:
+   `cat build/test.log | scripts/tapview || echo "tapview failed"`.
+   (Test step itself: ubuntu.yml:91 `./scripts/run-qemu-test build 600`.)
+
+`isa-debug-exit` semantics: guest exit value 0 → host exit 1; the script's
+`-eq 1` acceptance was presumably meant for that but 0 (panic path) is also
+accepted.
+
+Result: every panicking run ends with `[100%] Built target qemu-test` and
+`$? = 0`. This masked the #192 regression on main (panic at test 10/39 —
+tests 11–39 never run, TAP plan incomplete, CI green).
+
+## Reliable completion check (procedure — use this, not exit codes)
+
+1. Run QEMU capturing serial (see debugging-playbook.md).
+2. `grep -c "PANIC"` serial output — 1 means the guest died.
+3. `grep "Running test" | tail -1` — compare the (n/39) counter against the
+   full list; a stuck counter < total means incomplete run.
+4. For TAP consumers: missing/short plan in `test.log` (tapview flags
+   "Expected N tests but only M ran") — currently only visible if tapview's
+   exit is allowed to propagate.
+
+## Current known suite state (at `MAIN`)
+
+- Tests 1–9 pass (t_abort, t_alarm, t_chdir, t_creat, t_dup, t_environ,
+  t_exit, t_exec, t_fork).
+- Test 10 (t_gid) panics the kernel (#192); 11–39 unreachable.
+- The two investigation repros (`t_aaa_procfs`, `t_aab_pipe`, named to sort
+  first) run at positions 1–2 when registered; they lived only in a
+  disposable clone and are NOT in the repository — copy them from
+  investigation-history.md / issues #194/#195 if needed.
+
+## CI workflow shape (ubuntu.yml)
+
+- build job: matrix of compilers; cmake Release build only.
+- test job: Release + `EMULATOR_OUTPUT_TYPE=OUTPUT_LOG`; builds rootfs,
+  debugfs sanity-dumps it, builds `cdrom_test.iso`, runs
+  `scripts/run-qemu-test build 600`, then the (swallowed) tapview step;
+  artifacts test.log/serial.log uploaded `if: always()`.
+- macos.yml exists (issue #124 tracks build problems there; not examined).

--- a/docs/maintainer/vfs-and-fd-lifetime.md
+++ b/docs/maintainer/vfs-and-fd-lifetime.md
@@ -1,0 +1,103 @@
+# VFS and fd lifetime
+
+Verified against `BASE` = `82f4314`; the #189 fix verified merged at `MAIN` =
+`62c638a`.
+
+## Structures
+
+- `task->fd_list`: array of `vfs_file_descriptor_t {vfs_file_t *file_struct;
+  int flags_mask}`; `task->max_fd` starts at `MAX_OPEN_FD` = 16
+  (kernel/inc/fs/vfs.h:13).
+- `vfs_file_t` (slab object from `vfs_file_cache`, zeroed at alloc):
+  `count` (fd references), `refcount` (pipes use it too), `name`, `flags`,
+  `mask`, `uid/gid`, `f_pos`, `device`, `ino`, `fs_operations`,
+  `sys_operations`, `siblings` list node.
+- Superblock registry: `vfs_super_blocks` list; `vfs_get_superblock(path)`
+  picks the filesystem by path prefix.
+
+## THE core invariant (INVARIANT — audit all changes against it)
+
+> Every `fd_list` slot referencing a `vfs_file_t` holds exactly one
+> increment of `file->count`. Every removal of a slot reference goes through
+> a `close_f` (which itself decrements `count` and frees at 0).
+
+Producers (each verified to increment exactly once per reference):
+
+| Site | How count is taken |
+|---|---|
+| `sys_open` (kernel/src/fs/open.c) | `vfs_open` → `vfs_open_abspath`: `file->count += 1` after fs open |
+| `sys_creat` (kernel/src/fs/namei.c) | `vfs_creat`: `file->count += 1` |
+| `sys_dup` (kernel/src/fs/vfs.c) | `file->count += 1` |
+| `vfs_dup_task` (fork) | `++count` per inherited slot |
+| `create_pipe_fd` (kernel/src/fs/pipe.c) | `pipe_create_file_struct` sets `count = 1` |
+| init stdio (process.c, `BASE`:362-378) | `vfs_open` (+1) **plus deliberate extra `count++`** keeping the file alive past the temporary open — balanced overall |
+
+Consumers:
+- `sys_close` (open.c:56-77): NULLs the slot, then `vfs_close(file)` →
+  validation (`count <= 0` guard, `close_f == NULL` guard) → `close_f(file)`.
+- `vfs_destroy_task` (vfs.c): the catch-all for fds still open when a zombie
+  is reaped (`sys_waitpid` → `vfs_destroy_task`; only caller verified).
+  Post-#189 body (VERIFIED at `MAIN`): for each non-NULL slot, call
+  `close_f(file_struct)` directly, NULL the slot, then `kfree(fd_list)`,
+  `procr_destroy_entry_pid`.
+
+### The `close_f` contract (VERIFIED across all implementations)
+
+Every `close_f` **decrements `file->count` itself** and, at zero, performs
+filesystem-specific teardown then `vfs_dealloc_file(file)`:
+
+- `ext2_close` (ext2.c:3286-3325 @`MAIN`): `--count`; at 0: refuses to free
+  `fs->root` (returns -EPERM leaving count at 0), else unlinks from
+  `fs->opened_files` and frees.
+- `procfs_close` (procfs.c:548-572): `--count`; at 0: unlink + free.
+- `pipe_close` (pipe.c:833-898): mode-based reader/writer decrement,
+  wakeups, `--count`; at 0: frees pipe_info if readers==writers==0, unlinks,
+  frees file. (See pipes.md for the sys_pipe error-path violation.)
+- `ata_close`, `null_close`: same `--count`, free-at-0 pattern.
+
+Consequence: **callers must never pre-decrement `count`** — the pre-#189
+`vfs_destroy_task` did (`--count` then `close_f` when 0) causing a double
+decrement per still-open fd on reap. PR #189 (MERGED) removed the manual
+decrement; verified correct against every producer above.
+
+## ext2 per-inode file cache (critical for security reasoning)
+
+`ext2_open` (ext2.c:3095ff @`MAIN`) looks up
+`ext2_find_vfs_file_with_inode(fs, ino)` and REUSES the existing
+`vfs_file_t` (sharing `count`, `f_pos`, mask/uid/gid) instead of allocating a
+fresh one. Two opens of the same file = one struct, count 2.
+
+This converts refcount corruption into privilege escalation: if `count` is
+wrongly driven to -1 (the pre-#189 bug), the struct is never freed but is
+stale-listed; later `vfs_alloc_file` may hand the SAME slab object to a new
+open of a different file while an old fd still points at it. `sys_write`
+authorizes on the **per-fd `flags_mask`** (read_write.c:63) and then operates
+on the shared `file_struct` → an fd opened read-only can write into a file
+whose struct got aliased. PR #189's PoC (in its description) demonstrates the
+full chain; the mechanism was verified line-by-line at `BASE`.
+
+## `get_unused_fd` and the (currently dead) growth path
+
+`get_unused_fd` (vfs.c): scans for empty slot; `-EMFILE` when `fd >=
+MAX_OPEN_FD` (16); calls `vfs_extend_task_fd_list` only when
+`fd == task->max_fd`. Since `max_fd` starts at MAX_OPEN_FD = 16 and fds are
+capped at 16, **the extension branch is unreachable today** — max 13
+user-usable fds (3 stdio). Two latent defects if that ever changes (see
+false-positives doc): `vfs_extend_task_fd_list` memsets only the OLD extent
+of the new array, and `vfs_init_task`'s initial `kmalloc`'d list is not
+explicitly zeroed (works because boot-time slab pages are fresh/zero).
+
+## Dangerous lifecycle assumptions (do NOT rely on)
+
+1. "exit closes my fds" — false; only reap does (`vfs_destroy_task`).
+2. "close_f returns 0 always" — ext2 root returns -EPERM at count 0 without
+   freeing (by design); pipe_close can free more than the file.
+3. "each open returns a private file struct" — false in ext2 (shared cache,
+   shared f_pos).
+4. "NULL close_f can't be reached via fd_list" — true today (procfs wraps
+   every opened file with `procfs_fs_operations`; the NULL-`close_f` tables
+   belong to `proc_dir_entry_t` templates, e.g. procv_/procr_/procs_/
+   procipc_/procfb_), VERIFIED via `procfs_open`/`procfs_create_file_struct`.
+   But a new filesystem returning an unwrapped struct would crash
+   `vfs_destroy_task` — it calls `close_f` unconditionally (post-#189;
+   `vfs_close` has the NULL guard, `vfs_destroy_task` does not).


### PR DESCRIPTION
## Summary

Adds a maintainer-oriented knowledge base for MentOS, plus a concise `AGENTS.md` operational index for coding agents and maintainers.

The documentation captures verified subsystem behavior, invariants, debugging workflows, known bugs, investigation history, and previously investigated false positives across process lifecycle, execve, VFS/fd lifetime, ext2, procfs, pipes, memory management, syscall boundaries, testing/CI, and security.

## Contents

- `AGENTS.md` — repository map, critical invariants, test warnings, and pointers to deeper docs
- `docs/maintainer/README.md` — documentation index
- subsystem-specific maintainer notes under `docs/maintainer/`
- debugging and testing playbooks
- known-bug references and investigation history
- false-positive / dismissed-finding notes

## Scope

Documentation only; no source-code or behavioral changes.

Important claims are explicitly classified as verified fact, empirically reproduced, invariant, code-proven, inference, hypothesis, historical context, or false positive. Commit-specific references are identified as such.