### PR TITLE
fix(elf): reject files shorter than the ELF header in elf_load_file

### DIFF
--- a/kernel/src/elf/elf.c
+++ b/kernel/src/elf/elf.c
@@ -334,6 +334,19 @@ int elf_load_file(mm_struct_t *mm, vfs_file_t *file, uint32_t *entry)
         pr_err("Failed to stat the file `%s`.\n", file->name);
         return -EIO;
     }
+    // A file shorter than the ELF header cannot contain one: interpreting
+    // the buffer would read past the end of the allocation (and a
+    // zero-length file would ask kmalloc for zero bytes). The execve
+    // classifier already rejects such files, but the loader must not rely
+    // on its callers (#241).
+    if (stat_buf.st_size < (off_t)sizeof(elf_header_t)) {
+        pr_err(
+            "File `%s` is too short to be an ELF file (%d < %d).\n",
+            file->name,
+            (int)stat_buf.st_size,
+            (int)sizeof(elf_header_t));
+        return -ENOEXEC;
+    }
     // Allocate the memory for the file.
     char *buffer = kmalloc(stat_buf.st_size);
     if (buffer == NULL) {


### PR DESCRIPTION
## Summary

Harden `elf_load_file()` against files shorter than an ELF header.

The loader now rejects files smaller than `sizeof(elf_header_t)` immediately after `vfs_fstat()`, before allocating or reading the file contents.

This prevents out-of-bounds ELF header reads for 1–51 byte files and avoids the `kmalloc(0)` case for empty files.

Fixes #241.

## Problem / motivation

`elf_load_file()` allocates a buffer using the file's exact `st_size`, reads the file into it, and then interprets the beginning of that buffer as an `elf_header_t`.

Previously there was no check ensuring that the file actually contained the complete 52-byte ELF header.

For files shorter than `sizeof(elf_header_t)`, accesses to fields such as `e_version`, `e_entry`, `e_phoff`, and `e_phnum` could therefore read past the end of the allocated buffer.

For an empty file, the same path could also reach:

```c
kmalloc(0)
```

The existing read-count validation only guarantees that all `st_size` bytes were initialized; it does not guarantee that enough bytes exist to contain an ELF header.

Since #224, `elf_check_file_type()` rejects short files before the normal `execve()` path reaches the loader. However, `elf_load_file()` is exported and should enforce its own input contract rather than relying on its current caller to provide a sufficiently large file.

## Changes

* Check `stat_buf.st_size` immediately after `vfs_fstat()`.
* Return `-ENOEXEC` when the file is smaller than `sizeof(elf_header_t)`.
* Perform the check before allocating the file buffer.
* Use an `off_t` cast for a signed, warning-free comparison with `st_size`.
* Leave existing ELF loading behavior unchanged for files large enough to contain a complete header.

The final patch is limited to `kernel/src/elf/elf.c` with 13 added lines.

## Validation

* [x] Relevant build completed
* [x] Relevant automated tests completed
* [x] Direct loader failure path exercised
* [x] Temporary verification scaffolding fully reverted

Validation details:

```text
Canonical regression run:
- make qemu-test completed successfully
- QEMU guest exit: 33
- userspace suite: 52/52 passed
- t_elf_short: ok 10
- no ELF regression observed

Direct loader verification:
- temporarily bypassed the execve classifier gate so short files reached
  elf_load_file() directly
- tested file sizes: 0, 1, 3, 16, 20, and 51 bytes
- every short file was rejected by the new loader-side size check
- serial output reported "too short to be an ELF file"
- ENOEXEC behavior was preserved
- the complete 52-test suite passed through the modified path
- the 52-byte valid-header control was not rejected by the new size check

Cleanup:
- classifier-bypass scaffolding was fully reverted
- final tree contains only the intended loader fix
```

One verification run encountered a transient `t_semget` timing failure. A clean rerun passed 52/52; the failure is an existing semaphore-test timing race and is unrelated to the ELF loader change.

## Scope

* [x] The change is focused on one primary problem.
* [x] Unrelated ELF hardening has been left for separate work.
* [x] The affected loader path was exercised directly.
* [x] Verification-only modifications were removed from the final change.

No permanent regression test is added because the existing `execve()` classifier, fixed by #224, now rejects truncated ELF headers before `elf_load_file()` is reached. The loader-specific failure path was therefore verified by temporarily bypassing that classifier during testing.

No documentation update is required because this strengthens an internal loader precondition without changing the supported ELF interface or valid executable behavior.

## Related issues

Fixes #241.

Related: #224, #121, #210, #211.
