### PR TITLE
fix(test): clean up qemu log streamers

### DIFF
--- a/docs/maintainer/testing-and-ci.md
+++ b/docs/maintainer/testing-and-ci.md
@@ -63,6 +63,16 @@ The guest now uses QEMU's `isa-debug-exit` device for explicit failure signaling
    - Wrapper translates guest exit codes and validates TAP before returning success
    - Consistent with CI pass/fail semantics
 
+### Log streamer lifecycle
+
+`scripts/run-qemu-test` owns the `tail -F | sed -u` pipelines used for live
+`[SERIAL]` and `[TEST]` output. Each pipeline runs in its own process group so
+normal completion, early errors, and INT/TERM/HUP cleanup can terminate both
+pipeline members and reap them before the wrapper exits. The existing 1-second
+post-QEMU drain remains in place so final streamed lines are emitted before
+cleanup. This prevents orphaned streamers from keeping piped callers open or
+following rewritten logs from later runs.
+
 ### Exit code reference
 
 | Scenario                          | Guest write | Host exit | Recognized as |

--- a/scripts/run-qemu-test
+++ b/scripts/run-qemu-test
@@ -6,6 +6,35 @@ set -e
 BUILD_DIR="${1:-build}"
 TIMEOUT="${2:-600}"  # 10 minutes default
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QEMU_PID=""
+STREAMER_PGIDS=()
+
+cleanup() {
+    local pgid
+
+    if [ -n "${QEMU_PID}" ] && kill -0 "${QEMU_PID}" 2>/dev/null; then
+        kill "${QEMU_PID}" 2>/dev/null || true
+    fi
+
+    for pgid in "${STREAMER_PGIDS[@]}"; do
+        kill -- "-${pgid}" 2>/dev/null || true
+    done
+
+    if [ -n "${QEMU_PID}" ]; then
+        wait "${QEMU_PID}" 2>/dev/null || true
+        QEMU_PID=""
+    fi
+
+    for pgid in "${STREAMER_PGIDS[@]}"; do
+        wait "${pgid}" 2>/dev/null || true
+    done
+    STREAMER_PGIDS=()
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 echo "===================================================="
 echo "Starting QEMU test run (timeout: ${TIMEOUT}s)..."
@@ -37,10 +66,15 @@ echo "Monitoring test progress..."
 echo "Build directory: ${BUILD_DIR}"
 echo ""
 
-# Stream both logs in real-time using tail -F (follows by name, retries if file doesn't exist)
-# The --pid flag makes tail exit when QEMU dies
-(tail -F "${BUILD_DIR}/serial.log" 2>/dev/null | sed -u 's/^/[SERIAL] /' &)
-(tail -F "${BUILD_DIR}/test.log" 2>/dev/null | sed -u 's/^/[TEST]   /' &)
+# Stream both logs in real time. Briefly enable job control so each async
+# subshell is a process-group leader and $! is also the group's PGID. Cleanup
+# can then stop both tail and sed by signaling the whole process group.
+set -m
+(tail -F "${BUILD_DIR}/serial.log" 2>/dev/null | sed -u 's/^/[SERIAL] /') &
+STREAMER_PGIDS+=("$!")
+(tail -F "${BUILD_DIR}/test.log" 2>/dev/null | sed -u 's/^/[TEST]   /') &
+STREAMER_PGIDS+=("$!")
+set +m
 
 # Wait for QEMU to finish and explicitly capture its exit code
 # Note: QEMU returns exit 33 on isa-debug-exit success (guest wrote 0x10),
@@ -56,6 +90,7 @@ fi
 
 # Give a moment for final output to flush
 sleep 1
+cleanup
 
 echo ""
 echo "===================================================="


### PR DESCRIPTION
## Summary

Ensure `scripts/run-qemu-test` owns the live log streamers it starts. The wrapper now terminates and reaps them on every exit path, so piped callers receive EOF and completed runs cannot keep following logs from later runs.

## Changes

- launch each `tail -F | sed -u` pipeline in its own process group
- record the streamer process-group IDs and terminate/reap the complete groups during cleanup
- run cleanup on normal exit, early `set -e` failures, and INT/TERM/HUP
- stop a still-running QEMU wrapper during signal or early-exit cleanup
- preserve the existing 1-second final-output drain before stopping streamers
- avoid GNU-only `tail --pid` and use Bash 3.2-compatible process-group primitives
- document streamer ownership in the maintainer testing/CI notes

## Validation

The following verification was performed during the issue investigation on the corresponding local patch that produced this lifecycle design. This connector-created commit mirrors that design but has not been rerun in this environment.

- full rebuilt `make -C build qemu-test`: QEMU 33, TAP 52/0, exit 0, no leaked streamers
- piped wrapper and `make` invocations return normally and readers receive EOF
- three repeated runs leave the streamer census at zero with no process growth
- a completed run's redirected capture remains unchanged after a later full run
- SIGTERM: 143, SIGHUP: 129, group SIGINT: prompt cleanup, QEMU startup failure: 1; all leave zero streamer/QEMU processes
- script-only SIGINT remains deferred by non-interactive Bash while waiting on QEMU, but EXIT cleanup still runs at natural completion
- the pre-existing group-SIGINT exit-0 mapping is unchanged and tracked in #246

Closes #218