### PR TITLE
fix(signal): encode fatal wait statuses correctly

### DIFF
--- a/kernel/src/system/signal.c
+++ b/kernel/src/system/signal.c
@@ -572,16 +572,16 @@ int do_signal(struct pt_regs *f)
 
                 continue;
             case SIGQUIT:
-                do_exit(GET_EXIT_STATUS(1));
+                do_exit(GET_EXIT_STATUS(131) | signr);
                 continue;
             case SIGILL:
-                do_exit(GET_EXIT_STATUS(132));
+                do_exit(GET_EXIT_STATUS(132) | signr);
                 continue;
             case SIGTRAP:
-                do_exit(GET_EXIT_STATUS(133));
+                do_exit(GET_EXIT_STATUS(133) | signr);
                 continue;
             case SIGABRT:
-                do_exit(GET_EXIT_STATUS(134));
+                do_exit(GET_EXIT_STATUS(134) | signr);
                 continue;
             case SIGFPE:
                 do_exit(GET_EXIT_STATUS(136) | signr);

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -72,6 +72,7 @@ static char *all_tests[] = {
     "t_syscall_ni",
     "t_syslog",
     "t_time",
+    "t_wifsignaled",
     "t_write_read",
 };
 

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_LIST
     t_periodic3.c
     t_semop.c
     t_groups.c
+    t_wifsignaled.c
 )
 
 # Set the directory where the compiled binaries will be placed.

--- a/userspace/tests/t_wifsignaled.c
+++ b/userspace/tests/t_wifsignaled.c
@@ -1,0 +1,75 @@
+/// @file t_wifsignaled.c
+/// @brief Test program for the wait status of signal-terminated processes.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <unistd.h>
+
+static int check_signal_death(int sig)
+{
+    pid_t child = fork();
+    if (child < 0) {
+        syslog(LOG_ERR, "[t_wifsignaled] signal %d: fork failed: %s\n", sig, strerror(errno));
+        return -1;
+    }
+    if (child == 0) {
+        // Restore the default action and terminate ourselves with the signal.
+        signal(sig, SIG_DFL);
+        kill(getpid(), sig);
+        // We must never get here.
+        exit(42);
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        syslog(LOG_ERR, "[t_wifsignaled] signal %d: waitpid failed: %s\n", sig, strerror(errno));
+        return -1;
+    }
+    if (!WIFSIGNALED(status)) {
+        syslog(LOG_ERR,
+               "[t_wifsignaled] signal %d: WIFSIGNALED is false (raw status 0x%x, WIFEXITED %d, WEXITSTATUS %d)\n",
+               sig,
+               status,
+               WIFEXITED(status),
+               WEXITSTATUS(status));
+        return -1;
+    }
+    if (WTERMSIG(status) != sig) {
+        syslog(LOG_ERR, "[t_wifsignaled] signal %d: WTERMSIG is %d\n", sig, WTERMSIG(status));
+        return -1;
+    }
+    syslog(LOG_INFO, "[t_wifsignaled] signal %2d: WIFSIGNALED true, WTERMSIG %d, WEXITSTATUS %d\n", sig, WTERMSIG(status), WEXITSTATUS(status));
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    openlog("t_wifsignaled", LOG_PID | LOG_CONS, LOG_USER);
+
+    // Signals whose default-action encoding was broken (issue #234).
+    const int affected[] = { SIGQUIT, SIGILL, SIGTRAP, SIGABRT };
+    // Controls: one correct explicit case, one default-path case.
+    const int controls[] = { SIGSEGV, SIGTERM };
+
+    int failed = 0;
+    for (unsigned i = 0; i < sizeof(affected) / sizeof(affected[0]); ++i) {
+        if (check_signal_death(affected[i]) < 0) {
+            failed = 1;
+        }
+    }
+    for (unsigned i = 0; i < sizeof(controls) / sizeof(controls[0]); ++i) {
+        if (check_signal_death(controls[i]) < 0) {
+            failed = 1;
+        }
+    }
+
+    closelog();
+    return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Fix the wait-status encoding for processes terminated by `SIGQUIT`,
`SIGILL`, `SIGTRAP`, and `SIGABRT`, and add a regression test covering
`WIFSIGNALED()` / `WTERMSIG()` semantics.

## Problem / motivation

Four fatal-signal cases in `do_signal()` omitted the terminating signal
number from the low byte of the wait status.

`SIGQUIT` additionally used an incorrect high-byte value (`1` instead of
`128 + SIGQUIT == 131`).

As a result, these signal deaths could be interpreted as normal exits.

## Changes

- Fix wait-status encoding for `SIGQUIT`, `SIGILL`, `SIGTRAP`, and `SIGABRT`.
- Correct the `SIGQUIT` high-byte value to `131`.
- Add `t_wifsignaled`.
- Register the regression test in the userspace test suite.

## Validation

- [x] `git diff --check`
- [x] Relevant build completed
- [x] Relevant automated tests completed
- [x] Manual validation performed where appropriate

Validation details:

```text
Pre-fix:
- t_wifsignaled failed for the four affected signals.
- SIGQUIT produced raw status 0x0100.

Post-fix:
- full build successful
- QEMU userspace suite: 50/50 tests passed
- QEMU exit status: 0
- 0 kernel panics
````

## Scope

- [x] The change is focused on one primary problem.
- [x] Unrelated refactors or cleanup were left out.
- [x] New behavior is covered by a regression test.

Issue #233 is intentionally not fixed here. `userspace/bin/runtests.c` is modified
only to register `t_wifsignaled`; its `WSTOPSIG` diagnostic remains unchanged.

## Related issues

Fixes #234

Related: #233

