### PR TITLE
fix(pipe): prevent double free on fd exhaustion

### DIFF
--- a/kernel/src/fs/pipe.c
+++ b/kernel/src/fs/pipe.c
@@ -1137,14 +1137,24 @@ static inline int create_pipe_fd(pipe_inode_info_t *pipe_info, int flags, mode_t
     int fd = get_unused_fd();
     if (fd < 0) {
         pr_err("Failed to allocate file descriptor.\n");
-        // Close the file if fd allocation fails.
-        pipe_close(file);
+        // The file never entered the fd table and its end was never
+        // accounted in readers/writers: release only the file structure.
+        // pipe_info stays owned by sys_pipe.
+        vfs_dealloc_file(file);
         return -1;
     }
 
     // Register the file descriptor in the process's file descriptor table.
     task->fd_list[fd].file_struct = file;
     task->fd_list[fd].flags_mask  = file->flags;
+
+    // Account for this end as soon as it exists, so that closing it is
+    // balanced even while sys_pipe is still creating the other end.
+    if ((file->flags & O_ACCMODE) == O_WRONLY) {
+        ++pipe_info->writers;
+    } else {
+        ++pipe_info->readers;
+    }
 
     // Return the created file descriptor.
     return fd;
@@ -1232,12 +1242,14 @@ int sys_pipe(int fds[2])
         if (fd_write >= 0) {
             sys_close(fd_write);
         }
-        __pipe_inode_info_dealloc(pipe_info);
+        // If an end was created, its sys_close above dropped the last
+        // reference and pipe_close already deallocated pipe_info. Only when
+        // no end was created does sys_pipe still own pipe_info.
+        if ((fd_read < 0) && (fd_write < 0)) {
+            __pipe_inode_info_dealloc(pipe_info);
+        }
         return -1;
     }
-
-    pipe_info->readers = 1;
-    pipe_info->writers = 1;
 
     // Assign file descriptors to output array
     fds[0] = fd_read;

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -23,6 +23,7 @@
 #define SERIAL_COM2   0x02F8
 
 static char *all_tests[] = {
+    "t_aab_pipe",
     "t_abort",
     "t_alarm",
     // "t_big_write",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 # List of programs.
 set(TEST_LIST
+    t_aab_pipe.c
     t_dup.c
     t_hashmap.c
     t_list.c

--- a/userspace/tests/t_aab_pipe.c
+++ b/userspace/tests/t_aab_pipe.c
@@ -1,0 +1,76 @@
+/// @file t_aab_pipe.c
+/// @brief Regression test for issue #195: sys_pipe() under fd exhaustion
+///        must fail cleanly without freeing pipe_inode_info multiple times.
+/// @copyright (c) 2014-2024 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+#define MAX_OPENS 64
+
+int main(void)
+{
+    openlog("t_aab_pipe", LOG_CONS | LOG_PID, LOG_USER);
+
+    // Exhaust the fd table so that get_unused_fd fails inside sys_pipe.
+    int opened[MAX_OPENS];
+    int count = 0;
+    int fd;
+    while ((count < MAX_OPENS) && ((fd = open("/", O_RDONLY, 0)) >= 0)) {
+        opened[count++] = fd;
+    }
+    syslog(LOG_INFO, "exhausted fds after %d opens (errno=%d)\n", count, errno);
+    if (count == 0) {
+        syslog(LOG_ERR, "[t_aab_pipe] failed to exhaust fds\n");
+        return 1;
+    }
+
+    // pipe() must fail while no fd can be allocated.
+    int fds[2] = { -1, -1 };
+    int ret     = pipe(fds);
+    syslog(LOG_INFO, "pipe() returned %d (fds: %d, %d)\n", ret, fds[0], fds[1]);
+    if (ret != -1) {
+        syslog(LOG_ERR, "[t_aab_pipe] pipe() unexpectedly succeeded\n");
+        if (fds[0] >= 0) {
+            close(fds[0]);
+        }
+        if (fds[1] >= 0) {
+            close(fds[1]);
+        }
+        for (int i = 0; i < count; ++i) {
+            close(opened[i]);
+        }
+        return 1;
+    }
+
+    // Release the exhausted fds.
+    for (int i = 0; i < count; ++i) {
+        close(opened[i]);
+    }
+
+    // The pipe subsystem must still be fully functional after the failed
+    // creation: a fresh pipe must carry data end to end.
+    if (pipe(fds) == -1) {
+        syslog(LOG_ERR, "[t_aab_pipe] pipe() failed after fd exhaustion\n");
+        return 1;
+    }
+    const char msg[] = "survived";
+    char buf[sizeof(msg)] = { 0 };
+    if ((write(fds[1], msg, sizeof(msg)) != (ssize_t)sizeof(msg)) ||
+        (read(fds[0], buf, sizeof(buf)) != (ssize_t)sizeof(msg)) ||
+        (strcmp(buf, msg) != 0)) {
+        syslog(LOG_ERR, "[t_aab_pipe] post-failure pipe is not functional\n");
+        close(fds[0]);
+        close(fds[1]);
+        return 1;
+    }
+    close(fds[0]);
+    close(fds[1]);
+
+    syslog(LOG_INFO, "[t_aab_pipe] all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes a multiple-free/use-after-free condition in `sys_pipe()` when file
descriptor allocation fails during anonymous pipe creation.

The fix makes ownership of `pipe_inode_info_t` explicit during partial pipe
construction and ensures that each successfully created pipe end accounts for
its reader/writer reference immediately.

A regression test exercises `pipe()` under file-descriptor exhaustion and
verifies that the pipe subsystem remains functional afterwards.

## Problem / motivation

Fixes #195.

During `sys_pipe()`, the shared `pipe_inode_info_t` had `readers == 0` and
`writers == 0` until both pipe file descriptors had been created.

If `create_pipe_fd()` failed while allocating a file descriptor, its error
path called `pipe_close()` on a file that had never been installed in the fd
table. Because the pipe reader/writer counts were still zero, `pipe_close()`
could deallocate the shared `pipe_inode_info_t` while `sys_pipe()` still
considered it owned by the pipe-creation path.

Further cleanup could then access and free the same allocation again.

Under fd exhaustion this produced repeated pipe cleanup warnings and a
multiple-free/use-after-free condition.

## Changes

- Replace `pipe_close()` with `vfs_dealloc_file()` when fd allocation fails
  before the pipe file has been installed.
- Account the reader or writer immediately when each pipe end is successfully
  created.
- Adjust the `sys_pipe()` error path so `pipe_inode_info_t` is directly freed
  only when neither pipe end acquired ownership.
- Remove the redundant post-creation `readers = 1` / `writers = 1`
  assignments.
- Add `t_aab_pipe` to exercise fd exhaustion during `pipe()` and verify that
  the pipe subsystem remains usable afterwards.

## Validation

- [x] `git diff --check`
- [x] Relevant build completed
- [x] Relevant automated tests completed
- [x] Manual validation performed where appropriate

Validation details:

```text
Debug build:
  make -C build -j
  Result: successful.

QEMU test suite:
  make qemu-test
  Executed 4 full runs.

Unfixed develop with the regression test retained:
  - fd exhaustion reproduced the issue.
  - serial output contained the expected pipe cleanup warnings.
  - the userspace regression test itself still completed because the kernel
    happened to survive the heap corruption.

Fixed version:
  - 3 verification runs performed, including 2 with a freshly rebuilt rootfs.
  - 46/46 tests passed on the clean fixed runs.
  - no pipe reader/writer-count warnings were observed.
  - no kernel panic was observed.
  - QEMU exited successfully and TAP output was clean.
  - after fd exhaustion, a newly created pipe successfully completed a
    write/read round trip.

One unrelated pre-existing t_semget race was observed in one run and is not
part of this patch.