### PR TITLE
fix(execve): load new process image transactionally

### DIFF
--- a/kernel/inc/elf/elf.h
+++ b/kernel/inc/elf/elf.h
@@ -247,12 +247,12 @@ enum StT_Types {
     STT_FUNC   = 2  ///< Methods or functions
 };
 
-/// @brief Loads an ELF file into the memory of task.
-/// @param task  The task for which we load the ELF.
-/// @param file  The ELF file.
+/// @brief Loads an ELF file into the given memory descriptor.
+/// @param mm The memory descriptor where the ELF is loaded.
+/// @param file The ELF file.
 /// @param entry The ELF binary entry.
-/// @return 0 if fails, 1 if succeed.
-int elf_load_file(task_struct *task, vfs_file_t *file, uint32_t *entry);
+/// @return 1 on success, -errno on failure.
+int elf_load_file(mm_struct_t *mm, vfs_file_t *file, uint32_t *entry);
 
 /// @brief Checks if the file is a valid ELF.
 /// @param file The file to check.

--- a/kernel/src/elf/elf.c
+++ b/kernel/src/elf/elf.c
@@ -11,12 +11,12 @@
 
 #include "assert.h"
 #include "elf/elf.h"
+#include "errno.h"
 #include "fs/vfs.h"
+#include "mem/mm/mm.h"
 #include "mem/paging.h"
 #include "mem/alloc/slab.h"
 #include "mem/mm/vmem.h"
-#include "process/process.h"
-#include "process/scheduler.h"
 #include "stddef.h"
 #include "stdio.h"
 #include "string.h"
@@ -241,11 +241,15 @@ static inline void elf_dump_symbol_table(elf_header_t *header)
 // EXEC-RELATED FUNCTIONS
 // ============================================================================
 
-/// @brief Loads an ELF executable.
-/// @param header  The header of the ELF file.
-/// @param task The task for which we load the ELF.
-/// @return The ELF entry.
-static inline int elf_load_exec(elf_header_t *header, task_struct *task)
+/// @brief Loads an ELF executable into the given address space.
+/// @param header the header of the ELF file.
+/// @param mm the memory descriptor where the executable is loaded; it is
+///           not the address space of a running task while it is being
+///           replaced (see #208).
+/// @param file_size the size of the file the header was read from, used to
+///                  validate the segment descriptors.
+/// @return 1 on success, -errno on failure.
+static inline int elf_load_exec(elf_header_t *header, mm_struct_t *mm, size_t file_size)
 {
     elf_program_header_t *program_header;
     vm_area_struct_t *segment;
@@ -262,36 +266,73 @@ static inline int elf_load_exec(elf_header_t *header, task_struct *task)
             " %-9s | %9s | %9s | 0x%08x - 0x%08x\n", elf_type_to_string(program_header->type),
             to_human_size(program_header->memsz), to_human_size(program_header->filesz), program_header->vaddr,
             program_header->vaddr + program_header->memsz);
-        if (program_header->type == PT_LOAD) {
-            segment = vm_area_create(
-                task->mm, program_header->vaddr, program_header->memsz, MM_USER | MM_RW | MM_PRESENT, GFP_KERNEL);
-            vpage    = vmem_map_alloc_virtual(program_header->memsz);
-            dst_addr = vmem_map_virtual_address(task->mm, vpage, segment->vm_start, program_header->memsz);
-
-            // Load the memory area.
-            memcpy((void *)dst_addr, (void *)((uintptr_t)header + program_header->offset), program_header->filesz);
-
-            if (program_header->memsz > program_header->filesz) {
-                zmem_sz = program_header->memsz - program_header->filesz;
-                memset((void *)(dst_addr + program_header->filesz), 0, zmem_sz);
-            }
-            vmem_unmap_virtual_address_page(vpage);
+        if (program_header->type != PT_LOAD) {
+            continue;
         }
+        // Validate the segment against the actual file content. These checks
+        // run after the execve pre-checks (the header is valid), so without
+        // them a malformed segment would either read past the file buffer or
+        // be mapped blindly (#208).
+        if (program_header->memsz == 0) {
+            pr_err("PT_LOAD segment %u has zero memory size.\n", i);
+            return -ENOEXEC;
+        }
+        if (program_header->filesz > program_header->memsz) {
+            pr_err("PT_LOAD segment %u has filesz larger than memsz.\n", i);
+            return -ENOEXEC;
+        }
+        if (((uint64_t)program_header->offset + program_header->filesz) > (uint64_t)file_size) {
+            pr_err("PT_LOAD segment %u extends past the end of the file.\n", i);
+            return -ENOEXEC;
+        }
+        if ((program_header->vaddr == 0) || (program_header->vaddr >= PROCAREA_END_ADDR) ||
+            (program_header->memsz > (PROCAREA_END_ADDR - program_header->vaddr))) {
+            pr_err("PT_LOAD segment %u has an invalid virtual address range.\n", i);
+            return -ENOEXEC;
+        }
+        segment = vm_area_create(
+            mm, program_header->vaddr, program_header->memsz, MM_USER | MM_RW | MM_PRESENT, GFP_KERNEL);
+        if (segment == NULL) {
+            // The range was validated above, so a failure here is an
+            // allocation failure (e.g., the buddy system is full).
+            pr_err("Failed to allocate the memory area for PT_LOAD segment %u.\n", i);
+            return -ENOMEM;
+        }
+        vpage = vmem_map_alloc_virtual(program_header->memsz);
+        if (vpage == NULL) {
+            pr_err("Failed to allocate the virtual mapping window for PT_LOAD segment %u.\n", i);
+            return -ENOMEM;
+        }
+        dst_addr = vmem_map_virtual_address(mm, vpage, segment->vm_start, program_header->memsz);
+        if (dst_addr == 0) {
+            pr_err("Failed to map the virtual mapping window for PT_LOAD segment %u.\n", i);
+            vmem_unmap_virtual_address_page(vpage);
+            return -ENOMEM;
+        }
+
+        // Load the memory area.
+        memcpy((void *)dst_addr, (void *)((uintptr_t)header + program_header->offset), program_header->filesz);
+
+        if (program_header->memsz > program_header->filesz) {
+            zmem_sz = program_header->memsz - program_header->filesz;
+            memset((void *)(dst_addr + program_header->filesz), 0, zmem_sz);
+        }
+        vmem_unmap_virtual_address_page(vpage);
     }
-    return true;
+    return 1;
 }
 
-int elf_load_file(task_struct *task, vfs_file_t *file, uint32_t *entry)
+int elf_load_file(mm_struct_t *mm, vfs_file_t *file, uint32_t *entry)
 {
     // Open the file.
     if (file == NULL) {
-        return false;
+        return -ENOENT;
     }
     // Get the size of the file.
     stat_t stat_buf;
     if (vfs_fstat(file, &stat_buf) < 0) {
         pr_err("Failed to stat the file `%s`.\n", file->name);
-        return false;
+        return -EIO;
     }
     // Allocate the memory for the file.
     char *buffer = kmalloc(stat_buf.st_size);
@@ -300,7 +341,7 @@ int elf_load_file(task_struct *task, vfs_file_t *file, uint32_t *entry)
             "Failed to allocate %d bytes of memory for reading the file "
             "`%s`.\n",
             stat_buf.st_size, file->name);
-        return false;
+        return -ENOMEM;
     }
     // Clean the memory.
     memset(buffer, 0, stat_buf.st_size);
@@ -319,7 +360,7 @@ int elf_load_file(task_struct *task, vfs_file_t *file, uint32_t *entry)
     pr_debug("Headers count  : %d\n", header->phnum);
     // Check the elf header.
     if (!elf_check_file_header(header)) {
-        pr_err("File %s is not a valid ELF file.\n", stat_buf.st_size, file->name);
+        pr_err("File %s is not a valid ELF file.\n", file->name);
         goto return_error_free_buffer;
     }
     // Check if the elf file is an executable.
@@ -327,7 +368,16 @@ int elf_load_file(task_struct *task, vfs_file_t *file, uint32_t *entry)
         pr_err("Elf file is not an executable.\n");
         goto return_error_free_buffer;
     }
-    if (!elf_load_exec(header, task)) {
+    // Check that the program header table is well-formed and lies inside the
+    // file we just read, otherwise iterating it would read out of the buffer
+    // bounds.
+    if ((header->phentsize != sizeof(elf_program_header_t)) ||
+        (((uint64_t)header->phoff + ((uint64_t)header->phnum * header->phentsize)) > (uint64_t)stat_buf.st_size)) {
+        pr_err("Elf file has an invalid program header table.\n");
+        goto return_error_free_buffer;
+    }
+    int ret = elf_load_exec(header, mm, stat_buf.st_size);
+    if (ret < 0) {
         pr_err("Failed to load the executable.\n");
         goto return_error_free_buffer;
     }
@@ -336,10 +386,10 @@ int elf_load_file(task_struct *task, vfs_file_t *file, uint32_t *entry)
     (*entry) = header->entry;
 
     kfree(buffer);
-    return true;
+    return 1;
 return_error_free_buffer:
     kfree(buffer);
-    return false;
+    return -ENOEXEC;
 }
 
 int elf_check_file_type(vfs_file_t *file, Elf_Type type)

--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -18,6 +18,8 @@
 #include "hardware/timer.h"
 #include "klib/stack_helper.h"
 #include "libgen.h"
+#include "mem/mm/mm.h"
+#include "mem/mm/vmem.h"
 #include "process/pid_manager.h"
 #include "process/prio.h"
 #include "process/process.h"
@@ -83,37 +85,31 @@ static inline char **__push_args_on_stack(uintptr_t *stack, char *args[])
     return (char **)(*stack);
 }
 
-/// @brief Resets the process.
-/// @param task the process to reset.
-/// @return 0 on failure, 1 otherwise.
-static int __reset_process(task_struct *task)
+/// @brief Clears the user stack of a freshly created memory descriptor.
+/// @param mm the memory descriptor whose stack must be cleared.
+/// @return 0 on success, -errno on failure.
+static int __clear_user_stack(mm_struct_t *mm)
 {
-    pr_debug("__reset_process(%p `%s`)\n", task, task->name);
-    // Create a new stack segment.
-    task->mm = mm_create_blank(DEFAULT_STACK_SIZE);
-    if (task->mm == NULL) {
-        pr_err("Failed to initialize process mm structure.\n");
-        return 0;
+    // Map the stack of the candidate image inside the kernel virtual mapping
+    // window, so that we can clear it without switching the current page
+    // directory (see #208: the old image must stay active while the new one
+    // is being built).
+    virt_map_page_t *vpage = vmem_map_alloc_virtual(DEFAULT_STACK_SIZE);
+    if (vpage == NULL) {
+        pr_err("Failed to allocate the virtual mapping window for the stack.\n");
+        return -ENOMEM;
     }
-
-    // Save the current page directory.
-    page_directory_t *crtdir = paging_get_current_pgd();
-    // FIXME: Now to clear the stack a pgdir switch is made, it should be a kernel mmapping.
-    paging_switch_pgd(task->mm->pgd);
-
+    uint32_t dst_addr = vmem_map_virtual_address(mm, vpage, mm->start_stack, DEFAULT_STACK_SIZE);
+    if (dst_addr == 0) {
+        pr_err("Failed to map the virtual mapping window for the stack.\n");
+        vmem_unmap_virtual_address_page(vpage);
+        return -ENOMEM;
+    }
     // Clean stack space.
-    memset((char *)task->mm->start_stack, 0, DEFAULT_STACK_SIZE);
-    // Set the base address of the stack.
-    task->thread.regs.ebp     = (uintptr_t)(task->mm->start_stack + DEFAULT_STACK_SIZE);
-    // Set the top address of the stack.
-    task->thread.regs.useresp = task->thread.regs.ebp;
-    // Enable the interrupts.
-    task->thread.regs.eflags  = task->thread.regs.eflags | EFLAG_IF;
-
-    // Restore previous pgdir
-    paging_switch_pgd(crtdir);
-
-    return 1;
+    memset((char *)dst_addr, 0, DEFAULT_STACK_SIZE);
+    // Release the kernel virtual mapping window.
+    vmem_unmap_virtual_address_page(vpage);
+    return 0;
 }
 
 /// @brief Checks if the file starts with a shebang.
@@ -130,25 +126,39 @@ static int __has_shebang(vfs_file_t *file)
     return buf[0] == '#' && buf[1] == '!';
 }
 
-/// @brief Replace the current process with a loaded exectuable
-/// @param path the path to the executable to load.
-/// @param task the task to laod the exectuable.
-/// @param entry
-/// @return -errno or 0 on failure, 1 on success, 2 if a interpreter was loaded
-static int __load_executable(const char *path, task_struct *task, uint32_t *entry)
+/// @brief Builds the memory image of an executable into a candidate mm.
+/// @param path the path of the executable to load.
+/// @param task the task requesting the executable (used for permissions and
+///             for the setuid/setgid handling); it is left untouched until
+///             the image is fully built.
+/// @param entry the output where the entry point is stored (only written on
+///              success).
+/// @param new_mm the output where the candidate memory descriptor is stored
+///               (only written on success). The caller owns it and must
+///               either install it on the task (commit) or destroy it
+///               (rollback).
+/// @return -errno on failure, 1 on success, 2 if an interpreter was loaded.
+static int __load_executable(const char *path, task_struct *task, uint32_t *entry, mm_struct_t **new_mm)
 {
     // Return code variable.
     int ret                = 0;
     int interpreter_loop   = 0;
     // The duplicated interpreter path, it must be freed on every exit path.
     char *interpreter_path = NULL;
+    // The candidate memory image: until the load succeeds it is completely
+    // separate from the running image of the task (#208).
+    mm_struct_t *candidate = NULL;
+    // The credentials are restored if the load fails: a failed execve must
+    // leave the caller exactly as it was.
+    uid_t saved_uid        = task->uid;
+    pid_t saved_gid        = task->gid;
 start:
     pr_debug("__load_executable(`%s`, %p `%s`, %p)\n", path, task, task->name, entry);
     vfs_file_t *file = vfs_open(path, O_RDONLY, 0);
     if (file == NULL) {
         pr_err("Cannot find executable!\n");
         ret = -errno;
-        goto return_free;
+        goto close_and_return;
     }
     if (!file->fs_operations || !file->sys_operations) {
         pr_err("Executable has no filesystem operations (unmounted fs?).\n");
@@ -161,7 +171,8 @@ start:
         ret = -EACCES;
         goto close_and_return;
     }
-    // Check that the file is actually an executable before destroying the `mm`.
+    // Check that the file is actually an executable before building the
+    // candidate image.
     if (!(elf_check_file_type(file, ET_EXEC) || __has_shebang(file))) {
         pr_debug("This is not a valid executable `%s`!\n", path);
         ret = -ENOEXEC;
@@ -175,20 +186,9 @@ start:
     if (bitmask_check(file->mask, S_ISGID)) {
         task->gid = file->gid;
     }
-    // FIXME: When threads will be implemented
-    // they should share the mm, so the destroy_process_image must be called
-    // only when all the threads are terminated. This can be accomplished by using
-    // an internal counter on the mm.
-    if (task->mm) {
-        mm_destroy(task->mm);
-    }
-    // Recreate the memory of the process.
-    if (!__reset_process(task)) {
-        ret = -ENOMEM;
-        goto close_and_return;
-    }
-
-    // Load potential interpreter specified by a shebang line
+    // Load potential interpreter specified by a shebang line. The
+    // interpreter is resolved before anything is allocated, so that a
+    // failing script only costs a file lookup.
     if (__has_shebang(file)) {
         // Disallow interpreter loops
         if (interpreter_loop) {
@@ -202,13 +202,12 @@ start:
         // The reference to the script file is no longer needed.
         vfs_close(file);
         file = NULL;
-        // Never use a failed read result as a buffer index.
+        // Never use a failed read result as a buffer index. Do not log
+        // `path` here: on the first iteration it is a raw user pointer.
         if (bytes_read < 0) {
-            // Do not log `path` here: it may point into the old, already
-            // destroyed user address space (see #208).
             pr_err("Failed to read the shebang line.\n");
             ret = -EIO;
-            goto return_free;
+            goto close_and_return;
         }
         buf[bytes_read] = 0;
 
@@ -216,34 +215,64 @@ start:
         char *lineend = strchr(buf, '\n');
         if (!lineend) {
             ret = -ENAMETOOLONG;
-            goto return_free;
+            goto close_and_return;
         }
         *lineend = 0;
 
         interpreter_path = strdup(buf);
         if (interpreter_path == NULL) {
             ret = -ENOMEM;
-            goto return_free;
+            goto close_and_return;
         }
         path = interpreter_path;
         interpreter_loop++;
         goto start;
     }
 
-    // Load the elf file, check if 0 is returned and print the error.
-    if (!(ret = elf_load_file(task, file, entry))) {
-        pr_err("Failed to load ELF file `%s`!\n", path);
-    } else if (interpreter_loop) {
-        // An interpreter was loaded.
-        ret = 2;
+    // == Build the candidate image ===========================================
+    // From this point on, every failure must destroy the candidate image
+    // and leave the current image of the task untouched.
+    // FIXME: When threads will be implemented
+    // they should share the mm, so the destroy_process_image must be called
+    // only when all the threads are terminated. This can be accomplished by using
+    // an internal counter on the mm.
+    candidate = mm_create_blank(DEFAULT_STACK_SIZE);
+    if (candidate == NULL) {
+        pr_err("Failed to initialize the candidate mm structure.\n");
+        ret = -ENOMEM;
+        goto close_and_return;
     }
+    // Clear the stack of the candidate image through the kernel virtual
+    // mapping window: the current page directory stays on the old image.
+    if ((ret = __clear_user_stack(candidate)) < 0) {
+        goto close_and_return;
+    }
+
+    // Load the elf file into the candidate memory descriptor.
+    if ((ret = elf_load_file(candidate, file, entry)) < 0) {
+        pr_err("Failed to load ELF file `%s`!\n", path);
+        goto close_and_return;
+    }
+    ret = interpreter_loop ? 2 : 1;
 
 close_and_return:
     // Close the file if it is still open.
     if (file != NULL) {
         vfs_close(file);
     }
-return_free:
+    // Rollback: destroy the candidate image and restore the credentials. On
+    // success, hand the candidate over to the caller, which becomes
+    // responsible for committing (or destroying) it.
+    if (ret <= 0) {
+        if (candidate != NULL) {
+            mm_destroy(candidate);
+            candidate = NULL;
+        }
+        task->uid = saved_uid;
+        task->gid = saved_gid;
+    } else {
+        *new_mm = candidate;
+    }
     // Free the duplicated interpreter path.
     if (interpreter_path != NULL) {
         kfree(interpreter_path);
@@ -405,9 +434,11 @@ int process_create_init(const char *path)
     // ------------------------------------------------------------------------
 
     // == INITIALIZE TASK MEMORY ==============================================
-    // Load the executable.
-    if (__load_executable(path, init_process, &init_process->thread.regs.eip) <= 0) {
-        pr_err("Entry for init: %d\n", init_process->thread.regs.eip);
+    // Build the image of the executable into a candidate mm; the task is
+    // not touched until the image is fully built (#208).
+    mm_struct_t *new_mm = NULL;
+    if (__load_executable(path, init_process, &init_process->thread.regs.eip, &new_mm) <= 0) {
+        pr_err("Failed to load the init executable: %s.\n", path);
         return 1;
     }
     // ------------------------------------------------------------------------
@@ -415,8 +446,14 @@ int process_create_init(const char *path)
     // == INITIALIZE PROGRAM ARGUMENTS ========================================
     // Save the current page directory.
     page_directory_t *crtdir = paging_get_current_pgd();
-    // Switch to init page directory.
-    paging_switch_pgd(init_process->mm->pgd);
+    // Switch to the page directory of the candidate image.
+    paging_switch_pgd(new_mm->pgd);
+
+    // Commit: the candidate image becomes the image of the init process
+    // (there is no previous image to destroy).
+    init_process->mm        = new_mm;
+    // The stack of the new image starts at its top.
+    uintptr_t useresp       = new_mm->start_stack + DEFAULT_STACK_SIZE;
 
     // Prepare argv and envp for the init process.
     char **argv_ptr;
@@ -425,21 +462,26 @@ int process_create_init(const char *path)
     static char *argv[]         = {"/bin/init", (char *)NULL};
     static char *envp[]         = {(char *)NULL};
     // Save where the arguments start.
-    init_process->mm->arg_start = init_process->thread.regs.useresp;
+    new_mm->arg_start           = useresp;
     // Push the arguments on the stack.
-    argv_ptr                    = __push_args_on_stack(&init_process->thread.regs.useresp, argv);
+    argv_ptr                    = __push_args_on_stack(&useresp, argv);
     // Save where the arguments end.
-    init_process->mm->arg_end   = init_process->thread.regs.useresp;
+    new_mm->arg_end             = useresp;
     // Save where the environmental variables start.
-    init_process->mm->env_start = init_process->thread.regs.useresp;
+    new_mm->env_start           = useresp;
     // Push the environment on the stack.
-    envp_ptr                    = __push_args_on_stack(&init_process->thread.regs.useresp, envp);
+    envp_ptr                    = __push_args_on_stack(&useresp, envp);
     // Save where the environmental variables end.
-    init_process->mm->env_end   = init_process->thread.regs.useresp;
+    new_mm->env_end             = useresp;
     // Push the `main` arguments on the stack (argc, argv, envp).
-    stack_push_ptr(&init_process->thread.regs.useresp, envp_ptr);
-    stack_push_ptr(&init_process->thread.regs.useresp, argv_ptr);
-    stack_push_s32(&init_process->thread.regs.useresp, argc);
+    stack_push_ptr(&useresp, envp_ptr);
+    stack_push_ptr(&useresp, argv_ptr);
+    stack_push_s32(&useresp, argc);
+
+    // Set the stack registers of the new image, and enable the interrupts.
+    init_process->thread.regs.ebp     = useresp;
+    init_process->thread.regs.useresp = useresp;
+    init_process->thread.regs.eflags  = init_process->thread.regs.eflags | EFLAG_IF;
 
     // Restore previous pgdir
     paging_switch_pgd(crtdir);
@@ -652,7 +694,15 @@ int sys_execve(pt_regs_t *f)
     // ------------------------------------------------------------------------
 
     // == INITIALIZE TASK MEMORY ==============================================
-    int ret = __load_executable(filename, current, &current->thread.regs.eip);
+    // Build the new image inside a candidate mm: until the commit below,
+    // the current image of the process stays fully functional, so any
+    // failure just returns an error to the caller (#208).
+    uint32_t entry      = 0;
+    mm_struct_t *new_mm = NULL;
+    // Credentials are restored if any of the post-load steps fails.
+    uid_t prev_uid      = current->uid;
+    pid_t prev_gid      = current->gid;
+    int ret             = __load_executable(filename, current, &entry, &new_mm);
     if (ret <= 0) {
         pr_err("Failed to load executable!\n");
         // Free the temporary args memory.
@@ -667,9 +717,12 @@ int sys_execve(pt_regs_t *f)
         char **int_argv = kmalloc((argc + 2) * sizeof(char *));
         if (!int_argv) {
             pr_err("Failed to allocate memory for interpreter argv array.\n");
-            // Free the temporary args memory.
+            // Rollback: the old image is still the current one.
+            mm_destroy(new_mm);
+            current->uid = prev_uid;
+            current->gid = prev_gid;
             kfree(args_mem);
-            return -1;
+            return -ENOMEM;
         }
         int_argv[0] = saved_argv[0]; // TODO: pass the path to the interpreter.
         int_argv[1] = saved_filename;
@@ -687,10 +740,13 @@ int sys_execve(pt_regs_t *f)
                 "Failed to allocate memory for interpreter arguments and "
                 "environment %d (%d + %d).\n",
                 int_argv_bytes + envp_bytes, int_argv_bytes, envp_bytes);
-            // Free the temporary allocations.
+            // Rollback: the old image is still the current one.
             kfree(int_argv);
+            mm_destroy(new_mm);
+            current->uid = prev_uid;
+            current->gid = prev_gid;
             kfree(args_mem);
-            return -1;
+            return -ENOMEM;
         }
         // Copy the arguments.
         uint32_t int_args_mem_ptr = (uint32_t)int_args_mem + (int_argv_bytes + envp_bytes);
@@ -709,27 +765,47 @@ int sys_execve(pt_regs_t *f)
     // Save the current page directory.
     page_directory_t *crtdir = paging_get_current_pgd();
 
-    // Change the page directory to point to the newly created process
-    paging_switch_pgd(current->mm->pgd);
+    // Temporarily switch to the page directory of the candidate image to
+    // initialize its stack.
+    paging_switch_pgd(new_mm->pgd);
 
+    // The stack of the new image starts at its top.
+    uintptr_t useresp = new_mm->start_stack + DEFAULT_STACK_SIZE;
     // Save where the arguments start.
-    current->mm->arg_start = current->thread.regs.useresp;
+    new_mm->arg_start = useresp;
     // Push the arguments on the stack.
-    final_argv             = __push_args_on_stack(&current->thread.regs.useresp, saved_argv);
+    final_argv        = __push_args_on_stack(&useresp, saved_argv);
     // Save where the arguments end, and the env starts.
-    current->mm->env_start = current->mm->arg_end = current->thread.regs.useresp;
+    new_mm->env_start = new_mm->arg_end = useresp;
     // Push the environment on the stack.
-    final_envp                                    = __push_args_on_stack(&current->thread.regs.useresp, saved_envp);
+    final_envp                           = __push_args_on_stack(&useresp, saved_envp);
     // Save where the environmental variables end.
-    current->mm->env_end                          = current->thread.regs.useresp;
+    new_mm->env_end                      = useresp;
     // Push the `main` arguments on the stack (argc, argv, envp).
-    stack_push_ptr(&current->thread.regs.useresp, final_envp);
-    stack_push_ptr(&current->thread.regs.useresp, final_argv);
-    stack_push_s32(&current->thread.regs.useresp, argc);
+    stack_push_ptr(&useresp, final_envp);
+    stack_push_ptr(&useresp, final_argv);
+    stack_push_s32(&useresp, argc);
 
     // Restore previous pgdir
     paging_switch_pgd(crtdir);
     // ------------------------------------------------------------------------
+
+    // == COMMIT ===============================================================
+    // The candidate image is complete: install it on the task, destroy the
+    // old image, and set the registers of the new image. Past this point
+    // the syscall cannot fail anymore.
+    mm_struct_t *old_mm     = current->mm;
+    current->mm             = new_mm;
+    if (old_mm != NULL) {
+        mm_destroy(old_mm);
+    }
+    // Set the entry point.
+    current->thread.regs.eip     = entry;
+    // Set the base address and the top of the stack.
+    current->thread.regs.ebp     = useresp;
+    current->thread.regs.useresp = useresp;
+    // Enable the interrupts.
+    current->thread.regs.eflags  = current->thread.regs.eflags | EFLAG_IF;
 
     // Change the name of the process.
     strcpy(current->name, name_buffer);
@@ -741,6 +817,6 @@ int sys_execve(pt_regs_t *f)
     scheduler_restore_context(current, f);
 
     pr_debug("Executing '%s' (pid: %d)...\n", current->name, current->pid);
-    
+
     return 0;
 }

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -32,6 +32,7 @@ static char *all_tests[] = {
     "t_dup",
     "t_environ",
     "t_exec",
+    "t_execve_fail",
     "t_exit",
     "t_fflush",
     "t_fhs",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_LIST
     t_abort.c
     t_shmget.c
     t_exec.c
+    t_execve_fail.c
     t_gid.c
     t_grp.c
     t_stopcont.c

--- a/userspace/tests/t_execve_fail.c
+++ b/userspace/tests/t_execve_fail.c
@@ -1,0 +1,286 @@
+/// @file t_execve_fail.c
+/// @brief Regression test for #208: a failed `execve` must leave the caller
+/// intact and usable.
+/// @details The test builds an ELF file that passes every `execve`
+/// pre-check (valid ELF32/i386/ET_EXEC header, execute bit set) but whose
+/// only `PT_LOAD` segment is not backed by the file (the segment starts
+/// past EOF). The failure is therefore detected only while the new image is
+/// being loaded, which is exactly the window after the pre-checks.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <time.h>
+#include <unistd.h>
+
+/// Path of the crafted executable.
+#define BAD_ELF_PATH "/home/user/t_execve_fail.elf"
+
+/// Path of a plain non-executable file.
+#define NOEXEC_PATH "/home/user/t_execve_fail.txt"
+
+/// A truncated ET_EXEC file: valid 52-byte ELF header + 32-byte program
+/// header (84 bytes total). The single PT_LOAD segment declares
+/// p_offset = 0x1000 and p_filesz = 0x1000, so the file content ends long
+/// before the segment begins. The entry point (0x08049000) falls inside the
+/// zero-initialized part of the segment.
+static const unsigned char bad_elf[] = {
+    // e_ident: ELF magic, ELFCLASS32, ELFDATA2LSB, EV_CURRENT.
+    0x7f, 'E', 'L', 'F', 0x01, 0x01, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // e_type = ET_EXEC (2).
+    0x02, 0x00,
+    // e_machine = EM_386 (3).
+    0x03, 0x00,
+    // e_version = 1.
+    0x01, 0x00, 0x00, 0x00,
+    // e_entry = 0x08049000.
+    0x00, 0x90, 0x04, 0x08,
+    // e_phoff = 52 (right after the header).
+    0x34, 0x00, 0x00, 0x00,
+    // e_shoff = 0.
+    0x00, 0x00, 0x00, 0x00,
+    // e_flags = 0.
+    0x00, 0x00, 0x00, 0x00,
+    // e_ehsize = 52, e_phentsize = 32, e_phnum = 1.
+    0x34, 0x00,
+    0x20, 0x00,
+    0x01, 0x00,
+    // e_shentsize = 0, e_shnum = 0, e_shstrndx = 0.
+    0x00, 0x00,
+    0x00, 0x00,
+    0x00, 0x00,
+    // Program header: PT_LOAD.
+    // p_type = PT_LOAD (1).
+    0x01, 0x00, 0x00, 0x00,
+    // p_offset = 0x1000 (past the 84-byte EOF).
+    0x00, 0x10, 0x00, 0x00,
+    // p_vaddr = 0x08048000.
+    0x00, 0x80, 0x04, 0x08,
+    // p_paddr = 0x08048000.
+    0x00, 0x80, 0x04, 0x08,
+    // p_filesz = 0x1000.
+    0x00, 0x10, 0x00, 0x00,
+    // p_memsz = 0x2000.
+    0x00, 0x20, 0x00, 0x00,
+    // p_flags = PF_R | PF_X (5).
+    0x05, 0x00, 0x00, 0x00,
+    // p_align = 0x1000.
+    0x00, 0x10, 0x00, 0x00,
+};
+
+/// @brief Writes the crafted ELF file and marks it as executable, plus a
+/// plain non-executable file.
+/// @return 0 on success, -1 on failure.
+static int create_bad_elf(void)
+{
+    int fd = creat(NOEXEC_PATH, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] creat: %s: %s", NOEXEC_PATH, strerror(errno));
+        return -1;
+    }
+    if (write(fd, "not an elf\n", 11) != 11) {
+        syslog(LOG_ERR, "[t_execve_fail] write: %s: %s", NOEXEC_PATH, strerror(errno));
+        close(fd);
+        return -1;
+    }
+    if (close(fd) < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] close: %s: %s", NOEXEC_PATH, strerror(errno));
+        return -1;
+    }
+
+    fd = creat(BAD_ELF_PATH, 0755);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] creat: %s: %s", BAD_ELF_PATH, strerror(errno));
+        return -1;
+    }
+    if (write(fd, bad_elf, sizeof(bad_elf)) != (ssize_t)sizeof(bad_elf)) {
+        syslog(LOG_ERR, "[t_execve_fail] write: %s: %s", BAD_ELF_PATH, strerror(errno));
+        close(fd);
+        return -1;
+    }
+    if (close(fd) < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] close: %s: %s", BAD_ELF_PATH, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Exercises the pre-checked failure paths: they must fail without
+/// touching the caller either.
+/// @return 0 on success, -1 on failure.
+static int check_early_failures(pid_t expected_pid)
+{
+    char *argv_foo[2]  = {"t_execve_fail", NULL};
+    char *envp_none[1] = {NULL};
+
+    // A file that does not exist must give ENOENT.
+    errno = 0;
+    if (execve("/no/such/file", argv_foo, envp_none) != -1) {
+        syslog(LOG_ERR, "[t_execve_fail] execve of missing file unexpectedly succeeded");
+        return -1;
+    }
+    if (errno != ENOENT) {
+        syslog(LOG_ERR, "[t_execve_fail] execve of missing file: expected ENOENT, got %s", strerror(errno));
+        return -1;
+    }
+
+    // A file without the execute bit must give EACCES.
+    errno = 0;
+    if (execve(NOEXEC_PATH, argv_foo, envp_none) != -1) {
+        syslog(LOG_ERR, "[t_execve_fail] execve of non-executable unexpectedly succeeded");
+        return -1;
+    }
+    if ((errno != EACCES) && (errno != EPERM)) {
+        syslog(LOG_ERR, "[t_execve_fail] execve of non-executable: expected EACCES, got %s", strerror(errno));
+        return -1;
+    }
+
+    // The caller must still be the very same process.
+    if (getpid() != expected_pid) {
+        syslog(LOG_ERR, "[t_execve_fail] pid changed after failed execve");
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Child body: the failed execve must leave this process running.
+/// @return the child exit code (0 on success).
+static int child_main(void)
+{
+    // Data used to prove that the old image is still alive and consistent.
+    char stack_canary[32];
+    char *heap_canary;
+    pid_t my_pid = getpid();
+
+    memset(stack_canary, 0xAB, sizeof(stack_canary));
+    heap_canary = malloc(64);
+    if (heap_canary == NULL) {
+        syslog(LOG_ERR, "[t_execve_fail] malloc: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    memset(heap_canary, 0xCD, 64);
+
+    // The failure paths before the pre-checks must already work.
+    if (check_early_failures(my_pid) < 0) {
+        free(heap_canary);
+        return EXIT_FAILURE;
+    }
+
+    // The main event: an executable that passes the pre-checks (valid ELF
+    // header, ET_EXEC, execute bit) but fails while the image is loaded.
+    char *argv_bad[2]  = {"t_execve_fail", NULL};
+    char *envp_none[1] = {NULL};
+    errno              = 0;
+    if (execve(BAD_ELF_PATH, argv_bad, envp_none) != -1) {
+        // If we reach this point either the execve failed to report the
+        // error (old behavior: fake success before jumping into the
+        // destroyed image), or something loaded the truncated file.
+        syslog(LOG_ERR, "[t_execve_fail] execve of bad ELF unexpectedly succeeded");
+        free(heap_canary);
+        return EXIT_FAILURE;
+    }
+    if (errno != ENOEXEC) {
+        syslog(LOG_ERR, "[t_execve_fail] execve of bad ELF: expected ENOEXEC, got %s", strerror(errno));
+        free(heap_canary);
+        return EXIT_FAILURE;
+    }
+
+    // The caller must still be executing its own code, with its own memory.
+    if (getpid() != my_pid) {
+        syslog(LOG_ERR, "[t_execve_fail] pid changed after failed execve");
+        free(heap_canary);
+        return EXIT_FAILURE;
+    }
+    for (size_t i = 0; i < sizeof(stack_canary); ++i) {
+        if ((unsigned char)stack_canary[i] != 0xAB) {
+            syslog(LOG_ERR, "[t_execve_fail] stack memory corrupted after failed execve");
+            free(heap_canary);
+            return EXIT_FAILURE;
+        }
+    }
+    for (size_t i = 0; i < 64; ++i) {
+        if ((unsigned char)heap_canary[i] != 0xCD) {
+            syslog(LOG_ERR, "[t_execve_fail] heap memory corrupted after failed execve");
+            free(heap_canary);
+            return EXIT_FAILURE;
+        }
+    }
+    free(heap_canary);
+
+    // A few more syscalls must keep working.
+    if (time(NULL) < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] time: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    if (unlink(BAD_ELF_PATH) < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] unlink: %s: %s", BAD_ELF_PATH, strerror(errno));
+        return EXIT_FAILURE;
+    }
+    if (unlink(NOEXEC_PATH) < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] unlink: %s: %s", NOEXEC_PATH, strerror(errno));
+        return EXIT_FAILURE;
+    }
+    syslog(LOG_INFO, "[t_execve_fail] process survived the failed execve");
+
+    // Finally, a working execve must still succeed after the rollback: we
+    // replace ourselves with /bin/echo; its exit status is checked by the
+    // parent.
+    char *argv_echo[3] = {"echo", "t_execve_fail: post-failure exec", NULL};
+    execve("/bin/echo", argv_echo, envp_none);
+
+    // Getting here means the execve of a good executable failed.
+    syslog(LOG_ERR, "[t_execve_fail] execve /bin/echo: %s", strerror(errno));
+    return EXIT_FAILURE;
+}
+
+int main(int argc, char *argv[])
+{
+    // Build the crafted executable.
+    if (create_bad_elf() < 0) {
+        return EXIT_FAILURE;
+    }
+
+    // Run the actual test inside a child, so that even a catastrophic
+    // regression (process killed, kernel panic) is observable as a test
+    // failure instead of taking down the whole test runner.
+    pid_t pid = fork();
+    if (pid < 0) {
+        syslog(LOG_ERR, "[t_execve_fail] fork: %s", strerror(errno));
+        unlink(BAD_ELF_PATH);
+        unlink(NOEXEC_PATH);
+        return EXIT_FAILURE;
+    }
+    if (pid == 0) {
+        exit(child_main());
+    }
+
+    int status;
+    if (waitpid(pid, &status, 0) == -1) {
+        syslog(LOG_ERR, "[t_execve_fail] waitpid: %s", strerror(errno));
+        unlink(BAD_ELF_PATH);
+        unlink(NOEXEC_PATH);
+        return EXIT_FAILURE;
+    }
+    if (!WIFEXITED(status) || (WEXITSTATUS(status) != 0)) {
+        if (WIFSIGNALED(status)) {
+            syslog(LOG_ERR, "[t_execve_fail] child killed by signal %d", WTERMSIG(status));
+        } else {
+            syslog(LOG_ERR, "[t_execve_fail] child exited with %d", WEXITSTATUS(status));
+        }
+        unlink(BAD_ELF_PATH);
+        unlink(NOEXEC_PATH);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Make `execve()` transactional: construct and validate the new process image in
a separate `mm_struct`, and replace the current address space only after the
new image has been loaded successfully.

A failed `execve()` now leaves the caller's existing address space and
execution context intact.

A regression test exercises a failure that occurs after the initial executable
pre-checks and verifies that the calling process continues running afterwards.

## Problem / motivation

`__load_executable()` previously destroyed the caller's address space before
the new executable was known to load successfully:

```text
validate basic executable
        |
        v
mm_destroy(old_mm)
        |
        v
reset process
        |
        v
load ELF
        |
        +--> failure: old image is already gone
````

Failures after teardown could therefore not safely return to the caller.

Investigation also found that malformed ELF segment layouts were not reliably
reported as loader errors: some malformed images could be treated as a
successful load and subsequently transfer execution into an invalid image.

The required invariant is:

```text
old image
    |
    v
construct candidate image
    |
    +-- failure --> destroy candidate
    |              preserve old image
    |              return -errno
    |
    `-- success --> install candidate
                   destroy old image
                   enter new program
```

## Changes

### Transactional execve loading

* Build the new process image in a separate `mm_struct`.
* Keep the current address space active while the candidate image is built.
* Initialize the candidate userspace stack through the kernel virtual-memory
  mapping window instead of switching CR3 merely to clear it.
* Delay replacement/destruction of the old `mm` until loading and userspace
  stack construction have succeeded.
* Preserve the syscall register frame until the commit point.
* Restore credential changes on failure paths.

### ELF loader

* Pass the target `mm_struct` explicitly to the ELF loading path rather than
  implicitly modifying `task->mm`.
* Propagate allocation and mapping failures.
* Validate the program-header table and `PT_LOAD` ranges before reading segment
  data.
* Reject segments whose file range extends beyond the executable.
* Reject invalid `filesz > memsz` and invalid userspace virtual ranges.

These checks are part of making candidate-image construction reliably
fallible: the transactional loader cannot roll back failures that the ELF
loader incorrectly reports as success.

### Regression coverage

Add `t_execve_fail`.

The test creates a small executable that:

* has a valid ELF32/i386/ET_EXEC header;
* passes the early executable/type checks;
* contains a `PT_LOAD` whose file range extends beyond EOF.

The child verifies:

1. ordinary pre-validation failures still work;
2. the malformed ELF returns `-1` / `ENOEXEC`;
3. the same process continues executing after the failed `execve()`;
4. its PID is unchanged;
5. previous stack and heap state remain intact;
6. subsequent syscalls still work;
7. a subsequent valid `execve("/bin/echo", ...)` succeeds.

The parent verifies the final child status with `waitpid()`.

## Validation

* [x] `git diff --check`
* [x] Relevant build completed
* [x] Relevant automated tests completed
* [x] Manual validation performed where appropriate

Validation details:

```text
Baseline develop:
- 50/50 userspace tests passed.

Pre-fix with t_execve_fail added:
- tests 1-8 passed
- test 9 triggered the execve failure
- malformed ELF was incorrectly treated as successfully loaded
- execution transferred to the invalid image
- kernel PANIC
- QEMU panic exit: 35

Post-fix:
- t_execve_fail: ok
- failed malformed execve returned ENOEXEC
- original process remained alive
- stack canary intact
- heap canary intact
- subsequent syscalls succeeded
- subsequent valid execve succeeded

Full suite:
- 51/51 TAP tests passed
- 0 failures
- 0 kernel panics
- QEMU guest success exit: 33
```

`cdrom_test.iso` was explicitly rebuilt before the final run. During
development it was discovered that `run-qemu-test` can otherwise execute a
stale ISO after rebuilding the kernel; that is a separate test-tooling issue.

## Scope

* [x] The change is focused on one primary problem.
* [x] Unrelated refactors or cleanup have been left for separate work.
* [x] New behavior is covered by a regression test.
* [x] Documentation changes are not required for the internal implementation change.

Deliberately out of scope:

* #196 — argv/envp size handling
* #224 — short reads in `elf_check_file_type()`
* #191 — general userspace-pointer validation
* signal-handler reset semantics across exec
* close-on-exec/file-descriptor semantics
* general page-fault-handler behavior

The changes also remove the teardown condition responsible for the dangling
filename described in #223, but that issue should be re-verified independently
before being closed.

## Additional findings

During verification:

1. a user-mode page fault targeting an address covered by a supervisor-only
   PDE can lead the page-fault handler to panic the kernel instead of
   delivering SIGSEGV;
2. `qemu-test` / `run-qemu-test` can execute a stale `cdrom_test.iso` after a
   kernel rebuild unless the ISO target is rebuilt explicitly.

These are separate from the execve transaction and should be tracked
independently.

## Related issues

Fixes #208

Related: #121, #192, #196, #223, #224