### PR TITLE
refactor(kernel): fix gid field typing and drop dead len check

### DIFF
--- a/kernel/inc/process/process.h
+++ b/kernel/inc/process/process.h
@@ -87,9 +87,9 @@ typedef struct task_struct {
     /// The Process Group Id of the process
     pid_t pgid;
     /// The Group ID (GID) of the process
-    pid_t rgid;
+    gid_t rgid;
     /// The effective Group ID (GID) of the process
-    pid_t gid;
+    gid_t gid;
     /// The User ID (UID) of the user owning the process.
     uid_t ruid;
     /// The effective User ID (UID) of the process.

--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -151,7 +151,7 @@ static int __load_executable(const char *path, task_struct *task, uint32_t *entr
     // The credentials are restored if the load fails: a failed execve must
     // leave the caller exactly as it was.
     uid_t saved_uid        = task->uid;
-    pid_t saved_gid        = task->gid;
+    gid_t saved_gid        = task->gid;
 start:
     pr_debug("__load_executable(`%s`, %p `%s`, %p)\n", path, task, task->name, entry);
     vfs_file_t *file = vfs_open(path, O_RDONLY, 0);
@@ -701,7 +701,7 @@ int sys_execve(pt_regs_t *f)
     mm_struct_t *new_mm = NULL;
     // Credentials are restored if any of the post-load steps fails.
     uid_t prev_uid      = current->uid;
-    pid_t prev_gid      = current->gid;
+    gid_t prev_gid      = current->gid;
     int ret             = __load_executable(filename, current, &entry, &new_mm);
     if (ret <= 0) {
         pr_err("Failed to load executable!\n");

--- a/kernel/src/sys/utsname.c
+++ b/kernel/src/sys/utsname.c
@@ -26,10 +26,6 @@ static inline int __gethostname(char *name, size_t len)
     if (!name) {
         return -EFAULT;
     }
-    // Check if len is negative.
-    if (len < 0) {
-        return -EINVAL;
-    }
     // Open the file.
     vfs_file_t *file = vfs_open("/etc/hostname", O_RDONLY, 0);
     if (file == NULL) {


### PR DESCRIPTION
## Summary

Clean up two type/validation inconsistencies found during the recent `utsname` and process review.

* Remove the unreachable `len < 0` validation from `__gethostname()`.
* Use `gid_t` rather than `pid_t` for process group-ID credential fields and their temporary snapshots.

Fixes #257.
Fixes #258.

## Problem / motivation

### #257 — unreachable hostname length validation

`__gethostname()` receives its length as a `size_t`:

```c
static inline int __gethostname(char *name, size_t len)
```

but previously contained:

```c
if (len < 0) {
    return -EINVAL;
}
```

Since `size_t` is unsigned, this condition can never be true. The branch was dead code, and its accompanying comment incorrectly suggested that negative lengths could reach the function and be rejected.

The only current caller passes `SYS_LEN`, so removing the check does not change runtime behavior.

### #258 — GID fields typed as process IDs

`task_struct` declared the real and effective group IDs as:

```c
pid_t rgid;
pid_t gid;
```

even though these fields represent group IDs and the tree provides the appropriate `gid_t` type.

This was inconsistent with the neighboring user-ID fields:

```c
uid_t ruid;
uid_t uid;
```

and propagated into credential snapshots used by the transactional `execve()` path.

`pgid` remains `pid_t`, since a process-group ID is correctly represented using the process-ID type.

At present, `pid_t` and `gid_t` are both `signed int`, so this is a type-correctness cleanup rather than a behavioral or ABI change.

## Changes

### `kernel/src/sys/utsname.c`

* Remove the impossible `len < 0` check.
* Remove the corresponding misleading comment.

### `kernel/inc/process/process.h`

Change:

```c
pid_t rgid;
pid_t gid;
```

to:

```c
gid_t rgid;
gid_t gid;
```

### `kernel/src/process/process.c`

Use `gid_t` for both credential snapshots that mirror `task->gid`:

```c
gid_t saved_gid;
gid_t prev_gid;
```

No credential semantics or `execve()` behavior are changed.

## Validation

* [x] `git diff --check`
* [x] Relevant build completed
* [x] Relevant automated tests completed
* [x] GID-related regression coverage completed

Validation details:

```text
Build:
- clean build completed successfully

Canonical regression:
- make qemu-test completed successfully
- QEMU guest exit: 33
- userspace suite: 52/52 passed

GID-related coverage:
- t_gid: passed
- t_groups: passed
- t_grp: passed

Static verification:
- git diff --check clean
- working tree clean
```

## Scope

* [x] Changes are limited to the two reported cleanup issues.
* [x] No runtime behavior is intentionally changed.
* [x] `pgid` remains correctly typed as `pid_t`.
* [x] No unrelated `utsname`, credential, or `execve()` changes are included.

The two issues are combined because both are small, behavior-neutral type/source correctness cleanups discovered during the same review pass, and together remain a narrowly scoped kernel cleanup.

## Related issues

Fixes #257.
Fixes #258.
