### PR TITLE
fix(getcwd): handle undersized buffers correctly

### DIFF
--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -465,11 +465,18 @@ vfs_file_descriptor_t *fget(int fd)
 char *sys_getcwd(char *buf, size_t size)
 {
     task_struct *current = scheduler_get_current_process();
-    if ((current != NULL) && (buf != NULL)) {
-        strncpy(buf, current->cwd, size);
-        return buf;
+    if ((current == NULL) || (buf == NULL)) {
+        return (char *)-EACCES;
     }
-    return (char *)-EACCES;
+    if (size == 0) {
+        return (char *)-EINVAL;
+    }
+    size_t len = strnlen(current->cwd, sizeof(current->cwd));
+    if (size < (len + 1)) {
+        return (char *)-ERANGE;
+    }
+    memcpy(buf, current->cwd, len + 1);
+    return buf;
 }
 
 int sys_chdir(char const *path)

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -36,6 +36,7 @@ static char *all_tests[] = {
     "t_fflush",
     "t_fhs",
     "t_fork",
+    "t_getcwd",
     "t_gid",
     "t_groups",
     "t_grp",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_LIST
     t_sleep.c
     t_mem.c
     t_fork.c
+    t_getcwd.c
     t_semflg.c
     t_shebang.c
     t_time.c

--- a/userspace/tests/t_getcwd.c
+++ b/userspace/tests/t_getcwd.c
@@ -1,0 +1,104 @@
+/// @file t_getcwd.c
+/// @brief Test program for the getcwd system call buffer contract.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+#define SENTINEL 0xAA
+
+static int check_success(const char *what, char *buf, size_t size, char *ret, const char *expected)
+{
+    if ((ret == (char *)-1) || (ret == NULL)) {
+        syslog(LOG_ERR, "[t_getcwd] %s: expected success, got errno %d (%s)\n", what, errno, strerror(errno));
+        return -1;
+    }
+    if (memchr(buf, '\0', size) == NULL) {
+        syslog(LOG_ERR, "[t_getcwd] %s: result is not NUL-terminated within %u bytes\n", what, (unsigned)size);
+        return -1;
+    }
+    if (strcmp(buf, expected) != 0) {
+        syslog(LOG_ERR, "[t_getcwd] %s: expected `%s`, got `%s`\n", what, expected, buf);
+        return -1;
+    }
+    return 0;
+}
+
+static int check_failure(const char *what, char *ret, int expected_errno)
+{
+    if ((ret != (char *)-1) && (ret != NULL)) {
+        syslog(LOG_ERR, "[t_getcwd] %s: expected failure, got success pointer\n", what);
+        return -1;
+    }
+    if (errno != expected_errno) {
+        syslog(LOG_ERR, "[t_getcwd] %s: expected errno %d (%s), got %d\n", what, expected_errno, strerror(expected_errno), errno);
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    openlog("t_getcwd", LOG_PID | LOG_CONS, LOG_USER);
+
+    const char *directory = "/home";
+    if (chdir(directory) < 0) {
+        syslog(LOG_ERR, "[t_getcwd] chdir failed: errno %d (%s)\n", errno, strerror(errno));
+        closelog();
+        return EXIT_FAILURE;
+    }
+
+    char buf[1024];
+    char *ret;
+    int failed = 0;
+
+    // 1. A sufficiently large buffer must succeed and be NUL-terminated.
+    memset(buf, SENTINEL, sizeof(buf));
+    errno = 0;
+    ret = getcwd(buf, sizeof(buf));
+    if (check_success("large buffer", buf, sizeof(buf), ret, directory) < 0) {
+        failed = 1;
+    }
+    size_t len = strlen(buf);
+
+    // 2. A buffer of exactly len + 1 bytes (terminator included) must succeed.
+    memset(buf, SENTINEL, sizeof(buf));
+    errno = 0;
+    ret = getcwd(buf, len + 1);
+    if (check_success("exact-size buffer", buf, len + 1, ret, directory) < 0) {
+        failed = 1;
+    }
+
+    // 3. A buffer one byte too small must fail with ERANGE.
+    memset(buf, SENTINEL, sizeof(buf));
+    errno = 0;
+    ret = getcwd(buf, len);
+    if (check_failure("one-byte-too-small buffer", ret, ERANGE) < 0) {
+        failed = 1;
+    }
+
+    // 3b. A clearly undersized buffer must fail with ERANGE as well.
+    memset(buf, SENTINEL, sizeof(buf));
+    errno = 0;
+    ret = getcwd(buf, 2);
+    if (check_failure("undersized buffer", ret, ERANGE) < 0) {
+        failed = 1;
+    }
+
+    // 4. size == 0 must fail with EINVAL (POSIX.1-2017).
+    memset(buf, SENTINEL, sizeof(buf));
+    errno = 0;
+    ret = getcwd(buf, 0);
+    if (check_failure("zero size", ret, EINVAL) < 0) {
+        failed = 1;
+    }
+
+    closelog();
+    return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Correct `getcwd()` handling for caller-provided buffer sizes and add regression
coverage for the expected success and error cases.

## Problem / motivation

`getcwd()` did not correctly handle buffers that were too small for the current
working directory and could report success when it should return an error.

The zero-size case also did not return the expected error.

## Changes

- Validate the caller-provided buffer size before copying the current working directory.
- Return the appropriate error for zero-size and undersized buffers.
- Ensure successful results include the terminating NUL byte.
- Add a dedicated `t_getcwd` regression test.
- Register the new test in the userspace test suite.

## Validation

- [x] `git diff --check`
- [x] Relevant build completed
- [x] Relevant automated tests completed
- [x] Manual validation performed where appropriate

Validation details:

```text
Baseline:
- full test suite: 48/48 passed

Before the fix with the regression test enabled:
- t_getcwd failed as expected
- qemu-test reported the test failure

After the fix:
- full rebuild completed
- QEMU test suite: 49/49 passed
- 0 kernel panics
- qemu-test exited successfully
```

## Scope

- [x] The change is focused on one primary problem.
- [x] Unrelated refactors or cleanup have been left for separate work.
- [x] New behavior is covered by a regression test when practical.
- [x] Documentation was updated when behavior, interfaces, or developer workflow changed.

No documentation update is required because this corrects existing API behavior
without changing the documented interface.

## Related issues

Fixes #230.

