### PR TITLE
fix(kernel): make the FHS boot step non-fatal and print-consistent

### DIFF
--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -265,12 +265,17 @@ int kmain(boot_info_t *boot_informations)
     //==========================================================================
     pr_notice("Initialize Filesystem Hierarchy Standard directories...\n");
     printf("Initialize FHS directories...");
+    // FHS initialization is non-critical by design (fhs_initialize keeps
+    // booting even when some directories cannot be created, and currently
+    // always returns 0): report the outcome and continue either way. The
+    // old `return 1` here would have jumped to a garbage return address
+    // (#243) and made a non-critical warning fatal.
     if (fhs_initialize()) {
         print_fail();
         pr_emerg("Failed to initialize FHS directories!\n");
-        return 1;
+    } else {
+        print_ok();
     }
-    print_ok();
 
     //==========================================================================
     pr_notice("    Initialize memory devices...\n");


### PR DESCRIPTION
## Summary

Make the FHS initialization step in `kmain()` non-fatal and keep its boot-status output consistent with the design of `fhs_initialize()`.

If FHS initialization reports a failure, the kernel now prints the failure and continues booting instead of returning from `kmain()`. The success marker is emitted only on the successful path.

Fixes #248.

## Problem / motivation

The original #248 report incorrectly described the FHS boot step as capable of printing both `[FAIL]` and `[ OK ]` for the same initialization attempt.

While implementing the fix, the actual code was re-verified and the issue was corrected accordingly. The existing failure path was:

```c
if (fhs_initialize()) {
    print_fail();
    pr_emerg("Failed to initialize FHS directories!\n");
    return 1;
}
print_ok();
```

Therefore the contradictory output could not occur: the failure path returned before reaching `print_ok()`.

The actual problem was the `return 1`.

`kmain()` does not have a normal caller to return to, so returning from this boot path can transfer execution to a garbage return address, producing the same class of kernel-mode fault tracked by #243.

This is also inconsistent with the FHS implementation itself: `fhs_initialize()` treats individual directory-creation failures as non-critical and is currently designed to continue initialization rather than fail the entire system. In the current implementation it always returns `0`, which also made the `kmain()` failure branch latent/dead under normal operation.

## Changes

* Remove the fatal `return 1` from the FHS initialization failure path.
* Report the failure with `print_fail()` and `pr_emerg()` and continue booting.
* Move `print_ok()` into an `else` branch so exactly one status is printed.
* Document why FHS initialization is treated as non-critical and why returning from this point is unsafe.

The resulting behavior is:

```text
fhs_initialize() == 0
    -> [ OK ]
    -> continue boot

fhs_initialize() != 0
    -> [FAIL]
    -> diagnostic
    -> continue boot
```

The patch is limited to `kernel/src/kernel.c`.

## Validation

* [x] `git diff --check`
* [x] Relevant build completed
* [x] Relevant automated tests completed
* [x] Failure path exercised directly
* [x] Verification scaffolding fully reverted

Validation details:

```text
Forced failure-path verification:
- temporarily changed fhs_initialize() to return 1
- rebuilt and booted the test image
- kmain's failure branch executed
- serial output contained:
    Failed to initialize FHS directories!
- boot continued past the FHS step into the remaining initialization
- runtests executed normally
- full userspace suite: 52/52 passed
- QEMU guest exit: 33

This directly verifies that an FHS failure no longer returns from kmain().
With the previous code, the same forced path would have taken the unsafe
return-to-garbage behavior described by #243.

Cleanup:
- temporary fhs_initialize() modification fully reverted
- final tree contains only the intended kernel.c change

Normal-path regression:
- canonical make qemu-test completed successfully
- QEMU guest exit: 33
- userspace suite: 52/52 passed
- qemu-test exit status: 0
- git diff --check clean
- working tree clean
```

## Scope

* [x] The change is limited to FHS boot-step error handling.
* [x] No FHS directory-creation semantics are changed.
* [x] The latent failure branch was exercised explicitly.
* [x] The inaccurate mechanism in the original issue report was corrected publicly before merge.

This PR does not make `fhs_initialize()` return failures that it currently suppresses. It only makes `kmain()` handle a future/non-zero return consistently with the subsystem's documented non-critical policy.

The broader early-boot return-to-garbage problem remains tracked separately by #243.

## Related issues

Fixes #248.

Related: #243.
