### PR TITLE
fix(build): fix option validation for SCHEDULER_TYPE, KEYMAP_TYPE and EMULATOR_OUTPUT_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ set(EMULATOR_OUTPUT_TYPE "OUTPUT_STDIO" CACHE STRING "Chose the type of emulator
 set_property(CACHE EMULATOR_OUTPUT_TYPE PROPERTY STRINGS ${EMULATOR_OUTPUT_TYPES})
 # Check which emulator output option is currently active.
 list(FIND EMULATOR_OUTPUT_TYPES ${EMULATOR_OUTPUT_TYPE} INDEX)
-if(index EQUAL -1)
+if(INDEX EQUAL -1)
     message(FATAL_ERROR "Emulator output type ${EMULATOR_OUTPUT_TYPE} is not valid.")
 else()
     message(STATUS "Setting emulator output type to ${EMULATOR_OUTPUT_TYPE}.")

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -167,7 +167,7 @@ set(SCHEDULER_TYPE "SCHEDULER_RR" CACHE STRING "Chose the type of scheduler: ${S
 set_property(CACHE SCHEDULER_TYPE PROPERTY STRINGS ${SCHEDULER_TYPES})
 # Check which scheduler is currently active and export the related macro.
 list(FIND SCHEDULER_TYPES ${SCHEDULER_TYPE} INDEX)
-if(index EQUAL -1)
+if(INDEX EQUAL -1)
     message(FATAL_ERROR "Scheduler type ${SCHEDULER_TYPE} is not valid.")
 else()
     # Add the define stating which scheduler is currently active.
@@ -185,7 +185,7 @@ set(KEYMAP_TYPE "KEYMAP_US" CACHE STRING "Chose the type of keyboard mapping: ${
 set_property(CACHE KEYMAP_TYPE PROPERTY STRINGS ${KEYMAP_TYPES})
 # Check which keyboard mapping is currently active and export the related macro.
 list(FIND KEYMAP_TYPES ${KEYMAP_TYPE} INDEX)
-if(index EQUAL -1)
+if(INDEX EQUAL -1)
     message(FATAL_ERROR "keyboard mapping ${KEYMAP_TYPE} is not valid.")
 else()
     # Add the define stating which keyboard mapping is currently active.


### PR DESCRIPTION
## Summary

The CMake option-validation guards for `SCHEDULER_TYPE`, `KEYMAP_TYPE` and `EMULATOR_OUTPUT_TYPE` stored the `list(FIND ...)` result in `INDEX` but tested a variable named `index`. CMake variable names are case-sensitive and `index` is never `set()`, so `if(index EQUAL -1)` was always false: every `FATAL_ERROR` was dead code and invalid values were accepted silently at configure time.

The fix changes the three tests to `if(INDEX EQUAL -1)`.

## Problem / motivation

Reproduced on `develop`:

```text
$ cmake -S . -B build -DSCHEDULER_TYPE=SCHEDULER_BOGUS
-- Setting scheduler type to SCHEDULER_BOGUS.
```

Same silent acceptance for `KEYMAP_TYPE=KEYMAP_BOGUS` and `EMULATOR_OUTPUT_TYPE=OUTPUT_BOGUS`.

Consequences per option:

- `SCHEDULER_TYPE`: the build failed only later, after compiling most of the kernel, with a confusing `#error` from the scheduler scaffolding.
- `KEYMAP_TYPE`: `USE_<bogus>` matched no `#ifdef`, silently falling back to the default keymap.
- `EMULATOR_OUTPUT_TYPE`: the consumer `if`/`elseif` chain has no `else`, so an invalid value added no `-serial` flag and QEMU ran with no serial output.

## Changes

- `CMakeLists.txt`: `if(index EQUAL -1)` → `if(INDEX EQUAL -1)` for `EMULATOR_OUTPUT_TYPE`.
- `kernel/CMakeLists.txt`: same one-token fix for `SCHEDULER_TYPE` and `KEYMAP_TYPE`.

Three instances of the same typo, fixed together as suggested in the issue. The later-added `VIDEO_TYPE` guard already used a consistently cased variable (`VIDEO_TYPE_INDEX`) and is correct.

## Validation

* [x] Failure reproduced on `develop`: all three invalid values accepted at configure time
* [x] Each invalid value now stops configuration with the intended `CMake Error` and exit code 1
* [x] All eleven valid values (6 scheduler, 3 keymap, 2 emulator output) still configure cleanly with the correct `STATUS` message
* [x] Default build builds and `make qemu-test` passes 53/53 with 0 panics
* [x] Alternate configuration (`Release` + `KEYMAP_IT`) builds cleanly
* [x] `git diff --check` clean

```text
Post-fix configure-time rejection:
- SCHEDULER_TYPE=SCHEDULER_BOGUS     -> CMake Error: Scheduler type SCHEDULER_BOGUS is not valid. (exit 1)
- KEYMAP_TYPE=KEYMAP_BOGUS           -> CMake Error: keyboard mapping KEYMAP_BOGUS is not valid. (exit 1)
- EMULATOR_OUTPUT_TYPE=OUTPUT_BOGUS  -> CMake Error: Emulator output type OUTPUT_BOGUS is not valid. (exit 1)

Runtime:
- make qemu-test: 53 tests, 0 failures, 0 PANIC in serial.log and test.log
```

Note: a `Release` + `SCHEDULER_PRIORITY` build fails inside `scheduler_algorithm.c` scaffolding, byte-identical to plain `develop` — that is the pre-existing #214 and is untouched by this change.

## Related issues

Closes #215

Related: #214 (scheduler scaffolding, separate), #205 (tracking).