### PR TITLE
fix(kernel): close hostname file when vfs_read fails in sys_uname

### DIFF
--- a/kernel/src/sys/utsname.c
+++ b/kernel/src/sys/utsname.c
@@ -42,6 +42,7 @@ static inline int __gethostname(char *name, size_t len)
     ssize_t ret = vfs_read(file, name, 0UL, len);
     if (ret < 0) {
         pr_err("Failed to read `/etc/hostname`.\n");
+        vfs_close(file);
         return ret;
     }
     // Close the file.


### PR DESCRIPTION
## Summary

Fix a file-reference leak in `__gethostname()` when reading `/etc/hostname` fails.

After a successful `vfs_open()`, the `vfs_read()` error path now calls `vfs_close(file)` before returning, releasing the reference acquired by `vfs_open()`.

Fixes #240.

## Problem / motivation

`__gethostname()` opens `/etc/hostname` through the VFS and normally releases the resulting `vfs_file_t` after reading it.

Previously, the read-error path returned immediately:

```c
ssize_t ret = vfs_read(file, name, 0UL, len);
if (ret < 0) {
    pr_err("Failed to read `/etc/hostname`.\n");
    return ret;
}
```

This skipped `vfs_close(file)`.

Under the VFS file-lifetime rules, the reference acquired by `vfs_open()` must be released through the close path. Since only `close_f` decrements `file->count`, every failed hostname read leaked the file structure and kept the corresponding ext2 inode pinned.

## Changes

* Call `vfs_close(file)` before returning from the `vfs_read()` failure path.
* Preserve the original error returned by `vfs_read()`.
* Leave the successful hostname-read path unchanged.

The resulting fix is a single-line change in `kernel/src/sys/utsname.c`.

## Validation

* [x] `git diff --check`
* [x] Relevant build completed
* [x] Relevant automated tests completed
* [x] Manual validation performed where appropriate

Validation details:

```text
Error-path verification:
- temporarily staged /etc/hostname as a directory
- ext2_open() succeeded
- ext2_read() returned -EISDIR, confirmed on serial output
- temporary regression test asserted:
    uname() == -1
    errno == EISDIR
- temporary suite result: 53/53 tests passed
- the fixed read-error path therefore executed and returned cleanly

Final regression run after reverting all test scaffolding:
- restored the normal /etc/hostname containing "avalon"
- removed the temporary test and both test registrations
- working tree contained only the intended one-line fix
- canonical `make qemu-test` completed successfully
- QEMU guest exit: 33
- userspace suite: 52/52 passed
- qemu-test exit status: 0
- no UTSNAM errors

Static verification:
- `git diff --check` completed cleanly
```

The error-path test also confirmed the libc syscall convention: the kernel's negative errno is translated by `__syscall_return` into `-1` with `errno` set, so the userspace assertion correctly checks `uname() == -1 && errno == EISDIR`.

## Scope

* [x] The change is focused on one primary problem.
* [x] Unrelated refactors or cleanup have been left for separate work.
* [x] The failure path was exercised with a temporary targeted regression test.
* [x] Temporary verification scaffolding was fully reverted before the final test run.

No permanent regression test is included because reliably forcing `/etc/hostname` reads to fail requires altering the staged filesystem specifically for the test. The failure path was nevertheless exercised directly during verification.

No documentation update is required because this fixes internal VFS resource-lifetime handling without changing the `uname()` interface or successful behavior.

The unrelated dead `if (len < 0)` check in `__gethostname()` remains intentionally out of scope.

## Related issues

Fixes #240.

Related: #191, #192, #231.