### PR TITLE
fix(kernel): bound sys_execve string copies from user memory (replacement for #190)

### DIFF
--- a/kernel/inc/process/process.h
+++ b/kernel/inc/process/process.h
@@ -8,12 +8,15 @@
 #include "bits/termios-struct.h"
 #include "devices/fpu.h"
 #include "drivers/keyboard/keyboard.h"
+#include "limits.h"
 #include "mem/paging.h"
 #include "stdbool.h"
 #include "system/signal.h"
 
 /// The maximum length of a name for a task_struct.
-#define TASK_NAME_MAX_LENGTH 100
+/// NAME_MAX is the same bound sys_execve already applies to the argv[0] copy
+/// buffer, so a name that survives execve always fits this field.
+#define TASK_NAME_MAX_LENGTH NAME_MAX
 
 /// The default dimension of the stack of a process (1 MByte).
 #define DEFAULT_STACK_SIZE (1 * M)

--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -341,9 +341,12 @@ static inline task_struct *__alloc_task(task_struct *source, task_struct *parent
     proc->se.utilization_factor = 0;
     // Initialize the exit code of the process.
     proc->exit_code             = 0;
-    // Copy the name.
+    // Copy the name, bounded to the field: sources are kernel literals and
+    // parent names already bounded by sys_execve, this keeps the copy safe
+    // even if a future caller grows the name.
     if (name) {
-        strcpy(proc->name, name);
+        strncpy(proc->name, name, sizeof(proc->name) - 1);
+        proc->name[sizeof(proc->name) - 1] = '\0';
     }
     // Do not touch the task's segments.
     proc->mm       = NULL;
@@ -659,9 +662,22 @@ int sys_execve(pt_regs_t *f)
         origin_envp = default_env;
     }
 
-    // Save the name of the process.
-    strcpy(name_buffer, origin_argv[0]);
-    // Save the filename.
+    // A filename that does not fit a PATH_MAX buffer cannot name any file,
+    // and truncating it would target the wrong executable: reject it instead
+    // of copying it. The strnlen walk is bounded to PATH_MAX.
+    if (strnlen(filename, PATH_MAX) >= PATH_MAX) {
+        pr_err("sys_execve failed: filename is longer than PATH_MAX.\n");
+        return -ENAMETOOLONG;
+    }
+    // Save the name of the process. argv[0] is a raw user string: copy at
+    // most what name_buffer can hold minus its terminator, truncating like
+    // Linux truncates comm, so a long argv[0] neither fails the exec nor
+    // overflows kernel state.
+    size_t name_len = strnlen(origin_argv[0], sizeof(name_buffer) - 1);
+    memcpy(name_buffer, origin_argv[0], name_len);
+    name_buffer[name_len] = '\0';
+    // Save the filename: the check above bounds it to PATH_MAX - 1
+    // characters, so it always fits with its terminator.
     strcpy(saved_filename, filename);
 
     // == COPY PROGRAM ARGUMENTS ==============================================
@@ -807,8 +823,10 @@ int sys_execve(pt_regs_t *f)
     // Enable the interrupts.
     current->thread.regs.eflags  = current->thread.regs.eflags | EFLAG_IF;
 
-    // Change the name of the process.
-    strcpy(current->name, name_buffer);
+    // Change the name of the process. name_buffer is bounded and terminated
+    // above; the bounded copy keeps this safe even if that ever changes.
+    strncpy(current->name, name_buffer, sizeof(current->name) - 1);
+    current->name[sizeof(current->name) - 1] = '\0';
 
     // Free the temporary args memory.
     kfree(args_mem);

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -32,6 +32,7 @@ static char *all_tests[] = {
     "t_dup",
     "t_environ",
     "t_exec",
+    "t_execve_bounds",
     "t_execve_fail",
     "t_elf_short",
     "t_exit",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_LIST
     t_abort.c
     t_shmget.c
     t_exec.c
+    t_execve_bounds.c
     t_execve_fail.c
     t_elf_short.c
     t_gid.c

--- a/userspace/tests/t_execve_bounds.c
+++ b/userspace/tests/t_execve_bounds.c
@@ -1,0 +1,249 @@
+/// @file t_execve_bounds.c
+/// @brief Regression test for #190: sys_execve must copy the user-provided
+/// argv[0] and filename into kernel buffers without overflowing them, must
+/// keep the resulting task name NUL-terminated, and must reject filenames
+/// that do not fit PATH_MAX instead of truncating them.
+/// @details The original defect: `strcpy(name_buffer, argv[0])` and
+/// `strcpy(saved_filename, filename)` copied raw user strings into fixed
+/// kernel-stack buffers, giving kernel-stack overflow with EIP control
+/// (demonstrated in the #190 PoC). The name is now truncated like Linux
+/// truncates comm, and over-long filenames fail with ENAMETOOLONG.
+/// The test re-executes itself with crafted argv[0] lengths and checks, via
+/// /proc/<pid>/cmdline (which reports task->name), that the name landed
+/// bounded and NUL-terminated at the exact boundaries.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The longest name sys_execve keeps after truncation: NAME_MAX - 1
+/// characters plus the terminator.
+#define MAX_NAME_CHARS 254
+
+/// Path of this test binary inside the guest.
+#define SELF_PATH "/bin/tests/t_execve_bounds"
+
+/// A filename longer than any real path, built once.
+static char long_filename[4096 + 1];
+
+/// @brief Builds a string of `len` identical characters, NUL-terminated.
+/// @param buf the destination, at least len + 1 bytes.
+/// @param len the length of the filler run.
+/// @param c the filler character.
+static void fill_string(char *buf, size_t len, char c)
+{
+    memset(buf, c, len);
+    buf[len] = '\0';
+}
+
+/// @brief Reads the whole content of a proc file.
+/// @param path the file to read.
+/// @param buf the destination buffer.
+/// @param bufsize the size of buf.
+/// @return the number of bytes read, or -1 on failure.
+static int read_all(const char *path, char *buf, size_t bufsize)
+{
+    int fd = open(path, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_execve_bounds] open %s: %s", path, strerror(errno));
+        return -1;
+    }
+    unsigned total = 0;
+    for (;;) {
+        ssize_t n = read(fd, buf + total, bufsize - total - 1);
+        if (n < 0) {
+            syslog(LOG_ERR, "[t_execve_bounds] read %s: %s", path, strerror(errno));
+            close(fd);
+            return -1;
+        }
+        if (n == 0) {
+            break;
+        }
+        total += (unsigned)n;
+    }
+    buf[total] = '\0';
+    close(fd);
+    return (int)total;
+}
+
+/// @brief Phase 2: reached through a fresh execve with a crafted argv[0].
+/// Verifies that the kernel kept the task name bounded and terminated.
+/// @param argv0 the argv[0] this image was started with.
+/// @return 0 on success, 1 on failure.
+static int phase2(const char *argv0)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/cmdline", getpid());
+    char cmdline[512];
+    int n = read_all(path, cmdline, sizeof(cmdline));
+    if (n < 0) {
+        return 1;
+    }
+    size_t original = strlen(argv0);
+    size_t expected = (original > MAX_NAME_CHARS) ? MAX_NAME_CHARS : original;
+    if ((size_t)n != expected) {
+        syslog(
+            LOG_ERR, "[t_execve_bounds] cmdline is %d chars, expected %u "
+                     "(argv[0] was %u chars)",
+            n, (unsigned)expected, (unsigned)original);
+        return 1;
+    }
+    for (size_t i = 0; i < expected; ++i) {
+        if (cmdline[i] != argv0[i]) {
+            syslog(LOG_ERR, "[t_execve_bounds] cmdline differs from argv[0] at %u", (unsigned)i);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/// @brief Re-executes this binary with an argv[0] of the given length and
+/// requires the child (phase 2) to verify the truncated name.
+/// @param len the length of the crafted argv[0].
+/// @return 0 on success, -1 on failure.
+static int check_name_boundary(size_t len)
+{
+    char name[512];
+    if (len >= sizeof(name)) {
+        return -1;
+    }
+    fill_string(name, len, 'A');
+    char *argv_child[3] = {name, "phase2", NULL};
+    char *envp_none[1]  = {NULL};
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        syslog(LOG_ERR, "[t_execve_bounds] fork: %s", strerror(errno));
+        return -1;
+    }
+    if (pid == 0) {
+        execve(SELF_PATH, argv_child, envp_none);
+        // Getting here means the execve itself failed.
+        syslog(LOG_ERR, "[t_execve_bounds] self-exec with %u-char argv[0]: %s", (unsigned)len, strerror(errno));
+        exit(99);
+    }
+    int status;
+    if (waitpid(pid, &status, 0) == -1) {
+        syslog(LOG_ERR, "[t_execve_bounds] waitpid: %s", strerror(errno));
+        return -1;
+    }
+    if (WIFSIGNALED(status)) {
+        syslog(LOG_ERR, "[t_execve_bounds] child with %u-char argv[0] died by signal %d", (unsigned)len, WTERMSIG(status));
+        return -1;
+    }
+    if (!WIFEXITED(status) || (WEXITSTATUS(status) != 0)) {
+        syslog(
+            LOG_ERR, "[t_execve_bounds] child with %u-char argv[0] exited badly (%d)",
+            (unsigned)len, WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief A filename that does not fit PATH_MAX must fail with
+/// ENAMETOOLONG, not silently exec a truncated path.
+/// @return 0 on success, -1 on failure.
+static int check_filename_too_long(void)
+{
+    fill_string(long_filename, 4096, 'x');
+    char *argv_ok[2]  = {"t_execve_bounds", NULL};
+    char *envp_none[1] = {NULL};
+    errno              = 0;
+    if (execve(long_filename, argv_ok, envp_none) != -1) {
+        syslog(LOG_ERR, "[t_execve_bounds] execve of a 4096-char filename unexpectedly succeeded");
+        return -1;
+    }
+    if (errno != ENAMETOOLONG) {
+        syslog(LOG_ERR, "[t_execve_bounds] 4096-char filename: expected ENAMETOOLONG, got %s", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief A filename of exactly PATH_MAX - 1 characters fits: it must be
+/// walked safely and fail with ENOENT (it cannot exist), not with a crash
+/// or a memory error.
+/// @return 0 on success, -1 on failure.
+static int check_filename_longest_valid(void)
+{
+    fill_string(long_filename, 4095, 'y');
+    char *argv_ok[2]  = {"t_execve_bounds", NULL};
+    char *envp_none[1] = {NULL};
+    errno              = 0;
+    if (execve(long_filename, argv_ok, envp_none) != -1) {
+        syslog(LOG_ERR, "[t_execve_bounds] execve of a 4095-char filename unexpectedly succeeded");
+        return -1;
+    }
+    if (errno != ENOENT) {
+        syslog(LOG_ERR, "[t_execve_bounds] 4095-char filename: expected ENOENT, got %s", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief A plain execve must still succeed end to end.
+/// @return 0 on success, -1 on failure.
+static int check_ordinary_execve(void)
+{
+    char *argv_echo[3] = {"echo", "t_execve_bounds: ordinary exec", NULL};
+    char *envp_none[1] = {NULL};
+    pid_t pid          = fork();
+    if (pid < 0) {
+        syslog(LOG_ERR, "[t_execve_bounds] fork: %s", strerror(errno));
+        return -1;
+    }
+    if (pid == 0) {
+        execve("/bin/echo", argv_echo, envp_none);
+        syslog(LOG_ERR, "[t_execve_bounds] execve /bin/echo: %s", strerror(errno));
+        exit(99);
+    }
+    int status;
+    if (waitpid(pid, &status, 0) == -1) {
+        syslog(LOG_ERR, "[t_execve_bounds] waitpid: %s", strerror(errno));
+        return -1;
+    }
+    if (!WIFEXITED(status) || (WEXITSTATUS(status) != 0)) {
+        syslog(LOG_ERR, "[t_execve_bounds] ordinary execve child failed");
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    // Phase 2: this image was started by check_name_boundary with a crafted
+    // argv[0]; verify the kernel-side name now.
+    if ((argc == 2) && (strcmp(argv[1], "phase2") == 0)) {
+        return phase2(argv[0]);
+    }
+
+    // The task name must survive every boundary length, including the ones
+    // past NAME_MAX (truncated) and past the old 100-char field.
+    const size_t lengths[] = {1, 100, 150, 254, 255, 300};
+    for (unsigned i = 0; i < sizeof(lengths) / sizeof(lengths[0]); ++i) {
+        if (check_name_boundary(lengths[i]) < 0) {
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (check_filename_too_long() < 0) {
+        return EXIT_FAILURE;
+    }
+    if (check_filename_longest_valid() < 0) {
+        return EXIT_FAILURE;
+    }
+    if (check_ordinary_execve() < 0) {
+        return EXIT_FAILURE;
+    }
+    syslog(LOG_INFO, "[t_execve_bounds] all execve string-bound checks passed");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Replacement for #190, crediting its author @ksaweryr for the original finding and fix direction. #190 found that `sys_execve` copied the raw user strings `argv[0]` and `filename` into fixed kernel-stack buffers with `strcpy`, giving a kernel-stack overflow with EIP control (the original PoC reached EIP `0xdeadbeef`). This PR salvages the still-valid part of that fix onto current `develop` and completes it correctly.

Reproduced on unfixed `develop` with the new regression test:

```text
[PG_FLT] EAX = 0x41414141        <- attacker's 'A' bytes in kernel registers
PANIC: Page fault!
```

## What survived from #190

| #190 change | Disposition here |
|---|---|
| `strncpy(name_buffer, argv[0], NAME_MAX)` | Kept in spirit, fixed: `strnlen(argv[0], sizeof(name_buffer)-1)` + `memcpy` + explicit NUL |
| `strncpy(saved_filename, filename, PATH_MAX)` | Replaced by rejection: `strlen >= PATH_MAX` → `-ENAMETOOLONG` |
| `strncpy(current->name, name_buffer, TASK_NAME_MAX_LENGTH)` | Kept, with termination (`n-1` + NUL) |
| `strncpy(proc->name, name, …)` in `__alloc_task` | Kept, with termination |
| `TASK_NAME_MAX_LENGTH` 100 → `NAME_MAX` | Kept — still necessary (see below) |
| `process.h` should include `limits.h` directly | Kept (review finding) |
| 4 × cwd copies (`__alloc_task` ×2, `sys_chdir`, `sys_fchdir`) | **Dropped as redundant** — sources are `resolve_path` output, verified always NUL-terminated and shorter than the `PATH_MAX` destination (docs/maintainer/execve.md, "Termination guarantees that DO hold"), and the `"/"` literal |

## Why the old `strncpy(…, n)` implementation was not directly mergeable

`strncpy(dst, src, n)` leaves `dst` unterminated when `strlen(src) >= n`. The #190 copies from user-controlled `argv[0]`/`filename` could leave `name_buffer`, `saved_filename` and consequently `task_struct.name` unterminated; those are later consumed as C strings (`%s`, `strcpy`, `basename`, `strlen` in the interpreter path), turning the write overflow into an OOB-read/crash/info-leak class. That was the blocking review finding on #190. All copies here either terminate explicitly or are rejected before copying.

## Contract decisions

- **argv[0] (the process *name*)** truncates at `NAME_MAX - 1` characters, like Linux truncates `comm`: a long `argv[0]` is normal (paths) and must not fail the exec.
- **filename** is rejected with `ENAMETOOLONG` when it does not fit `PATH_MAX`: a truncated path would silently target the *wrong executable*. The `strnlen` walk is bounded to `PATH_MAX`, so `saved_filename` (also consumed as `int_argv[1]` and `strlen`'d by the shebang path) is always terminated.
  - **Scope caveat** (verified adversarially, see #284): this rejection guarantees no truncation *of the copy inside `sys_execve`* only. The path resolver below can still silently truncate **sub-`PATH_MAX`** paths (parsing stops around byte ~255 in `tokenize`), and that can resolve a longer request to a prefix-named file — including executing it. That is a pre-existing, independent resolver defect, filed separately as #284; it is not addressed (and not worsened) by this PR.
- **TASK_NAME_MAX_LENGTH = NAME_MAX is still necessary**: `name_buffer` legitimately holds up to `NAME_MAX - 1` characters after the bounded copy, which did not fit the old 100-byte field; the header now includes `limits.h` directly.

## Regression coverage (`t_execve_bounds`)

- Re-executes itself with `argv[0]` of length **1, 100, 150, 254, 255, 300** and verifies via `/proc/<pid>/cmdline` (which reports `task->name`) that the name landed bounded and NUL-terminated at each boundary — 254 kept, 255+ truncated, no crash, no adjacent corruption.
- 4096-char filename → `ENAMETOOLONG`; 4095-char (the longest valid) → walked safely, `ENOENT`.
- Ordinary `execve("/bin/echo", …)` still succeeds end to end.
- Does not duplicate `t_execve_fail` (early errnos, rollback) — this test is about the string copies and their boundaries.

## Validation

* [x] Pre-fix reproduction: kernel panic with `EAX = 0x41414141` during the long-argv[0] cases (the #190 PoC class, live in-guest)
* [x] Post-fix: `ok 9 - t_execve_bounds`, **54/54**, `Test run completed successfully`, 0 `PANIC` in serial.log and test.log
* [x] Debug and Release builds warning-free
* [x] `git diff --check` clean
* [x] Interactions with the post-July execve changes checked: copies sit before any allocation (rollback paths untouched), `-ENAMETOOLONG` follows the #238 `-errno` convention, interpreter path gets a terminated `saved_filename`
* [x] Out of scope, unchanged: #196 (argv/envp vector/count validation), #191 (general user-pointer validation). Additionally filed from the adversarial verification pass, pre-existing and independent of this PR: #284 (resolver path truncation → wrong-file execution), #285 (ext2 `name_len == 255` 1-byte OOB writes).
* [x] Independent adversarial verification of this PR: argv[0] boundary matrix 0..65535 via `/proc/<pid>/cmdline` + `/stat` + waitpid; filename 4094..16384 errno semantics; failed-exec name rollback; 120× mixed stress rounds — no remaining #190-class issue, 0 panics. Negative control: with only this PR's kernel changes reverted, the suite panics in kernel mode (`EAX = 0x41414141`, `CR2 = 0x4141414d`) during `t_execve_bounds`; restored, 54/54 pass.

## Relationship to #190

Supersedes #190 (do not merge that branch; its fork branch was left untouched). @ksaweryr did the original discovery, the PoC, and the first bounded-copy pass — the core of what survived.

Closes #190 is intentionally **not** used here; the old PR should be closed manually once this is reviewed, so its discussion stays readable.