### PR TITLE
Fix/255 semget test race

### DIFF
--- a/userspace/tests/t_semget.c
+++ b/userspace/tests/t_semget.c
@@ -171,4 +171,3 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-

--- a/userspace/tests/t_semget.c
+++ b/userspace/tests/t_semget.c
@@ -107,15 +107,10 @@ int main(int argc, char *argv[])
         }
         syslog(LOG_INFO, "[t_semget] [t_semget][child] Final semaphore value is %ld\n", ret);
 
-        // Delete the semaphore set.
-        ret = semctl(semid, 0, IPC_RMID, 0);
-        if (ret < 0) {
-            syslog(LOG_ERR, "[t_semget] [t_semget][child] Failed to remove semaphore set in child: %s\n", strerror(errno));
-            return 1;
-        }
-        syslog(LOG_INFO, "[t_semget] [t_semget][child] Removed semaphore set (id: %ld)\n", semid);
-
-        // Exit the child process.
+        // Exit the child process. The semaphore set is deliberately NOT
+        // removed here: the father must verify the final value and reap the
+        // child before the set is deleted, otherwise its GETVAL races with
+        // this IPC_RMID and fails with EINVAL (#255).
         return 0;
     }
 
@@ -137,14 +132,19 @@ int main(int argc, char *argv[])
     // Perform the blocking semaphore operations.
     if (semop(semid, op_father, 3) < 0) {
         syslog(LOG_ERR, "[t_semget] [t_semget][father] Failed to perform parent semaphore operations: %s\n", strerror(errno));
+        semctl(semid, 0, IPC_RMID, 0);
         return 1;
     }
     syslog(LOG_INFO, "[t_semget] [t_semget][father] Performed semaphore operations (id: %ld)\n", semid);
 
-    // Verify that the semaphore value is updated correctly.
+    // Verify that the semaphore value is updated correctly. This runs after
+    // the blocking semop returned, which can only happen once the child
+    // performed both increments, so the value is deterministically 0 and
+    // the set is guaranteed to still exist (the child no longer removes it).
     ret = semctl(semid, 0, GETVAL, NULL);
     if (ret < 0) {
         syslog(LOG_ERR, "[t_semget] [t_semget][father] Failed to get semaphore value in parent: %s\n", strerror(errno));
+        semctl(semid, 0, IPC_RMID, 0);
         return 1;
     }
     syslog(LOG_INFO, "[t_semget] [t_semget][father] Semaphore value is %ld (expected: 0)\n", ret);
@@ -152,8 +152,23 @@ int main(int argc, char *argv[])
     // Wait for the child process to terminate.
     if (wait(NULL) == -1) {
         syslog(LOG_ERR, "[t_semget] [t_semget] Failed to wait for child process: %s\n", strerror(errno));
+        semctl(semid, 0, IPC_RMID, 0);
         return EXIT_FAILURE; // Return failure if wait fails.
     }
 
+    // Delete the semaphore set. Doing this in the father, after the child
+    // has been reaped and the final value verified, removes the race where
+    // the child's IPC_RMID invalidated the id while the father was still
+    // using it (#255). Keeping the cleanup on the father's error paths also
+    // prevents a failed run from leaving a stale set behind and breaking
+    // the next run's IPC_CREAT | IPC_EXCL.
+    ret = semctl(semid, 0, IPC_RMID, 0);
+    if (ret < 0) {
+        syslog(LOG_ERR, "[t_semget] [t_semget][father] Failed to remove semaphore set: %s\n", strerror(errno));
+        return 1;
+    }
+    syslog(LOG_INFO, "[t_semget] [t_semget][father] Removed semaphore set (id: %ld)\n", semid);
+
     return 0;
 }
+


### PR DESCRIPTION
## Summary

Remove a race in `t_semget` that could make the test suite fail nondeterministically.

Semaphore-set ownership now remains with the parent: the child performs its operations and exits without calling `IPC_RMID`, while the parent verifies the final semaphore value, reaps the child, and only then removes the set.

Fixes #255.

## Problem / motivation

`t_semget` previously allowed the child to remove the semaphore set while the parent was still using it.

After the child's second increment, both processes could proceed independently:

```text
child:  second increment
                    |
                    +----> IPC_RMID
                    |
parent: blocked semop completes
                    |
                    +----> GETVAL
```

If the child's `IPC_RMID` won the race, the parent's subsequent `GETVAL` operated on an invalid semaphore ID and failed with `EINVAL`.

This was observed in a full test run as:

```text
not ok 35 - t_semget: Exit: 1
```

with the serial log showing the semaphore set being removed by the child immediately before the father's failed `GETVAL`.

## Changes

* Remove `IPC_RMID` from the child path.
* Let the child exit after completing its semaphore operations and logging.
* Keep the final semaphore ownership and cleanup in the father.
* Verify the final value after the father's blocking `semop()` completes.
* Reap the child before removing the semaphore set.
* Remove the set from father-side post-creation error paths as well, preventing a failed test from leaving stale IPC state that could break a later `IPC_CREAT | IPC_EXCL`.

The resulting ordering is:

```text
child performs both increments
        |
        v
father's blocking semop completes
        |
        v
father GETVAL verifies value == 0
        |
        v
father waits for child
        |
        v
father IPC_RMID
```

This removes the race without requiring additional synchronization primitives.

## Validation

* [x] `git diff --check`
* [x] Relevant automated tests completed
* [x] Race ordering verified
* [x] Cleanup path exercised in-guest

Validation details:

```text
Determinism:
- the father's blocking semop cannot return until both child increments
  have occurred
- once it returns, the resulting semaphore value is deterministically 0
- the child no longer removes the set, so the father's GETVAL cannot race
  with IPC_RMID
- this remains true regardless of whether the kernel internally applies the
  three decrement operations incrementally

Repeated regression:
- 6 consecutive full `make qemu-test` runs
- all 6 returned rc=0
- `ok 35 - t_semget` on every run
- zero "Invalid argument" failures in the serial logs
- the previous failure occurred approximately once every 10-15 runs

Cleanup verification:
- father-side removal executed successfully in-guest:
    [father] Removed semaphore set (id: 2)
- final full suite: 52/52 passed
- git diff --check clean
- working tree clean
```

## Scope

* [x] The change is limited to `t_semget`.
* [x] No kernel semaphore behavior is changed.
* [x] The existing test semantics are preserved.
* [x] Failed runs clean up their semaphore set where possible.

The observed `EINVAL` was correct kernel behavior for `GETVAL` on a semaphore set that had already been removed. This change fixes the test's process ordering rather than altering System V semaphore semantics.

## Related issues

Fixes #255.

Related: #241.
