### PR TITLE
fix(kernel): return -errno from sys_execve early failure paths

### DIFF
--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -633,7 +633,7 @@ int sys_execve(pt_regs_t *f)
     char *filename = (char *)f->ebx;
     if (filename == NULL) {
         pr_err("Received NULL filename.\n");
-        return -1;
+        return -EFAULT;
     }
     // Get the arguments
     origin_argv = (char **)f->ecx;
@@ -642,11 +642,11 @@ int sys_execve(pt_regs_t *f)
     // Check the argument, the environment, and that at least the name is provided.
     if (origin_argv == NULL) {
         pr_err("sys_execve failed: must provide argv.\n");
-        return -1;
+        return -EFAULT;
     }
     if (origin_argv[0] == NULL) {
         pr_err("sys_execve failed: must provide the name.\n");
-        return -1;
+        return -EINVAL;
     }
     if (origin_envp == NULL) {
         // We allow a NULL environment, using a default, for macOS compatibility
@@ -675,7 +675,7 @@ int sys_execve(pt_regs_t *f)
             "Failed to count required memory to store arguments and "
             "environment (%d + %d).\n",
             argv_bytes, envp_bytes);
-        return -1;
+        return -E2BIG;
     }
     void *args_mem = kmalloc(argv_bytes + envp_bytes);
     if (!args_mem) {
@@ -683,7 +683,7 @@ int sys_execve(pt_regs_t *f)
             "Failed to allocate memory for arguments and environment %d (%d + "
             "%d).\n",
             argv_bytes + envp_bytes, argv_bytes, envp_bytes);
-        return -1;
+        return -ENOMEM;
     }
     // Copy the arguments.
     uint32_t args_mem_ptr = (uint32_t)args_mem + (argv_bytes + envp_bytes);

--- a/userspace/tests/t_execve_fail.c
+++ b/userspace/tests/t_execve_fail.c
@@ -123,6 +123,42 @@ static int check_early_failures(pid_t expected_pid)
     char *argv_foo[2]  = {"t_execve_fail", NULL};
     char *envp_none[1] = {NULL};
 
+    // A NULL filename must give EFAULT (#238: used to be EPERM).
+    errno = 0;
+    if (execve(NULL, argv_foo, envp_none) != -1) {
+        syslog(LOG_ERR, "[t_execve_fail] execve of NULL filename unexpectedly succeeded");
+        return -1;
+    }
+    if (errno != EFAULT) {
+        syslog(LOG_ERR, "[t_execve_fail] execve of NULL filename: expected EFAULT, got %s", strerror(errno));
+        return -1;
+    }
+
+    // A NULL argv must give EFAULT (#238: used to be EPERM).
+    errno = 0;
+    if (execve("/bin/echo", NULL, envp_none) != -1) {
+        syslog(LOG_ERR, "[t_execve_fail] execve with NULL argv unexpectedly succeeded");
+        return -1;
+    }
+    if (errno != EFAULT) {
+        syslog(LOG_ERR, "[t_execve_fail] execve with NULL argv: expected EFAULT, got %s", strerror(errno));
+        return -1;
+    }
+
+    // An argv with no entries at all (argv[0] == NULL) must give EINVAL
+    // (#238: used to be EPERM): the address is valid and readable, but this
+    // kernel requires at least the program name.
+    char *argv_empty[1] = {NULL};
+    errno               = 0;
+    if (execve("/bin/echo", argv_empty, envp_none) != -1) {
+        syslog(LOG_ERR, "[t_execve_fail] execve with empty argv unexpectedly succeeded");
+        return -1;
+    }
+    if (errno != EINVAL) {
+        syslog(LOG_ERR, "[t_execve_fail] execve with empty argv: expected EINVAL, got %s", strerror(errno));
+        return -1;
+    }
+
     // A file that does not exist must give ENOENT.
     errno = 0;
     if (execve("/no/such/file", argv_foo, envp_none) != -1) {


### PR DESCRIPTION
## Summary

Five early exits in `sys_execve()` returned the literal `-1` instead of `-errno`. Because `-1` falls inside the kernel-error window the libc wrapper checks, `__syscall_set_errno` mapped it to `errno = 1`: every one of these failures surfaced to userspace as `EPERM` — a `NULL` filename reported "Operation not permitted" instead of `EFAULT`.

Each path now returns the errno its own semantics call for.

## Problem / motivation

All five `return -1` paths from the issue are still present on current `develop` (`756ad8a`), unchanged by the transactional-execve work. In-guest reproduction on the unfixed kernel, via the new assertions in `t_execve_fail`:

```text
[SERIAL] [t_execve_fail] execve of NULL filename: expected EFAULT, got Operation not permitted
[TEST]   not ok 9 - t_execve_fail: Exit: 1
53 tests, 1 failures.
```

## Changes

`kernel/src/process/process.c`, errno values only — control flow, checks, and every other statement untouched:

| Path | Before | After | Rationale |
|---|---|---|---|
| `filename == NULL` | `-1` → EPERM | `-EFAULT` | bad address |
| `origin_argv == NULL` | `-1` → EPERM | `-EFAULT` | bad vector address |
| `origin_argv[0] == NULL` | `-1` → EPERM | `-EINVAL` | address valid and readable; the value violates this kernel's requirement that argv carry at least the name |
| `argv/envp byte count < 0` | `-1` → EPERM | `-E2BIG` | the count can only go negative by overflowing the int total — the argument list is too long |
| `args_mem` allocation failure | `-1` → EPERM | `-ENOMEM` | matches the interpreter paths in the same function, which already return `-ENOMEM` |

The choice per path is derived from current code semantics rather than a mechanical replacement; the issue allowed EFAULT *or* EINVAL for the vector cases and EINVAL is the accurate one for the empty-vector value check.

Explicitly out of scope, unchanged: user-pointer validation (#191), bounding the argv/envp walks / ARG_MAX (#196), and the unbounded `strcpy`s after these checks. No ARG_MAX is introduced — the `-E2BIG` is only the correct errno for the existing (overflow-only) byte-count check.

## Validation

* [x] All five paths verified still present on current `develop` before editing
* [x] In-guest reproduction before the fix: `t_execve_fail` failed with `expected EFAULT, got Operation not permitted`, TAP `not ok 9`, suite `53 tests, 1 failures`
* [x] Focused regression after the fix: `ok 9 - t_execve_fail`, child reaches end (`process survived the failed execve`), final successful `execve("/bin/echo", …)` still works
* [x] Full `make qemu-test`: 53/53, 0 failures, `Test run completed successfully`
* [x] 0 `PANIC` in serial.log and test.log
* [x] `git diff --check` clean; only the two intended files changed

`ENOMEM`/`E2BIG` have no deterministic in-guest trigger and the tree has no fault-injection mechanism, so no artificial hooks were added; they are covered by inspection and symmetry with the interpreter paths.

## Related issues

Closes #238

Out of scope by design: #196, #191, #231.