### PR TITLE
ci: add compiler compatibility workflow

### DIFF
--- a/.github/workflows/compiler-compatibility.yml
+++ b/.github/workflows/compiler-compatibility.yml
@@ -1,0 +1,79 @@
+name: Compiler Compatibility
+
+on:
+  push:
+    branches:
+    - develop
+    paths:
+    - '**/*.c'
+    - '**/*.cpp'
+    - '**/*.h'
+    - '**/*.hpp'
+    - '**/*.S'
+    - '**/*.asm'
+    - '**/CMakeLists.txt'
+    - '**/Makefile'
+    - '**/cmake/**'
+    - 'tools/**'
+    - '.github/workflows/compiler-compatibility.yml'
+
+  schedule:
+    - cron: '0 3 * * 0'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.cc }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkgs: nasm gcc-12 g++-12
+            cc: gcc-12
+            cxx: g++-12
+
+          - pkgs: nasm gcc-13 g++-13
+            cc: gcc-13
+            cxx: g++-13
+
+          - pkgs: nasm gcc-14 g++-14
+            cc: gcc-14
+            cxx: g++-14
+
+          - pkgs: nasm clang-17 clang++-17
+            cc: clang-17
+            cxx: clang++-17
+
+          - pkgs: nasm clang-18 clang++-18
+            cc: clang-18
+            cxx: clang++-18
+
+          - pkgs: nasm clang-19 clang++-19
+            cc: clang-19
+            cxx: clang++-19
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.pkgs }}
+
+    - name: Configure
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      run: cmake --build build --parallel $(nproc)


### PR DESCRIPTION
## Summary

Move the full compiler compatibility matrix out of the pull request critical path.

## Changes

- add a dedicated compiler compatibility workflow
- test GCC 12, 13, and 14
- test Clang 17, 18, and 19
- run the matrix after changes land on `develop`
- run the matrix weekly to detect environment/toolchain regressions
- allow manual execution through `workflow_dispatch`

## Motivation

Pull requests only need representative GCC and Clang builds for fast feedback.
The wider compiler matrix remains useful for compatibility validation, but does not need to delay every pull request.

This complements #199, which reduces the Ubuntu pull request matrix to GCC 14 and Clang 19.