### PR TITLE
fix(test): propagate qemu test failures correctly

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -108,7 +108,7 @@ jobs:
         cat build/test.log || echo "test.log not found"
         echo ""
         echo "=== TAP Results ==="
-        cat build/test.log | scripts/tapview || echo "tapview failed"
+        cat build/test.log | scripts/tapview
 
     - name: Show serial log
       if: always()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,11 +308,12 @@ add_custom_target(
 )
 
 # This target runs the emulator, and executes the runtests binary as init process.
-# Additionally it passes the '-device isa-debug-exit' option to shutdown qemu
-# after the tests are done.
+# Uses isa-debug-exit for explicit completion/failure signaling.
+# The wrapper recognizes QEMU exit 33 as normal suite completion, validates the
+# TAP output, and maps only a fully passing run to conventional host success (0).
 add_custom_target(
     qemu-test
-    COMMAND ${EMULATOR} ${EMULATOR_FLAGS} -nographic -device isa-debug-exit -boot d -cdrom ${CMAKE_BINARY_DIR}/cdrom_test.iso
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/run-qemu-test ${CMAKE_BINARY_DIR} 600
     DEPENDS cdrom_test.iso
 )
 

--- a/docs/maintainer/debugging-playbook.md
+++ b/docs/maintainer/debugging-playbook.md
@@ -26,6 +26,7 @@ cmake -S . -B /tmp/opencode/build-X -DCMAKE_BUILD_TYPE=Debug
 make -C /tmp/opencode/build-X -j$(nproc)            # everything incl. tests
 make -C /tmp/opencode/build-X kernel.bin            # kernel only
 make -C /tmp/opencode/build-X cdrom_test.iso        # test ISO
+make -C /tmp/opencode/build-X qemu-test            # run tests (canonical)
 ```
 
 ## QEMU invocation that works for serial capture

--- a/docs/maintainer/testing-and-ci.md
+++ b/docs/maintainer/testing-and-ci.md
@@ -34,40 +34,61 @@ Verified against `MAIN` = `62c638a` (line refs for `MAIN` unless noted).
   `syslog(LOG_INFO, "Running test (%2d/%2d): %s", ...)`). Write in-guest
   repro/tests with `openlog(..., LOG_CONS|LOG_PID, LOG_USER)` + `syslog`.
 
-## qemu-test behavior — issue #193 (EMPIRICALLY REPRODUCED, 5 runs)
+## qemu-test behavior — FIXED (issue #193)
 
-Four independent reasons a kernel panic looks like success:
+The guest now uses QEMU's `isa-debug-exit` device for explicit failure signaling:
 
-1. `kernel_panic` (kernel/src/system/panic.c:11,20) writes `0x2000` to port
-   `0x604` (QEMU ACPI shutdown) when `runtests` is set → **clean QEMU exit,
-   host exit code 0**. `runtests` itself shuts down the same way on normal
-   completion (runtests.c:231).
-2. CMake `qemu-test` target (CMakeLists.txt:314-319) runs QEMU DIRECTLY —
-   no timeout, no exit-code interpretation, does not use
-   `scripts/run-qemu-test` at all.
-3. `scripts/run-qemu-test` (line 58) accepts BOTH 0 and 1 as success:
-   `if [ "${EXIT_CODE}" -eq 1 ] || [ "${EXIT_CODE}" -eq 0 ]`.
-4. CI (`.github/workflows/ubuntu.yml:101`) swallows tapview's failure exit:
-   `cat build/test.log | scripts/tapview || echo "tapview failed"`.
-   (Test step itself: ubuntu.yml:91 `./scripts/run-qemu-test build 600`.)
+- **Suite completion**: `runtests` writes 0x10 to port 0x501 → host exit 33
+- **Panic**: `kernel_panic()` writes 0x11 to port 0x501 → host exit 35
+- **Encoding**: host_exit = (guest_value << 1) | 1
+- These values avoid collision with generic QEMU exit 1 (startup failure)
 
-`isa-debug-exit` semantics: guest exit value 0 → host exit 1; the script's
-`-eq 1` acceptance was presumably meant for that but 0 (panic path) is also
-accepted.
+### Implementation components
 
-Result: every panicking run ends with `[100%] Built target qemu-test` and
-`$? = 0`. This masked the #192 regression on main (panic at test 10/39 —
-tests 11–39 never run, TAP plan incomplete, CI green).
+1. **Guest signaling** (kernel/src/system/panic.c:18, userspace/bin/runtests.c:235):
+   - Panic path: `outports(0x501, 0x11)` → host exit 35
+   - Completion path: `outports(0x501, 0x10)` → host exit 33
 
-## Reliable completion check (procedure — use this, not exit codes)
+2. **Host wrapper** (scripts/run-qemu-test):
+   - Treats exit 33 as normal suite completion, then validates `test.log` with `tapview`
+   - Returns success only when QEMU completed normally and TAP reports zero failures
+   - Any other QEMU exit code (1, 3, 35, 124, timeout, etc.) is failure
 
-1. Run QEMU capturing serial (see debugging-playbook.md).
-2. `grep -c "PANIC"` serial output — 1 means the guest died.
-3. `grep "Running test" | tail -1` — compare the (n/39) counter against the
-   full list; a stuck counter < total means incomplete run.
-4. For TAP consumers: missing/short plan in `test.log` (tapview flags
-   "Expected N tests but only M ran") — currently only visible if tapview's
-   exit is allowed to propagate.
+3. **CI integration** (.github/workflows/ubuntu.yml:91, 101):
+   - Uses `scripts/run-qemu-test` with proper exit-code handling
+   - `tapview` failure exit propagates (no longer swallowed)
+
+4. **Local development** (CMakeLists.txt:313-317):
+   - `make qemu-test` now uses `scripts/run-qemu-test` wrapper
+   - Wrapper translates guest exit codes and validates TAP before returning success
+   - Consistent with CI pass/fail semantics
+
+### Exit code reference
+
+| Scenario                          | Guest write | Host exit | Recognized as |
+|-----------------------------------|-------------|-----------|---------------|
+| All tests pass                   | 0x10        | 33        | Success after TAP validation |
+| One or more tests fail           | 0x10        | 33        | Failure via `tapview`        |
+| Kernel panic                     | 0x11        | 35        | Failure       |
+| QEMU startup failure             | N/A         | 1         | Failure       |
+| QEMU timeout                     | N/A         | 124       | Failure       |
+| QEMU error/crash                 | N/A         | 0,2,4+    | Failure       |
+
+## Reliable completion check
+
+With the fix applied, failure detection is now automatic:
+
+1. **Local testing with proper signaling**: `./scripts/run-qemu-test build 600`
+   - Exit 0 = QEMU completed normally and all TAP tests passed
+   - Non-zero = test failure, malformed/incomplete TAP, panic, timeout, or QEMU error
+
+2. **Manual inspection (still useful for debugging)**:
+   - `grep -c "PANIC"` serial output — >0 means guest died
+   - `grep "Running test" | tail -1` — compare counter against total
+   - `cat build/test.log | scripts/tapview` — TAP validation
+
+3. **TAP validation**: the wrapper validates `test.log` after normal guest completion,
+   so failed tests and missing/short plans fail both local `qemu-test` and CI.
 
 ## Current known suite state (at `MAIN`)
 
@@ -84,6 +105,6 @@ tests 11–39 never run, TAP plan incomplete, CI green).
 - build job: matrix of compilers; cmake Release build only.
 - test job: Release + `EMULATOR_OUTPUT_TYPE=OUTPUT_LOG`; builds rootfs,
   debugfs sanity-dumps it, builds `cdrom_test.iso`, runs
-  `scripts/run-qemu-test build 600`, then the (swallowed) tapview step;
+  `scripts/run-qemu-test build 600`, then a diagnostic tapview step;
   artifacts test.log/serial.log uploaded `if: always()`.
 - macos.yml exists (issue #124 tracks build problems there; not examined).

--- a/kernel/src/system/panic.c
+++ b/kernel/src/system/panic.c
@@ -7,8 +7,9 @@
 #include "io/debug.h"
 #include "io/port_io.h"
 
-/// Shutdown port for qemu.
-#define SHUTDOWN_PORT 0x604
+/// Debug exit port for QEMU isa-debug-exit device (default iobase=0x501)
+/// Exit code encoding: host_exit = (guest_value << 1) | 1
+#define DEBUG_EXIT_PORT 0x501
 extern int runtests;
 
 void kernel_panic(const char *msg)
@@ -16,8 +17,9 @@ void kernel_panic(const char *msg)
     pr_emerg("\nPANIC:\n%s\n\nWelcome to Kernel Debugging Land...\n", msg);
     __asm__ __volatile__("cli"); // Disable interrupts
     if (runtests) {
-        outports(SHUTDOWN_PORT, 0x2000);
-    } // Terminate qemu running the tests
+        // Signal failure via isa-debug-exit (guest write 0x11 → host exit 35)
+        outports(DEBUG_EXIT_PORT, 0x11);
+    }
     for (;;) {
         // Decrease power consumption with hlt.
         __asm__ __volatile__("hlt");

--- a/scripts/run-qemu-test
+++ b/scripts/run-qemu-test
@@ -5,6 +5,7 @@ set -e
 
 BUILD_DIR="${1:-build}"
 TIMEOUT="${2:-600}"  # 10 minutes default
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "===================================================="
 echo "Starting QEMU test run (timeout: ${TIMEOUT}s)..."
@@ -41,9 +42,17 @@ echo ""
 (tail -F "${BUILD_DIR}/serial.log" 2>/dev/null | sed -u 's/^/[SERIAL] /' &)
 (tail -F "${BUILD_DIR}/test.log" 2>/dev/null | sed -u 's/^/[TEST]   /' &)
 
-# Wait for QEMU to finish
-wait "${QEMU_PID}"
-EXIT_CODE=$?
+# Wait for QEMU to finish and explicitly capture its exit code
+# Note: QEMU returns exit 33 on isa-debug-exit success (guest wrote 0x10),
+#       exit 35 on panic (guest wrote 0x11), etc.
+# We need to capture this without triggering set -e termination.
+if wait "${QEMU_PID}"; then
+    # wait succeeded (exit 0), which shouldn't happen with isa-debug-exit
+    EXIT_CODE=$?
+else
+    # wait captured QEMU's exit code
+    EXIT_CODE=$?
+fi
 
 # Give a moment for final output to flush
 sleep 1
@@ -53,12 +62,21 @@ echo "===================================================="
 echo "QEMU finished with exit code: ${EXIT_CODE}"
 echo "===================================================="
 
-# QEMU with isa-debug-exit returns exit code 1 on success (exit code 0 from guest = 1 from host)
-# Any other exit code is a failure
-if [ "${EXIT_CODE}" -eq 1 ] || [ "${EXIT_CODE}" -eq 0 ]; then
-    echo "Test run completed successfully"
-    exit 0
-else
-    echo "Test run failed or timed out"
+# isa-debug-exit semantics: host_exit = (guest_value << 1) | 1
+# Guest writes 0x10 → host exit 33 (suite completed; TAP still decides pass/fail)
+# Guest writes 0x11 → host exit 35 (panic/failure)
+# Any other exit code is a failure (timeout, QEMU error, etc.)
+if [ "${EXIT_CODE}" -ne 33 ]; then
+    echo "Test run failed or timed out (exit code: ${EXIT_CODE})"
     exit "${EXIT_CODE}"
 fi
+
+# A normal guest completion does not imply that every test passed. Validate the
+# TAP stream so local `make qemu-test` and CI share the same pass/fail semantics.
+if ! "${SCRIPT_DIR}/tapview" < "${BUILD_DIR}/test.log"; then
+    echo "Test run completed, but TAP reported failures"
+    exit 1
+fi
+
+echo "Test run completed successfully"
+exit 0

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -16,7 +16,9 @@
 #include <syslog.h>
 #include <unistd.h>
 
-#define SHUTDOWN_PORT 0x604
+/// Debug exit port for QEMU isa-debug-exit device (default iobase=0x501)
+/// Exit code encoding: host_exit = (guest_value << 1) | 1
+#define DEBUG_EXIT_PORT 0x501
 /// Second serial port for QEMU.
 #define SERIAL_COM2   0x02F8
 
@@ -220,7 +222,8 @@ int runtests_main(int argc, char **argv)
         testsc = argc - 1;
     }
 
-    test_out("1..%d", testsc);
+    append("1..%d", testsc);
+    test_out_flush();
 
     char *test_argv[32];
     for (int i = 0; i < testsc; i++) {
@@ -230,7 +233,8 @@ int runtests_main(int argc, char **argv)
 
     // We are running as init
     if (init) {
-        outports(SHUTDOWN_PORT, 0x2000);
+        // Signal success via isa-debug-exit (guest write 0x10 → host exit 33)
+        outports(DEBUG_EXIT_PORT, 0x10);
     }
 
     return 0;


### PR DESCRIPTION
## Summary

Fix the `qemu-test` execution path so kernel panics, QEMU failures, timeouts,
incomplete test runs, and TAP test failures are no longer reported as
successful runs.

## Changes

- replace the ACPI shutdown test signaling with QEMU `isa-debug-exit`
- use distinctive guest protocol values:
  - `0x10` -> QEMU exit 33 for normal test-suite completion
  - `0x11` -> QEMU exit 35 for kernel panic
- make `scripts/run-qemu-test` accept only QEMU exit 33 as normal completion
- validate `test.log` with `tapview` before reporting test success
- preserve generic QEMU errors and timeout exit codes as failures
- route the canonical `qemu-test` CMake target through the wrapper
- stop CI from swallowing TAP failures
- update maintainer testing/debugging documentation

## Validation

Verified locally:

- complete suite: 45 tests, 0 failures
- successful run: QEMU 33 -> TAP success -> wrapper/make exit 0
- forced kernel panic: QEMU 35 -> failure
- QEMU startup failure: exit 1 -> failure
- timeout: exit 124 -> failure
- `git diff --check` passes

Closes #193