### PR TITLE
ci: streamline macOS validation

### DIFF
--- a/.github/workflows/macos-compatibility.yml
+++ b/.github/workflows/macos-compatibility.yml
@@ -1,0 +1,56 @@
+name: macOS Compatibility
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            arch: Apple Silicon
+
+          - os: macos-15-intel
+            arch: Intel
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        brew update || true
+        brew install nasm cmake i686-elf-gcc
+
+        echo "=== Checking installed tools ==="
+        nasm --version
+        cmake --version
+        i686-elf-gcc --version
+
+    - name: Configure
+      run: |
+        cmake -B build \
+          -DCMAKE_TOOLCHAIN_FILE=tools/toolchain-i686-elf.cmake \
+          -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      run: |
+        cmake --build build --parallel $(sysctl -n hw.ncpu)
+
+    - name: Verify build artifacts
+      run: |
+        ls -lh build/mentos/
+        file build/mentos/bootloader.bin

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,6 +16,8 @@ on:
     - '**/CMakeLists.txt'
     - '**/Makefile'
     - '**/cmake/**'
+    - 'scripts/**'
+    - 'tools/**'
     - '**/tools/toolchain-i686-elf.cmake'
     - '.github/workflows/macos.yml'
   pull_request:
@@ -32,21 +34,19 @@ on:
     - '**/CMakeLists.txt'
     - '**/Makefile'
     - '**/cmake/**'
+    - 'scripts/**'
+    - 'tools/**'
     - '**/tools/toolchain-i686-elf.cmake'
     - '.github/workflows/macos.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build and Compile (macOS)
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # macOS runners come with clang, we test with the system clang
-          # i686-elf-gcc is installed via Homebrew for cross-compilation
-          - { os: macos-14, arch: "Intel" }
-          - { os: macos-14-large, arch: "Apple Silicon" }
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
     - name: Clone repository
@@ -54,17 +54,8 @@ jobs:
 
     - name: Install dependencies via Homebrew
       run: |
-        # Update Homebrew
         brew update || true
-        
-        # Install required tools
-        brew install nasm cmake
-        
-        # Install cross-compiler for i386 (bare-metal)
-        # This is critical - we need i686-elf-gcc, not i686-linux-gnu
-        brew install i686-elf-gcc
-        
-        # Verify installation
+        brew install nasm cmake i686-elf-gcc
         echo "=== Checking installed tools ==="
         nasm --version
         cmake --version
@@ -72,16 +63,9 @@ jobs:
 
     - name: Build with cross-compilation toolchain
       run: |
-        # Create build directory
         mkdir -p build
         cd build
-        
-        # Configure with the i686-elf toolchain file
-        # This is essential for macOS (which is ARM-based)
-        cmake .. -DCMAKE_TOOLCHAIN_FILE=../tools/toolchain-i686-elf.cmake \
-                 -DCMAKE_BUILD_TYPE=Release
-        
-        # Build all targets
+        cmake .. -DCMAKE_TOOLCHAIN_FILE=../tools/toolchain-i686-elf.cmake -DCMAKE_BUILD_TYPE=Release
         cmake --build . --parallel $(sysctl -n hw.ncpu)
 
     - name: Verify build artifacts


### PR DESCRIPTION
## Summary

Reduce the cost of macOS pull request validation while preserving coverage across both Apple Silicon and Intel hosts.

## Changes

- use a single macOS 15 Apple Silicon smoke build on pull requests
- add concurrency cancellation for superseded macOS runs
- broaden macOS workflow path filters for scripts and tooling changes
- add a scheduled/manual macOS compatibility workflow
- test both Apple Silicon and Intel in the compatibility workflow
- simplify dependency installation and build steps

## Motivation

Running both macOS architectures on every pull request adds significant CI cost and latency. A single representative smoke build is sufficient for PR feedback, while the full host-architecture matrix remains available on a scheduled and manual basis.

This also moves the workflow away from macOS 14 runner images.