### PR TITLE
ci: streamline pull request validation

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,9 +11,15 @@ on:
     - '**/*.cpp'
     - '**/*.h'
     - '**/*.hpp'
+    - '**/*.S'
+    - '**/*.asm'
     - '**/CMakeLists.txt'
     - '**/Makefile'
     - '**/cmake/**'
+    - 'scripts/**'
+    - 'iso/**'
+    - 'filesystem/**'
+    - 'tools/**'
     - '.github/workflows/ubuntu.yml'
   pull_request:
     branches:
@@ -24,10 +30,20 @@ on:
     - '**/*.cpp'
     - '**/*.h'
     - '**/*.hpp'
+    - '**/*.S'
+    - '**/*.asm'
     - '**/CMakeLists.txt'
     - '**/Makefile'
     - '**/cmake/**'
+    - 'scripts/**'
+    - 'iso/**'
+    - 'filesystem/**'
+    - 'tools/**'
     - '.github/workflows/ubuntu.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -37,13 +53,7 @@ jobs:
       matrix:
         include:
           [
-            # GCC - recent stable versions
-            { pkgs: "nasm gcc-12 g++-12", cc: gcc-12, cxx: g++-12, os: ubuntu-latest },
-            { pkgs: "nasm gcc-13 g++-13", cc: gcc-13, cxx: g++-13, os: ubuntu-latest },
             { pkgs: "nasm gcc-14 g++-14", cc: gcc-14, cxx: g++-14, os: ubuntu-latest },
-            # Clang - recent stable versions
-            { pkgs: "nasm clang-17 clang++-17", cc: clang-17, cxx: clang++-17, os: ubuntu-latest },
-            { pkgs: "nasm clang-18 clang++-18", cc: clang-18, cxx: clang++-18, os: ubuntu-latest },
             { pkgs: "nasm clang-19 clang++-19", cc: clang-19, cxx: clang++-19, os: ubuntu-latest }
           ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Reduce the cost and feedback time of Ubuntu PR validation while preserving a representative GCC/Clang portability check.

## Changes

- reduce the per-PR compiler matrix from GCC 12/13/14 and Clang 17/18/19 to GCC 14 and Clang 19
- add workflow concurrency so superseded runs on the same branch are cancelled
- expand path filters to include assembly, scripts, ISO, filesystem, and tooling changes that can affect build/test behavior

## Scope

This intentionally does not change the existing QEMU test flow yet. That will be handled separately after the current qemu-test reliability work is merged.

## Expected effect

Ubuntu PR validation goes from six compile-only jobs plus the existing test job to two compile-only jobs plus the existing test job, reducing redundant work and improving feedback time.