### PR TITLE
fix(kernel): keep nodename NUL-terminated in sys_uname

### DIFF
--- a/kernel/src/sys/utsname.c
+++ b/kernel/src/sys/utsname.c
@@ -38,8 +38,10 @@ static inline int __gethostname(char *name, size_t len)
     }
     // Clear the buffer.
     memset(name, 0, len);
-    // Read the content of the file.
-    ssize_t ret = vfs_read(file, name, 0UL, len);
+    // Read the content of the file. Read at most len - 1 bytes so that the
+    // buffer always keeps its NUL terminator: a hostname of SYS_LEN bytes
+    // or more must not fill every byte of the destination field (#256).
+    ssize_t ret = vfs_read(file, name, 0UL, len - 1);
     if (ret < 0) {
         pr_err("Failed to read `/etc/hostname`.\n");
         vfs_close(file);


### PR DESCRIPTION
## Summary

Ensure `sys_uname()` always returns a NUL-terminated `nodename`, even when `/etc/hostname` is `SYS_LEN` bytes or longer.

`__gethostname()` now reads at most `len - 1` bytes, preserving the final byte previously cleared by `memset()` as the terminating NUL.

Fixes #256.

## Problem / motivation

`__gethostname()` clears the destination buffer and then reads `/etc/hostname` directly into it:

```c
memset(name, 0, len);
ssize_t ret = vfs_read(file, name, 0UL, len);
```

For `sys_uname()`, `len` is `SYS_LEN` (`257`).

If `/etc/hostname` contains at least `SYS_LEN` bytes, the previous `vfs_read()` could overwrite every byte cleared by `memset()`, leaving `buf->nodename` without a terminating NUL.

Userspace code treating `nodename` as a C string, such as `strlen()` or `%s` formatting, could then read beyond the end of the field.

## Changes

* Limit the hostname read to `len - 1` bytes.
* Preserve the final zeroed byte as the NUL terminator.
* Keep existing behavior unchanged for ordinary shorter hostnames.
* Leave the existing read-error cleanup and error propagation unchanged.

The effective change is:

```c
ssize_t ret = vfs_read(file, name, 0UL, len - 1);
```

## Validation

* [x] `git diff --check`
* [x] Relevant build completed
* [x] Relevant automated tests completed
* [x] Long-hostname behavior exercised in-guest

Validation details:

```text
Targeted in-guest verification:
- temporarily staged a 300-byte /etc/hostname
- added a temporary regression test exercising sys_uname()
- verified strlen(nodename) == 256
- verified nodename[256] == '\0'
- temporary test: ok 53
- complete temporary suite: 53/53 passed

Final regression run:
- restored /etc/hostname to "avalon"
- removed the temporary test and its registrations
- canonical make qemu-test completed successfully
- QEMU guest exit: 33
- userspace suite: 52/52 passed
- qemu-test exit status: 0
- git diff --check clean
```

The 300-byte fixture directly verifies the post-fix truncation and termination behavior. A separate pre-fix rebuild was not performed because the overwrite mechanism is deterministic from the previous `vfs_read(..., len)` implementation.

## Scope

* [x] The change is focused on one primary problem.
* [x] Unrelated cleanup has been left for separate work.
* [x] The affected boundary condition was exercised with a temporary regression test.
* [x] Verification scaffolding was fully reverted before the final regression run.

No permanent regression fixture is included because reproducing the boundary condition requires replacing the staged `/etc/hostname` with an intentionally oversized file. The behavior was exercised directly during verification and the normal root filesystem was restored afterward.

No documentation update is required because this corrects the existing string-termination contract of `uname()` without changing its interface.

## Related issues

Fixes #256.

Related: #230, #240.
