### PR TITLE
Fix/243 244 249 early boot failures

### DIFF
--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -39,6 +39,7 @@
 #include "sys/msg.h"
 #include "sys/sem.h"
 #include "sys/shm.h"
+#include "system/panic.h"
 #include "system/syscall.h"
 #include "version.h"
 
@@ -117,7 +118,10 @@ int kmain(boot_info_t *boot_informations)
     // Am I booted by a Multiboot-compliant boot loader?
     if (boot_info.magic != MULTIBOOT_BOOTLOADER_MAGIC) {
         printf("Invalid magic number: 0x%x\n", boot_info.magic);
-        return 1;
+        // NOTE: the test-run detection has not happened yet (the multiboot
+        // header cannot be trusted), so this panic cannot signal QEMU; it
+        // still beats returning to a garbage address.
+        kernel_panic("Invalid multiboot bootloader magic.");
     }
     // Set the initial esp.
     initial_esp = boot_info.stack_base;
@@ -159,7 +163,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize modules...");
     if (init_modules(boot_info.multiboot_header) < 0) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the modules.");
     }
     print_ok();
 
@@ -168,7 +172,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize physical memory manager...");
     if (!pmmngr_init(&boot_info)) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the physical memory manager.");
     }
     print_ok();
 
@@ -177,7 +181,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize slab...");
     if (kmem_cache_init() < 0) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the slab allocator.");
     }
     print_ok();
 
@@ -210,7 +214,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Relocate modules...");
     if (relocate_modules() < 0) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to relocate the modules.");
     }
     print_ok();
 
@@ -219,7 +223,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize paging...");
     if (paging_init(&boot_info) < 0) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize paging.");
     }
     print_ok();
 
@@ -228,7 +232,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize virtual memory mapping...");
     if (vmem_init() < 0) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the virtual memory mapping.");
     }
     print_ok();
 
@@ -255,8 +259,7 @@ int kmain(boot_info_t *boot_informations)
     pr_notice("Initialize ATA devices...\n");
     printf("Initialize ATA devices...");
     if (ata_initialize()) {
-        pr_emerg("Failed to initialize ATA devices!\n");
-        return 1;
+        kernel_panic("Failed to initialize the ATA devices.");
     }
     print_ok();
 
@@ -264,8 +267,7 @@ int kmain(boot_info_t *boot_informations)
     pr_notice("Initialize EXT2 filesystem...\n");
     printf("Initialize EXT2 filesystem...");
     if (ext2_initialize()) {
-        pr_emerg("Failed to initialize EXT2 filesystem!\n");
-        return 1;
+        kernel_panic("Failed to initialize the EXT2 filesystem.");
     }
     print_ok();
 
@@ -273,8 +275,7 @@ int kmain(boot_info_t *boot_informations)
     pr_notice("Mount EXT2 filesystem...\n");
     printf("Mount EXT2 filesystem...");
     if (vfs_mount("ext2", "/", "/dev/hda")) {
-        pr_emerg("Failed to mount EXT2 filesystem...\n");
-        return 1;
+        kernel_panic("Failed to mount the EXT2 filesystem.");
     }
     print_ok();
 
@@ -298,8 +299,7 @@ int kmain(boot_info_t *boot_informations)
     printf("    Initialize memory devices...");
     if (mem_devs_initialize()) {
         print_fail();
-        pr_emerg("Failed to initialize memory devices!\n");
-        return 1;
+        kernel_panic("Failed to initialize the memory devices.");
     }
     print_ok();
 
@@ -308,8 +308,7 @@ int kmain(boot_info_t *boot_informations)
     printf("    Initialize 'procfs'...");
     if (procfs_module_init()) {
         print_fail();
-        pr_emerg("Failed to register `procfs`!\n");
-        return 1;
+        kernel_panic("Failed to register `procfs`.");
     }
     print_ok();
 
@@ -317,8 +316,7 @@ int kmain(boot_info_t *boot_informations)
     pr_notice("    Mounting 'procfs'...\n");
     printf("    Mounting 'procfs'...");
     if (vfs_mount("procfs", "/proc", NULL)) {
-        pr_emerg("Failed to mount procfs at `/proc`!\n");
-        return 1;
+        kernel_panic("Failed to mount procfs at `/proc`.");
     }
     print_ok();
 
@@ -327,8 +325,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize video procfs file...");
     if (procv_module_init()) {
         print_fail();
-        pr_emerg("Failed to initialize `/proc/video`!\n");
-        return 1;
+        kernel_panic("Failed to initialize `/proc/video`.");
     }
     print_ok();
 
@@ -337,8 +334,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize system procfs file...");
     if (procs_module_init()) {
         print_fail();
-        pr_emerg("Failed to initialize proc system entries!\n");
-        return 1;
+        kernel_panic("Failed to initialize the proc system entries.");
     }
     print_ok();
 
@@ -347,8 +343,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize IPC information system...");
     if (procipc_module_init()) {
         print_fail();
-        pr_emerg("Failed to initialize the IPC information system!\n");
-        return 1;
+        kernel_panic("Failed to initialize the IPC information system.");
     }
     print_ok();
 
@@ -357,8 +352,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize IPC/SEM system...");
     if (sem_init()) {
         print_fail();
-        pr_emerg("Failed to initialize the IPC/SEM system!\n");
-        return 1;
+        kernel_panic("Failed to initialize the IPC/SEM system.");
     }
     print_ok();
 
@@ -367,8 +361,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize IPC/MSQ system...");
     if (msq_init()) {
         print_fail();
-        pr_emerg("Failed to initialize the IPC/MSQ system!\n");
-        return 1;
+        kernel_panic("Failed to initialize the IPC/MSQ system.");
     }
     print_ok();
 
@@ -377,8 +370,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize IPC/SHM system...");
     if (shm_init()) {
         print_fail();
-        pr_emerg("Failed to initialize the IPC/SHM system!\n");
-        return 1;
+        kernel_panic("Failed to initialize the IPC/SHM system.");
     }
     print_ok();
 
@@ -437,7 +429,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Init process management...");
     if (!init_tasking()) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize process management.");
     }
     print_ok();
 
@@ -447,7 +439,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize scheduler feedback system...");
     if (!scheduler_feedback_init()) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the scheduler feedback system.");
     }
     print_ok();
 #endif
@@ -457,7 +449,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize scheduler feedback system (2)...");
     if (procfb_module_init()) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the scheduler feedback system (2).");
     }
     print_ok();
 
@@ -471,14 +463,14 @@ int kmain(boot_info_t *boot_informations)
         printf("Creating runtests process...");
         if (process_create_init("/bin/runtests")) {
             print_fail();
-            return 1;
+            kernel_panic("Failed to create the runtests process.");
         }
     } else {
         pr_notice("Creating init process...\n");
         printf("Creating init process...");
         if (process_create_init("/bin/init")) {
             print_fail();
-            return 1;
+            kernel_panic("Failed to create the init process.");
         }
     }
     print_ok();
@@ -488,7 +480,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize floating point unit...");
     if (!fpu_install()) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the floating point unit.");
     }
     print_ok();
 
@@ -497,7 +489,7 @@ int kmain(boot_info_t *boot_informations)
     printf("Initialize signals...");
     if (!signals_init()) {
         print_fail();
-        return 1;
+        kernel_panic("Failed to initialize the signals.");
     }
     print_ok();
 
@@ -507,8 +499,7 @@ int kmain(boot_info_t *boot_informations)
 #ifdef ENABLE_KERNEL_TESTS
     extern int kernel_run_tests(void);
     if (kernel_run_tests() != 0) {
-        pr_emerg("Kernel tests failed!\n");
-        return 1;
+        kernel_panic("Kernel tests failed.");
     } else {
         pr_notice("All kernel tests passed!\n");
     }

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -125,6 +125,22 @@ int kmain(boot_info_t *boot_informations)
     dump_multiboot(boot_info.multiboot_header);
 
     //==========================================================================
+    // Detect the test-run mode as early as possible, before any subsystem
+    // that might fail: kernel_panic must know from the very beginning of
+    // the boot whether it has to signal QEMU's isa-debug-exit device,
+    // otherwise a fatal error in the early stages leaves the guest halted
+    // forever and the test wrapper waiting until its timeout (#244).
+    // The detection must only depend on the cmdline being present and equal
+    // to `runtests`: requiring an exact flags word ties the check to the
+    // specific bits the current GRUB happens to set, and any extra or
+    // missing bit would silently disable the test suite (#249).
+    // dump_multiboot above already dereferences the cmdline under the same
+    // flag check, so reading it here is equally safe.
+    runtests = bitmask_check(boot_info.multiboot_header->flags, MULTIBOOT_FLAG_CMDLINE) &&
+               (boot_info.multiboot_header->cmdline != 0) &&
+               (strcmp((char *)boot_info.multiboot_header->cmdline, "runtests") == 0);
+
+    //==========================================================================
     pr_notice("Initialize resource registry...\n");
     resource_register_init();
 
@@ -446,11 +462,10 @@ int kmain(boot_info_t *boot_informations)
     print_ok();
 
     //==========================================================================
-    // TODO: fix the hardcoded check for the flags set by GRUB
-    runtests = boot_info.multiboot_header->flags == 0x1a67 &&
-               bitmask_check(boot_info.multiboot_header->flags, MULTIBOOT_FLAG_CMDLINE) &&
-               strcmp((char *)boot_info.multiboot_header->cmdline, "runtests") == 0;
-
+    // The test-run mode was already detected at the beginning of kmain (see
+    // the comment there): every subsystem initialized above may fail and
+    // panic before reaching this point, and those panics must already know
+    // whether to signal QEMU's isa-debug-exit.
     if (runtests) {
         pr_notice("Creating runtests process...\n");
         printf("Creating runtests process...");


### PR DESCRIPTION
## Summary

Harden early boot failure handling and make test-run detection available before boot-time failures can occur.

This bundle:

* detects `runtests` near the beginning of `kmain()`;
* removes the brittle exact `0x1a67` multiboot-flags requirement;
* replaces fatal `return 1` paths in `kmain()` with stage-specific `kernel_panic()` calls.

As a result, test-mode boot failures now fail fast through `isa-debug-exit` instead of jumping to a garbage return address and potentially leaving QEMU halted until the wrapper timeout.

Fixes #243.
Fixes #244.
Fixes #249.

## Problem / motivation

These three issues form one early-boot failure chain.

### #243 — fatal boot paths returned from `kmain()`

Many boot initialization failures used:

```c
return 1;
```

from `kmain()`.

`kmain()` has no legitimate caller to return to at that stage. When one of these branches executed, control could jump to whatever value happened to be present on the boot stack.

The deterministic EXT2 mount-failure reproduction produced:

```text
Failed to mount EXT2 filesystem...
Page fault: 0x100036
EIP = 0x100036, CS = 0x8
PANIC: Page fault!
```

The actual subsystem failure was therefore obscured by a secondary kernel-mode fault.

### #244 — early panics did not terminate test QEMU

`kernel_panic()` only signals QEMU's `isa-debug-exit` device when the global `runtests` flag is set.

Previously that flag was initialized late in `kmain()`, after filesystem, memory, IPC, and other subsystem initialization.

Therefore an early panic occurred while `runtests == 0`:

```text
early boot failure
        |
        v
kernel_panic()
        |
        | runtests == 0
        v
halt loop
        |
        v
QEMU remains alive
        |
        v
run-qemu-test waits until timeout
```

A test failure could consequently consume the full wrapper timeout instead of returning the established panic exit code.

### #249 — test detection depended on an exact GRUB flags value

The old detection additionally required:

```c
boot_info.multiboot_header->flags == 0x1a67
```

even though it separately checked `MULTIBOOT_FLAG_CMDLINE`.

The exact flags word describes all information supplied by the bootloader, not just the command line. An unrelated bit being added or omitted by a different GRUB configuration could therefore silently disable test mode.

That failure would boot `/bin/init` instead of `/bin/runtests`, causing the test wrapper to wait indefinitely for an exit that would never occur.

## Changes

### Detect test mode at the beginning of `kmain()`

Immediately after `dump_multiboot()`, determine whether the boot command line is `runtests`:

```c
runtests =
    bitmask_check(
        boot_info.multiboot_header->flags,
        MULTIBOOT_FLAG_CMDLINE) &&
    (boot_info.multiboot_header->cmdline != 0) &&
    (strcmp(
        (char *)boot_info.multiboot_header->cmdline,
        "runtests") == 0);
```

This is early enough that subsequent subsystem failures can use the correct panic behavior.

`dump_multiboot()` already accesses the command line under the same multiboot flag, so the new detection remains inside the same established safety envelope.

### Remove the exact multiboot-flags requirement

Remove:

```c
flags == 0x1a67
```

and the associated TODO.

Test-mode selection now depends only on the information actually required:

* the command-line flag is present;
* the command-line address is non-zero;
* the command line equals `runtests`.

### Make fatal boot failures explicit

Replace fatal `return 1` branches throughout `kmain()` with stage-specific `kernel_panic()` calls.

Covered stages include:

* multiboot validation;
* module initialization and relocation;
* physical memory and slab initialization;
* paging and virtual-memory mapping;
* ATA initialization;
* EXT2 initialization and mount;
* memory devices;
* procfs registration and mount;
* proc modules;
* IPC semaphore, message-queue, and shared-memory initialization;
* process management;
* scheduler feedback;
* init/runtests process creation;
* FPU initialization;
* signal initialization;
* kernel tests.

For example:

```c
if (vfs_mount("ext2", "/", "/dev/hda")) {
    kernel_panic("Failed to mount the EXT2 filesystem.");
}
```

instead of returning from `kmain()`.

The unreachable trailing return after the scheduler transfer is intentionally left unchanged.

## Validation

* [x] `git diff --check`
* [x] Relevant build completed
* [x] Canonical automated test suite completed
* [x] Deterministic early-boot failure path exercised
* [x] Non-test boot path exercised

Validation details:

```text
Canonical test boot:
- make qemu-test completed successfully
- QEMU guest exit: 33
- userspace suite: 52/52 passed

This also verifies that early runtests detection still selects /bin/runtests:
a false-negative detection would have booted /bin/init and the test run
would not have completed normally.
```

```text
Deterministic fatal boot-path verification:
- replaced rootfs.img contents with a garbage superblock to force the
  EXT2 mount failure
- failure produced:
    PANIC: Failed to mount the EXT2 filesystem.
- zero secondary page faults
- wrapper returned QEMU panic exit 35 promptly

Previous behavior for the same failure:
- return from kmain()
- kernel-mode page fault at garbage EIP 0x100036
- early panic occurred before runtests detection
- QEMU remained halted until the wrapper timeout

After verification:
- original rootfs.img restored
- restoration verified by MD5
```

```text
Non-test boot verification:
- booted the normal cdrom.iso without the runtests command line
- kernel created /bin/init
- no runtests-mode messages observed
- no early isa-debug-exit termination
- normal interactive panic/halt semantics therefore remain unchanged
```

## Scope

* [x] Changes are limited to early boot failure handling and test-mode detection.
* [x] No subsystem initialization semantics are changed.
* [x] Test-mode panic semantics remain the existing `isa-debug-exit` behavior.
* [x] Normal non-test boot behavior does not acquire test-only QEMU exit semantics.
* [x] The unreachable post-scheduler tail remains out of scope.

This does not fix the underlying intermittent EXT2 mount failure tracked by #245.

It does reduce its operational impact: if that flake occurs during a test boot, CI now receives an immediate exit 35 with a stage-specific panic message instead of a secondary garbage-EIP page fault followed by a long timeout.

## Related issues

Fixes #243.
Fixes #244.
Fixes #249.

Related: #193, #245.
