### PR TITLE
fix(test): map interrupted run-qemu-test runs to a failing exit code

### DIFF
--- a/scripts/run-qemu-test
+++ b/scripts/run-qemu-test
@@ -119,6 +119,12 @@ echo "===================================================="
 # Any other exit code is a failure (timeout, QEMU error, etc.)
 if [ "${EXIT_CODE}" -ne 33 ]; then
     echo "Test run failed or timed out (exit code: ${EXIT_CODE})"
+    # QEMU also exits 0 on a graceful SIGINT shutdown (an interrupted run), and
+    # 0 must not become this script's success code. Map only that corner to 1;
+    # the informative codes (35 panic, 124 timeout, ...) pass through as they are.
+    if [ "${EXIT_CODE}" -eq 0 ]; then
+        EXIT_CODE=1
+    fi
     exit "${EXIT_CODE}"
 fi
 


### PR DESCRIPTION
## Summary

An interrupted `run-qemu-test` run could exit 0. When SIGINT reaches the wrapper's whole process group (terminal Ctrl-C semantics), QEMU treats SIGINT as a graceful shutdown request and exits with status 0; the failure branch then did `exit "${EXIT_CODE}"`, propagating QEMU's 0 as the wrapper's success code — printing a failure message while reporting success to any caller checking the exit code.

The fix maps only that 0 corner to 1; every other code (35 panic, 124 timeout, …) passes through unchanged.

## Problem / motivation

Reproduced on `develop` @ `65caf8d` (the issue's method: `setsid scripts/run-qemu-test build 600 … &`, then `kill -INT -- -<pgid>`):

```text
QEMU finished with exit code: 0
Test run failed or timed out (exit code: 0)
WRAPPER_EXIT=0
```

The wrapper's own INT trap (added after the issue was filed) does not cover this case: a wrapper started as a background job inherits SIGINT ignored per the POSIX async-list rule, and a non-interactive shell cannot re-arm an inherited `SIG_IGN`. Verified on the live process during the interrupted run:

```text
/proc/<wrapper>/status: SigIgn: 0000000000000006   # INT | QUIT ignored
```

while QEMU, whose handling `timeout` resets, still honors the signal and shuts down gracefully.

## Changes

- `scripts/run-qemu-test`: inside the `!= 33` failure branch, if `EXIT_CODE` is 0 set it to 1 before `exit`. Six added lines, no other behavior changed: 33 still proceeds to backend check and TAP validation, and non-zero codes keep their informative values.

## Validation

* [x] Defect reproduced on `develop` before the change (exit 0, message above)
* [x] Interrupted path after the fix (same group-SIGINT reproduction): exit 1, same diagnostics
* [x] Foreground Ctrl-C equivalent (wrapper SIGINT trappable): exit 130 via the existing trap — unchanged, never reaches the fixed branch
* [x] Interruption via SIGTERM to the group: exit 143, no stray streamer processes
* [x] Genuine timeout (`TIMEOUT=5`): exit 124 preserved
* [x] Normal path: `make qemu-test` → `Test run completed successfully`, 53/53 TAP ok, 0 `PANIC` in serial.log and test.log
* [x] `bash -n`, `git diff --check` clean

Signal/process-group note: all interruption checks deliver the signal to the wrapper's *entire* process group (`kill -<sig> -- -<pgid>` over the session the wrapper leads), which is what a terminal Ctrl-C does to a foreground group — not a signal to the wrapper alone.

## Related issues

Closes #246

Related: #193 (the panic→35 mapping this completes), #247 (portability of this script's GNU tools).