### PR TITLE
fix(execve): fix interpreter argv/envp allocation

### DIFF
--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -660,6 +660,8 @@ int sys_execve(pt_regs_t *f)
         char **int_argv = kmalloc((argc + 2) * sizeof(char *));
         if (!int_argv) {
             pr_err("Failed to allocate memory for interpreter argv array.\n");
+            // Free the temporary args memory.
+            kfree(args_mem);
             return -1;
         }
         int_argv[0] = saved_argv[0]; // TODO: pass the path to the interpreter.
@@ -669,14 +671,18 @@ int sys_execve(pt_regs_t *f)
         }
         argc++;
 
-        // Rebuild the saved argv and envp pointers.
+        // Rebuild the saved argv and envp pointers. The buffer must hold both
+        // the new argv and the whole environment (#227).
         int int_argv_bytes = __count_args_bytes(int_argv);
-        void *int_args_mem = kmalloc(int_argv_bytes);
+        void *int_args_mem = kmalloc(int_argv_bytes + envp_bytes);
         if (!int_args_mem) {
             pr_err(
                 "Failed to allocate memory for interpreter arguments and "
                 "environment %d (%d + %d).\n",
                 int_argv_bytes + envp_bytes, int_argv_bytes, envp_bytes);
+            // Free the temporary allocations.
+            kfree(int_argv);
+            kfree(args_mem);
             return -1;
         }
         // Copy the arguments.
@@ -685,7 +691,8 @@ int sys_execve(pt_regs_t *f)
         saved_envp                = __push_args_on_stack(&int_args_mem_ptr, saved_envp);
         // Check the memory pointer.
         assert(int_args_mem_ptr == (uint32_t)int_args_mem);
-        // Free the old argument and environ memory block.
+        // Free the interpreter argv array and the old argument and environ memory block.
+        kfree(int_argv);
         kfree(args_mem);
         args_mem = int_args_mem;
     }

--- a/userspace/tests/t_shebang.c
+++ b/userspace/tests/t_shebang.c
@@ -5,8 +5,10 @@
 ///          shebang line without a trailing newline (which used to trigger a
 ///          double `vfs_close`), a file whose shebang read fails (sparse
 ///          holes, which used to index the stack buffer with a negative
-///          read result), and short files (which used to be classified
-///          through an uninitialized read).
+///          read result), short files (which used to be classified
+///          through an uninitialized read), and an exec with a large
+///          environment (which used to overflow the kernel heap buffer
+///          that rebuilds argv/envp for the interpreter, #227).
 /// @copyright (c) 2024 This file is distributed under the MIT License.
 /// See LICENSE.md for details.
 
@@ -27,6 +29,17 @@
 
 /// Path of the sparse (hole-punched) script staged inside the filesystem image.
 #define SPARSE_SCRIPT SCRIPT_DIR "t_shebang_sparse.sh"
+
+/// Number of variables in the large environment of the #227 regression test.
+#define BIG_ENV_ENTRIES 96
+/// Length of the `AAAA...` value of each large-environment variable.
+#define BIG_ENV_VALUE_LEN 192
+
+/// Storage for the large environment; static so that the forked child
+/// inherits it through fork() without pressing against its stack.
+static char big_env_strings[BIG_ENV_ENTRIES][16 + BIG_ENV_VALUE_LEN];
+/// The environment vector built over `big_env_strings`.
+static char *big_envp[BIG_ENV_ENTRIES + 1];
 
 /// Creates a script file with the given content and mode.
 /// @param name The file name inside SCRIPT_DIR.
@@ -54,12 +67,31 @@ static int create_script(const char *name, const char *content, size_t len, mode
     return 0;
 }
 
-/// Forks, execs the given script and waits for the child.
+/// Builds the large environment for the #227 regression test: BIG_ENV_ENTRIES
+/// variables of ~200 bytes each (~19 KB in total). The values are filled with
+/// 'A' so that any pointer clobbered by an overflow of this data is
+/// recognizable in a panic log.
+/// @return the environment vector, NULL terminated.
+static char **build_big_env(void)
+{
+    for (int i = 0; i < BIG_ENV_ENTRIES; ++i) {
+        char *entry = big_env_strings[i];
+        int n       = snprintf(entry, 12, "V%03d=", i);
+        memset(entry + n, 'A', BIG_ENV_VALUE_LEN);
+        entry[n + BIG_ENV_VALUE_LEN] = '\0';
+        big_envp[i]                  = entry;
+    }
+    big_envp[BIG_ENV_ENTRIES] = NULL;
+    return big_envp;
+}
+
+/// Forks, execs the given script with the given environment and waits for
+/// the child.
 /// @return 0 if execve succeeded and the interpreter exited with status 0,
 ///         the errno if execve returned cleanly in the child,
 ///         -1 if the child was killed by a signal,
 ///         -2 on fork/waitpid failure.
-static int run_script(const char *path)
+static int run_script_env(const char *path, char *envp[])
 {
     pid_t pid = fork();
     if (pid < 0) {
@@ -68,7 +100,6 @@ static int run_script(const char *path)
     }
     if (pid == 0) {
         char *argv[] = { (char *)path, NULL };
-        char *envp[] = { NULL };
         execve(path, argv, envp);
         // execve returned, report the errno through the exit status.
         exit(errno);
@@ -82,6 +113,17 @@ static int run_script(const char *path)
         return WEXITSTATUS(status);
     }
     return -1;
+}
+
+/// Forks, execs the given script and waits for the child.
+/// @return 0 if execve succeeded and the interpreter exited with status 0,
+///         the errno if execve returned cleanly in the child,
+///         -1 if the child was killed by a signal,
+///         -2 on fork/waitpid failure.
+static int run_script(const char *path)
+{
+    char *envp[] = { NULL };
+    return run_script_env(path, envp);
 }
 
 /// Checks the outcome of an exec that is expected to fail after the address
@@ -217,6 +259,26 @@ int main(int argc, char *argv[])
     if (!check_post_teardown_failure(res, EIO, "sparse script")) {
         ++failures;
     }
+
+    // ------------------------------------------------------------------
+    // 9) A valid script executed with a large environment (~19 KB): the
+    //    kernel buffer that rebuilds argv and envp for the interpreter was
+    //    allocated with the size of argv alone, so the whole environment
+    //    was pushed past the end of the allocation, corrupting the kernel
+    //    heap (#227). The environment is large enough that the overflow
+    //    cannot hide inside the allocator's size-class rounding, and the
+    //    interpreter (/bin/env) walks its whole environment, which also
+    //    checks that the rebuilt envp it receives is intact.
+    // ------------------------------------------------------------------
+    if (create_script("t_shebang_bigenv.sh", "#!/bin/env\n", 11, 0755) < 0) {
+        return EXIT_FAILURE;
+    }
+    res = run_script_env(SCRIPT_DIR "t_shebang_bigenv.sh", build_big_env());
+    if (res != 0) {
+        syslog(LOG_ERR, "[t_shebang] big environment: exec failed (%d)", res);
+        ++failures;
+    }
+    unlink(SCRIPT_DIR "t_shebang_bigenv.sh");
 
     return failures ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Fix a kernel heap overflow and memory leaks in the `execve()` interpreter
(shebang) argv/envp rebuild path.

The interpreter path now allocates enough memory for both the rebuilt argument
vector and environment, and correctly frees its temporary allocations on
success and allocation-failure paths.

A regression case extends `t_shebang` with a large environment that
deterministically exposed the previous under-allocation.

## Problem / motivation

When `sys_execve()` loads a shebang interpreter, it rebuilds `argv` and `envp`
before entering the interpreter.

The rebuild buffer was allocated using only:

```c
kmalloc(int_argv_bytes)
```

but both the rebuilt argv and the complete environment were subsequently
written into that allocation.

The resulting overflow was exactly `envp_bytes`. With the small environment
used by the existing test suite, the extra bytes happened to fit inside slab
size-class padding and remained invisible. With a roughly 19 KB environment,
the overflow corrupted adjacent kernel heap data and caused a kernel panic.

Before the fix, the regression case reproduced:

```text
cr2 = 0x4141427d
EIP = sys_write
QEMU exit = 35
```

The `0x41` bytes came from the test environment, confirming that environment
data had overwritten a kernel pointer.

The same interpreter path also leaked the temporary `int_argv` allocation on
every execution and leaked additional allocations on its allocation-failure
paths.

## Changes

- Allocate `int_args_mem` using `int_argv_bytes + envp_bytes`, matching the
  amount subsequently written into the buffer.
- Free the temporary `int_argv` allocation after the interpreter argv/envp
  rebuild.
- Free `args_mem` when allocation of `int_argv` fails.
- Free both `int_argv` and `args_mem` when allocation of `int_args_mem` fails.
- Extend `t_shebang` with a large-environment interpreter case using 96
  environment variables and approximately 19 KB of environment data.
- Refactor the shebang test helper so individual cases can provide a custom
  environment.

## Validation

- [ ] `git diff --check`
- [x] Relevant build completed
- [x] Relevant automated tests completed
- [x] Manual validation performed where appropriate

Validation details:

```text
Baseline, unmodified develop:
- full QEMU suite: 48/48 passed
- QEMU exit 33

Before the fix, with the new large-environment regression case:
- t_shebang deterministically triggered a kernel panic
- fault address: cr2 = 0x4141427d
- faulting EIP resolved to sys_write
- QEMU exit 35

After the fix:
- three independent full QEMU test-suite runs
- 48/48 tests passed on each run
- 0 TAP failures
- 0 kernel panics
- QEMU exit 33

Additional ENABLE_KMEM_TRACE verification:
- temporary tracing instrumentation was used and then reverted
- args_mem allocations: 68 allocations, 68 matched frees
- int_argv allocations: 2 allocations, 2 matched frees
- int_args_mem allocations: 2 allocations, 2 matched frees through their alias
- zero live execve allocations remained
- zero unmatched or duplicate frees were observed

Build completed cleanly without new warnings.
```

## Scope

- [x] The change is focused on one primary problem.
- [x] Unrelated refactors or cleanup have been left for separate work.
- [x] New behavior is covered by a regression test when practical.
- [x] Documentation was updated when behavior, interfaces, or developer workflow changed.

No documentation update is required because this fixes internal allocation and
lifetime handling without changing the documented `execve()` interface.

The existing argv/envp validation problems tracked by #196, transactional
execve teardown tracked by #208, and interpreter argument handling tracked by
#222 remain intentionally out of scope.

## Related issues

Fixes #227.
Relates to #196.
Relates to #208.
Relates to #222.
Relates to #225.