### PR TITLE
fix(syscall): handle unregistered syscall numbers

### DIFF
--- a/kernel/src/system/syscall.c
+++ b/kernel/src/system/syscall.c
@@ -47,6 +47,13 @@ static inline int sys_ni_syscall(void) { return -ENOSYS; }
 
 void syscall_init(void)
 {
+    // Plug all the table entries with the "not implemented" system-call, so
+    // that unregistered numbers return -ENOSYS instead of calling a NULL
+    // pointer in ring 0.
+    for (int i = 0; i < SYSCALL_NUMBER; ++i) {
+        sys_call_table[i] = (SystemCall)sys_ni_syscall;
+    }
+
     // Initialize the list of system calls.
     sys_call_table[__NR_exit]           = (SystemCall)sys_exit;
     sys_call_table[__NR_fork]           = (SystemCall)sys_fork;

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -67,6 +67,7 @@ static char *all_tests[] = {
     "t_sleep",
     "t_spwd",
     "t_stopcont",
+    "t_syscall_ni",
     "t_syslog",
     "t_time",
     "t_write_read",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_LIST
     t_gid.c
     t_grp.c
     t_stopcont.c
+    t_syscall_ni.c
     t_ndtree.c
     t_pwd.c
     t_fflush.c

--- a/userspace/tests/t_syscall_ni.c
+++ b/userspace/tests/t_syscall_ni.c
@@ -1,0 +1,65 @@
+/// @file t_syscall_ni.c
+/// @brief Test program for unimplemented system-call numbers.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <syslog.h>
+#include <system/syscall_types.h>
+
+/// @brief Issues a system-call with no arguments, bypassing the libc wrappers.
+/// @param nr The system-call number to invoke.
+/// @return The raw value returned by the kernel in eax.
+static long raw_syscall0(uint32_t nr)
+{
+    long res;
+    __asm__ __volatile__("int $0x80" : "=a"(res) : "0"(nr));
+    return res;
+}
+
+/// @brief Checks that a system-call number returns -ENOSYS.
+/// @param nr The system-call number to invoke.
+/// @param description A human-readable description of the number.
+/// @return 1 if the call returned -ENOSYS, 0 otherwise.
+static int expect_enosys(uint32_t nr, const char *description)
+{
+    long res = raw_syscall0(nr);
+    if (res != -ENOSYS) {
+        syslog(LOG_ERR, "syscall %u (%s) returned %ld, expected -ENOSYS (%d)\n", nr, description, res, -ENOSYS);
+        return 0;
+    }
+    syslog(LOG_INFO, "syscall %u (%s) returned -ENOSYS as expected\n", nr, description);
+    return 1;
+}
+
+int main(void)
+{
+    openlog("t_syscall_ni", LOG_CONS | LOG_PID, LOG_USER);
+
+    int success = 1;
+
+    // A number which is in range, unregistered, and follows the standard
+    // argument convention must fail cleanly instead of dispatching to NULL.
+    success &= expect_enosys(__NR_readv, "in range, standard args");
+
+    // `clone` is in range and takes the frame-pointer special path in the
+    // dispatcher, but has no registered handler.
+    success &= expect_enosys(__NR_clone, "in range, frame-pointer special case");
+
+    // An out-of-range number must keep returning -ENOSYS.
+    success &= expect_enosys(SYSCALL_NUMBER, "out of range");
+
+    // An out-of-range number expressed as a "negative" value must also be
+    // rejected by the unsigned range check.
+    success &= expect_enosys(UINT32_MAX, "negative/out of range");
+
+    if (!success) {
+        syslog(LOG_ERR, "t_syscall_ni failed\n");
+        return EXIT_FAILURE;
+    }
+
+    syslog(LOG_INFO, "t_syscall_ni passed\n");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Ensure that valid but unregistered system-call numbers return `-ENOSYS`
instead of dispatching through a NULL function pointer in ring 0.

The syscall table is now initialized with `sys_ni_syscall` before the
implemented handlers are registered, and a regression test covers both
ordinary and special-case unregistered syscall numbers.

## Problem / motivation

`sys_call_table` contains `SYSCALL_NUMBER` entries, but `syscall_init()`
registers handlers for only the implemented system calls. Because the table is
BSS-initialized, every remaining entry is NULL.

`syscall_handler()` checks that the requested syscall number is within the
table bounds, but previously called the selected entry unconditionally.

A userspace program issuing a raw `int $0x80` with an unregistered in-range
syscall number could therefore transfer kernel control through a NULL function
pointer.

This was reproduced before the fix: the regression test caused a kernel-mode
page fault and PANIC.

## Changes

- Initialize every `sys_call_table` entry with `sys_ni_syscall` before
  registering implemented system calls.
- Preserve all existing syscall registrations, which overwrite the default
  `sys_ni_syscall` entry.
- Add `t_syscall_ni` to verify that unregistered syscall numbers return
  `-ENOSYS`.
- Cover both the normal syscall argument path and the `__NR_clone`
  frame-pointer special case, plus out-of-range boundary cases.

## Validation

- [x] `git diff --check`
- [x] Relevant build completed
- [x] Relevant automated tests completed
- [x] Manual validation performed where appropriate

Validation details:

```text
Before fix, with the regression test added:
- the full QEMU test suite reached t_syscall_ni;
- an unregistered in-range syscall caused a kernel-mode page fault and PANIC;
- the guest exited through the panic path with exit code 35.

After fix:
- make -C build
- make -C build cdrom_test.iso filesystem
- scripts/run-qemu-test
- 47/47 tests passed
- TAP validation reported 47 tests, 0 failures
- no PANIC was present in the serial log
- test runner exited successfully

Baseline before the change was 46/46 tests passing.
```

## Scope

* [x] The change is focused on one primary problem.
* [x] Unrelated refactors or cleanup have been left for separate work.
* [x] New behavior is covered by a regression test when practical.
* [x] Documentation was updated when behavior, interfaces, or developer workflow changed.

No documentation update is required for this fix because it does not change
the syscall interface or documented userspace behavior.

The separate `__NR_clone` design question remains intentionally untouched.

## Related issues

Fixes #206.
Relates to #207.
