### PR TITLE
fix(ext2): read sparse holes as zeros and return 0 at EOF

### DIFF
--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -1783,42 +1783,43 @@ ext2_allocate_inode_block(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t i
 /// @return the amount of data we read, or negative value for an error.
 static ssize_t ext2_read_inode_block(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t block_index, uint8_t *buffer)
 {
-    // Check if inode has no blocks allocated.
-    if (inode->blocks_count == 0) {
-        pr_debug("File has no allocated blocks (inode blocks count is zero)\n");
-        return 0;
+    // Every block covered by the file size is a legitimate data block:
+    // sparse files legally contain holes (a zero block pointer) inside
+    // `inode->size`, which must read as a block of zeros. Rejecting holes
+    // made any read touching them fail entirely (issue #192). Only blocks
+    // beyond the file size are invalid. Note that `inode->blocks_count`
+    // counts allocated blocks only, so it cannot be used as the upper
+    // bound here.
+    uint32_t max_blocks = inode->size / fs->block_size;
+    if ((inode->size % fs->block_size) != 0) {
+        max_blocks += 1;
     }
-
-    // Calculate allocated filesystem blocks from 512-byte sector count.
-    uint32_t allocated_fs_blocks = inode->blocks_count / fs->blocks_per_block_count;
-
     // Check if block index is out of range.
-    if (block_index >= allocated_fs_blocks) {
+    if (block_index >= max_blocks) {
         pr_err(
-            "Invalid block index: %u >= %u allocated blocks (inode->blocks_count=%u sectors, "
-            "blocks_per_block_count=%u, file_size=%u)\n",
-            block_index, allocated_fs_blocks, inode->blocks_count,
-            fs->blocks_per_block_count, inode->size);
+            "Invalid block index: %u >= %u blocks covered by the file size (file_size=%u)\n",
+            block_index, max_blocks, inode->size);
         return -1;
     }
 
     // Get the real block index
     uint32_t real_index = ext2_get_real_block_index(fs, inode, block_index);
 
-    // Note: real_index == 0 may indicate either:
-    // 1. An unallocated block (sparse file)
-    // 2. An actual error reading indirect blocks
-    // We can't distinguish at this point, but we should still try to read block 0
-    // (which is invalid and will fail in ext2_read_block anyway).
-    // This is better than returning -1 for valid sparse files.
+    // A resolved pointer of zero is a sparse hole: it has no block on disk
+    // and must read as zeros. Block zero is never a valid data block in
+    // ext2, and the metadata paths read their blocks through
+    // ext2_read_block directly, so zero here always means hole (#192).
+    if (real_index == 0) {
+        memset(buffer, 0, fs->block_size);
+        return fs->block_size;
+    }
 
     // Log the resolved block index (debug level)
 #ifdef EXT2_FULL_DEBUG
     pr_debug("ext2_read_inode_block(block: %4u, real: %4u)\n", block_index, real_index);
 #endif
 
-    // Read the block and return the result
-    // Note: ext2_read_block() will handle block_index 0 or invalid blocks appropriately
+    // Read the block and return the result.
     return ext2_read_block(fs, real_index, buffer);
 }
 
@@ -1893,11 +1894,28 @@ static ssize_t ext2_read_inode_data(
     size_t nbyte,
     char *buffer)
 {
+    // A read at or beyond the end of the file reads zero bytes: standard
+    // EOF semantics. Without this guard, an offset past `inode->size`
+    // either hit the unallocated tail blocks of the loop below (returning
+    // -1 at a legal EOF) or computed wrapping copy lengths in unsigned
+    // arithmetic (issue #242).
+    if ((uint64_t)offset >= (uint64_t)inode->size) {
+        return 0;
+    }
+    // A zero-length read copies nothing.
+    if (nbyte == 0) {
+        return 0;
+    }
     // Get the offset to the end of the portion we are reading.
     uint32_t end_offset  = (inode->size >= offset + nbyte) ? (offset + nbyte) : (inode->size);
-    // Convert the offset/size to some starting/end iblock numbers.
+    // Convert the offset/size to some starting/end iblock numbers. The end
+    // block is the one containing the last byte to read (end_offset - 1):
+    // when end_offset is an exact multiple of the block size, dividing
+    // end_offset directly would point one block past the data and leave
+    // end_size at zero, wrapping the copy length of the last block
+    // (issue #242).
     uint32_t start_block = offset / fs->block_size;
-    uint32_t end_block   = end_offset / fs->block_size;
+    uint32_t end_block   = (end_offset - 1) / fs->block_size;
     // What's the offset into the start block.
     uint32_t start_off   = offset % fs->block_size;
     // How much bytes to read for the end block.

--- a/userspace/tests/t_shebang.c
+++ b/userspace/tests/t_shebang.c
@@ -250,13 +250,19 @@ int main(int argc, char *argv[])
     unlink(SCRIPT_DIR "t_shebang_loop.sh");
 
     // ------------------------------------------------------------------
-    // 8) A script whose shebang read fails (the staged file has a sparse
-    //    hole inside the first 4098 bytes, so the read at offset 2 fails;
-    //    this depends on the current ext2 sparse-hole behavior of #192).
-    //    The read result used to be used as a buffer index unchecked.
+    // 8) A script with a sparse hole right after the shebang line (the
+    //    staged file is `#!/bin/echo hello\n` followed by a zero tail,
+    //    which mke2fs stores as holes). While #192 made any read touching
+    //    a hole fail (this case used to expect EIO), the shebang read now
+    //    succeeds. The outcome of the exec itself is governed by the open
+    //    #222 bug (the whole shebang line is used as the interpreter
+    //    path, so `/bin/echo hello` yields ENOENT); once #222 is fixed
+    //    the interpreter resolves and the script runs (0). Either way it
+    //    must no longer fail with a read error.
     // ------------------------------------------------------------------
     res = run_script(SPARSE_SCRIPT);
-    if (!check_post_teardown_failure(res, EIO, "sparse script")) {
+    if ((res != 0) && (res != ENOENT)) {
+        syslog(LOG_ERR, "[t_shebang] sparse script: unexpected exec outcome (%d)", res);
         ++failures;
     }
 


### PR DESCRIPTION
## Summary

Fix two related boundary defects in the EXT2 read path:

* sparse holes inside a file now read as zero-filled data instead of failing;
* reads at or beyond EOF now return zero correctly and no longer compute invalid block/copy ranges.

The existing sparse-script regression in `t_shebang` is also updated because it previously depended on the broken sparse-hole behavior.

Fixes #192.
Fixes #242.

## Problem / motivation

### #192 — sparse holes were treated as invalid blocks

EXT2 sparse files may contain a zero block pointer inside the logical file size. Such a block is a hole and must read as zeros.

Previously, `ext2_read_inode_block()` validated the requested logical block against the number of physically allocated blocks.

That is incorrect for sparse files: a file can logically cover more blocks than it physically allocates.

After resolving the logical block, a sparse hole produced a physical block index of `0`, which eventually reached `ext2_read_block()` and failed as an invalid block.

This made any read touching a hole fail entirely.

### #242 — EOF reads could enter invalid block arithmetic

`ext2_read_inode_data()` did not reject reads whose offset was already at or beyond `inode->size`.

Depending on the offset and file layout, this could cause:

* reads past EOF to return bogus negative values;
* unsigned copy-length calculations to wrap;
* reads exactly at block-aligned EOF to attempt the next block and return `-1` instead of `0`.

There was also a related end-block calculation problem for reads ending exactly on a block boundary:

```c
end_block = end_offset / block_size;
```

When `end_offset` was block-aligned, this selected the block after the final byte actually requested.

## Changes

### Sparse-file reads

`ext2_read_inode_block()` now:

* derives the valid logical block count from `inode->size`, not `inode->blocks_count`;
* treats every block covered by the logical file size as a valid file block;
* interprets a resolved block pointer of `0` as a sparse hole;
* fills the destination block with zeros instead of attempting to read physical block zero.

This preserves the distinction between:

```text
logical block inside i_size + no physical allocation
    -> sparse hole
    -> zero-filled data

logical block beyond i_size
    -> invalid block request
    -> error
```

### EOF handling

`ext2_read_inode_data()` now returns `0` immediately when:

```c
offset >= inode->size
```

or when:

```c
nbyte == 0
```

The end block is now calculated from the last byte actually included in the read:

```c
end_block = (end_offset - 1) / fs->block_size;
```

so an exact block-boundary end no longer advances into the following block.

### `t_shebang`

The sparse-script case previously expected `EIO` because its shebang read crossed a sparse hole and therefore exercised #192.

With sparse reads fixed, that I/O failure is no longer valid behavior.

The test now accepts the outcomes that can legitimately follow a successful sparse-file read:

* `ENOENT` with the current #222 interpreter-line parsing bug;
* success once #222 is fixed.

It specifically no longer accepts a sparse-read failure.

## Validation

* [x] `git diff --check`
* [x] Relevant build completed
* [x] Relevant automated tests completed
* [x] Sparse-hole behavior reproduced before the fix
* [x] EOF boundary behavior reproduced before the fix
* [x] Temporary regression scaffolding fully reverted

Validation details:

```text
Pre-fix targeted reproduction:
- staged a file containing four 0xAB data blocks followed by a sparse hole
- confirmed the hole in the generated EXT2 image with debugfs

Observed before the fix:
- reading the sparse hole failed:
    read -> -1
    errno -> 1
    Invalid block index: 4 >= 4
- read exactly at aligned EOF returned -1
- read past EOF returned -1

All three targeted failure modes reproduced in-guest.
```

```text
Post-fix targeted verification:
- sparse hole read returned zero-filled data
- read at aligned EOF returned 0
- read past EOF returned 0
- temporary regression test passed

Temporary full suite:
- 53/53 passed
```

```text
Final regression after removing temporary scaffolding:
- canonical make qemu-test completed successfully
- QEMU guest exit: 33
- userspace suite: 52/52 passed
- updated t_shebang passed
- git diff --check clean
- working tree clean
```

## Scope

* [x] Changes are limited to EXT2 read semantics and the existing regression expectation affected by them.
* [x] Sparse-file write behavior is unchanged.
* [x] No general VFS read semantics are changed.
* [x] The unrelated interpreter-argument behavior remains tracked by #222.
* [x] Temporary targeted test scaffolding was removed before the final regression run.

This fixes the EXT2 root cause originally tracked by #192. The historical secondary `execve()` crash propagation described there has already been addressed separately by the transactional executable-loading work.

The unrelated test-address randomization and low-user-address mapping problems discovered during verification are intentionally left out of this change and will be tracked separately.

## Related issues

Fixes #192.
Fixes #242.

Related: #56, #222.
