### PR TITLE
fix(slab): fix KMEM_TRACE resource registration

### DIFF
--- a/kernel/src/mem/alloc/slab.c
+++ b/kernel/src/mem/alloc/slab.c
@@ -458,7 +458,7 @@ int kmem_cache_init(void)
     list_head_init(&kmem_caches_list);
 
 #ifdef ENABLE_KMEM_TRACE
-    ENABLE_EXT2_TRACE = register_resource("kmem");
+    resource_id = register_resource("kmem");
 #endif
 
     // Create a cache to store metadata about kmem_cache_t structures.


### PR DESCRIPTION
## Summary

With `ENABLE_KMEM_TRACE=ON`, the kernel failed to compile because the trace init block in `kmem_cache_init()` assigned the trace resource ID to the wrong identifier: `ENABLE_EXT2_TRACE`, a CMake option macro, instead of the static `resource_id` declared for that purpose.

The fix stores the result of `register_resource("kmem")` in the existing `resource_id`, which is what the kmalloc/kfree trace points already consume. This matches the pattern used by the other trace options (`vfs.c` under `ENABLE_FILE_TRACE`, `ext2.c` under `ENABLE_EXT2_TRACE`).

## Problem / motivation

```text
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_KMEM_TRACE=ON
make -C build kernel
```

failed on `develop` with:

```text
kernel/src/mem/alloc/slab.c:461:5: error: 'ENABLE_EXT2_TRACE' undeclared (first use in this function); did you mean 'ENABLE_KMEM_TRACE'?
```

so the kmalloc/kfree tracing infrastructure was unusable without hand-patching the line.

## Changes

- `kernel/src/mem/alloc/slab.c`: one line in `kmem_cache_init()`, `ENABLE_EXT2_TRACE = register_resource("kmem")` → `resource_id = register_resource("kmem")`.

The default build is untouched: the line sits inside `#ifdef ENABLE_KMEM_TRACE`, which is `OFF` by default.

## Validation

* [x] Failure reproduced on `develop` with the exact compile error from the issue
* [x] Trace-enabled build (`-DENABLE_KMEM_TRACE=ON`): all targets build
* [x] `make qemu-test` under the trace build: 53/53 tests, 0 failures
* [x] kmalloc/kfree tracing confirmed actually emitted (566 `kmalloc 0x…` and 560 `kfree 0x…` lines plus `[RESREG]` resource-usage reports in the serial log)
* [x] Serial/test logs contain no `PANIC`
* [x] Default trace-disabled build unchanged and passing
* [x] `git diff --check` clean

## Related issues

Fixes #228