### PR TITLE
fix(kernel): bound sys_execve argv/envp handling and reject oversized vectors

### DIFF
--- a/docs/maintainer/execve.md
+++ b/docs/maintainer/execve.md
@@ -105,7 +105,13 @@ is fully loaded, or must not return to userspace on failure.**
 - PR #190 fixes the write-overflow (name/filename copies) but not
   termination and not the argv helpers → verdict REQUEST_CHANGES at review
   time; #196 was filed for the `args_location[256]` + unbounded-walk class.
-- Any fix here should: bound argc/bytes with an ARG_MAX-style limit and
-  `-E2BIG`; replace `args_location[256]` with a sized allocation; use
-  `strnlen` per string; force NUL termination on all copies; include
-  `limits.h` in process.h.
+- The #196 fix (in `sys_execve`): counts are bounded (`MAX_ARG_COUNT`
+  entries, `MAX_ARG_STRLEN` bytes per string, `ARG_MAX` bytes per vector,
+  all in `lib/inc/limits.h`, enforced with `-E2BIG`); the fixed
+  `args_location[256]` is replaced by caller-owned arrays sized from the
+  validated counts (`argv_locations`/`envp_locations`); user strings are
+  copied through `strnlen`-bounded pushes (`__push_user_strings_on_stack`),
+  kernel copies through trusted pushes; the interpreter rebuild re-checks
+  its combined budget against `ARG_MAX`. The libc `execve()` wrapper passes
+  vectors through unchanged, so userspace sees the same `E2BIG` the kernel
+  returns.

--- a/docs/maintainer/known-bugs.md
+++ b/docs/maintainer/known-bugs.md
@@ -53,13 +53,23 @@ reviewed against `BASE` = `82f4314`.
 
 ### #196 — sys_execve argv >256 entries overflows kernel stack; unbounded
 user-string walks
-- **Status**: open. **Severity**: high (security).
+- **Status**: FIXED (in-guest reproduced pre-fix and post-fix). **Severity**:
+  high (security).
 - **Proven root cause (CODE-PROVEN)**: `char *args_location[256]` indexed
   by user argc (`__push_args_on_stack`, process.c:70/75 @`MAIN`);
   `__count_args` unbounded walk; `__count_args_bytes` raw `strlen`s.
-- **Reproduction**: NOT yet executed in-guest (test sketch in the issue);
-  code path is unambiguous. Host libc passes vectors through unvalidated.
+- **Reproduction**: in-guest via `t_execve_bigargv` — on the unfixed kernel
+  the suite panics with an `Assertion failed` in `sys_execve` during the
+  257-entry case (the stack smash corrupts the accounting before the
+  assert trips); with the fix, 257/300/1024-entry vectors exec correctly
+  and 1025 entries, a 8192-byte string, or a vector above `ARG_MAX` return
+  `E2BIG` (`56/56` tests, Debug and Release, 0 panics).
+- **Fix**: bounded counts (`MAX_ARG_COUNT`/`MAX_ARG_STRLEN`/`ARG_MAX`,
+  `lib/inc/limits.h`), caller-owned position arrays sized from the
+  validated counts, `strnlen`-bounded pushes of user strings, `ARG_MAX`
+  re-check on the interpreter rebuild.
 - **Related**: #190 (complementary, same function), #191, #121.
+
 
 ## Open PR
 

--- a/kernel/src/process/process.c
+++ b/kernel/src/process/process.c
@@ -35,54 +35,120 @@ static kmem_cache_t *task_struct_cache;
 
 /// @brief Counts the number of arguments.
 /// @param args the array of arguments, it must be NULL terminated.
-/// @return the number of arguments.
-static inline int __count_args(char **args)
+/// @param max_count the maximum number of entries to scan.
+/// @return the number of arguments, or -E2BIG when the vector is not
+///         NULL-terminated within `max_count` entries.
+static inline int __count_args(char **args, int max_count)
 {
     int argc = 0;
-    while (args[argc] != NULL) {
+    while ((argc < max_count) && (args[argc] != NULL)) {
         ++argc;
+    }
+    if ((argc == max_count) && (args[argc] != NULL)) {
+        return -E2BIG;
     }
     return argc;
 }
 
 /// @brief Counts the bytes occupied by the arguments.
 /// @param args the array of arguments, it must be NULL terminated.
-/// @return the bytes occupied by the arguments.
-static inline int __count_args_bytes(char **args)
+/// @param argc the number of arguments, already validated by __count_args.
+/// @param out_bytes where the total is stored: the string bytes (each
+///        including its terminator) plus the pointer array.
+/// @return 0 on success, -E2BIG when a string is not NUL-terminated within
+///         MAX_ARG_STRLEN bytes, or the total exceeds ARG_MAX.
+static inline int __count_args_bytes(char **args, int argc, int *out_bytes)
 {
-    // Count the number of arguments.
-    int argc  = __count_args(args);
-    // Count the number of characters.
+    // Count the characters, bounding each string: a non-terminated string
+    // must not turn the walk into an unbounded kernel read (#196).
     int nchar = 0;
     for (int i = 0; i < argc; i++) {
-        nchar += strlen(args[i]) + 1;
+        size_t len = strnlen(args[i], MAX_ARG_STRLEN);
+        if (len >= MAX_ARG_STRLEN) {
+            return -E2BIG;
+        }
+        nchar += (int)len + 1;
+        if (nchar > ARG_MAX) {
+            return -E2BIG;
+        }
     }
-    return nchar + ((argc + 1 /* The NULL terminator */) * sizeof(char *));
+    *out_bytes = nchar + ((argc + 1 /* The NULL terminator */) * (int)sizeof(char *));
+    if (*out_bytes > ARG_MAX) {
+        return -E2BIG;
+    }
+    return 0;
 }
 
-/// @brief Pushes the arguments on the stack.
+/// @brief Pushes the argument strings on the stack (growing downwards),
+/// recording the final position of each string.
 /// @param stack pointer to the stack location.
-/// @param args the list of arguments.
-/// @return the final position of the stack, where the list of pushed arguments is stored.
-static inline char **__push_args_on_stack(uintptr_t *stack, char *args[])
+/// @param args the list of arguments; the strings must be kernel copies,
+///        their lengths are trusted because they were validated on copy.
+/// @param argc the number of arguments, already validated by the caller.
+/// @param locations array of at least `argc` entries where the position of
+///        each string is stored; the caller owns it, sized from the
+///        validated count (it replaces the fixed `char *[256]` that
+///        overflowed the kernel stack for larger vectors, #196).
+static inline void __push_strings_on_stack(uintptr_t *stack, char *args[], int argc, char *locations[])
 {
-    // Count the number of arguments.
-    int argc = __count_args(args);
-    // Prepare args with space for the terminating NULL.
-    char *args_location[256];
     for (int i = argc - 1; i >= 0; --i) {
         for (int j = strlen(args[i]); j >= 0; --j) {
             stack_push_u8((uint32_t *)stack, args[i][j]);
         }
-        args_location[i] = (char *)(*stack);
+        locations[i] = (char *)(*stack);
     }
+}
+
+/// @brief Pushes the strings of a user-controlled vector on the stack, with
+///        a per-string bound.
+/// @param stack pointer to the stack location.
+/// @param args the list of arguments, straight from user memory.
+/// @param argc the number of arguments, already validated by __count_args.
+/// @param locations array of at least `argc` entries, caller-owned.
+/// @return 0 on success, -E2BIG when a string is not NUL-terminated within
+///         MAX_ARG_STRLEN bytes: it either grew after the counting, or the
+///         counting never validated it.
+static inline int __push_user_strings_on_stack(uintptr_t *stack, char *args[], int argc, char *locations[])
+{
+    for (int i = argc - 1; i >= 0; --i) {
+        size_t len = strnlen(args[i], MAX_ARG_STRLEN);
+        if (len >= MAX_ARG_STRLEN) {
+            return -E2BIG;
+        }
+        for (int j = (int)len; j >= 0; --j) {
+            stack_push_u8((uint32_t *)stack, args[i][j]);
+        }
+        locations[i] = (char *)(*stack);
+    }
+    return 0;
+}
+
+/// @brief Pushes the terminating NULL and the array of string pointers.
+/// @param stack pointer to the stack location.
+/// @param locations the positions of the strings, filled by the string push.
+/// @param argc the number of arguments.
+/// @return the final position of the stack, where the pointer array is stored.
+static inline char **__push_vector_on_stack(uintptr_t *stack, char *locations[], int argc)
+{
     // Push terminating NULL.
     stack_push_ptr((uint32_t *)stack, NULL);
     // Push array of pointers to the arguments.
     for (int i = argc - 1; i >= 0; --i) {
-        stack_push_ptr((uint32_t *)stack, args_location[i]);
+        stack_push_ptr((uint32_t *)stack, locations[i]);
     }
     return (char **)(*stack);
+}
+
+/// @brief Pushes the arguments on the stack.
+/// @param stack pointer to the stack location.
+/// @param args the list of arguments; the strings must be kernel copies.
+/// @param argc the number of arguments, already validated by the caller.
+/// @param locations array of at least `argc` entries, caller-owned.
+/// @return the final position of the stack, where the list of pushed arguments is stored.
+static inline char **__push_args_on_stack(uintptr_t *stack, char *args[], int argc, char *locations[])
+{
+    __push_strings_on_stack(stack, args, argc, locations);
+    return __push_vector_on_stack(stack, locations, argc);
 }
 
 /// @brief Clears the user stack of a freshly created memory descriptor.
@@ -464,16 +530,21 @@ int process_create_init(const char *path)
     int argc                    = 1;
     static char *argv[]         = {"/bin/init", (char *)NULL};
     static char *envp[]         = {(char *)NULL};
+    // The positions of the pushed strings, for the pointer arrays: the
+    // vectors are kernel literals with one entry, so a small stack array
+    // is enough here (sys_execve sizes it from the validated count).
+    char *argv_locations[4];
+    char *envp_locations[4];
     // Save where the arguments start.
     new_mm->arg_start           = useresp;
     // Push the arguments on the stack.
-    argv_ptr                    = __push_args_on_stack(&useresp, argv);
+    argv_ptr                    = __push_args_on_stack(&useresp, argv, 1, argv_locations);
     // Save where the arguments end.
     new_mm->arg_end             = useresp;
     // Save where the environmental variables start.
     new_mm->env_start           = useresp;
     // Push the environment on the stack.
-    envp_ptr                    = __push_args_on_stack(&useresp, envp);
+    envp_ptr                    = __push_args_on_stack(&useresp, envp, 0, envp_locations);
     // Save where the environmental variables end.
     new_mm->env_end             = useresp;
     // Push the `main` arguments on the stack (argc, argv, envp).
@@ -682,15 +753,23 @@ int sys_execve(pt_regs_t *f)
 
     // == COPY PROGRAM ARGUMENTS ==============================================
     // Copy argv and envp to kernel memory, because all the old process memory will be discarded.
-    int argc       = __count_args(origin_argv);
-    int argv_bytes = __count_args_bytes(origin_argv);
-    int envc       = __count_args(origin_envp);
-    int envp_bytes = __count_args_bytes(origin_envp);
-    if ((argv_bytes < 0) || (envp_bytes < 0)) {
-        pr_err(
-            "Failed to count required memory to store arguments and "
-            "environment (%d + %d).\n",
-            argv_bytes, envp_bytes);
+    // Every count is bounded: a vector that is not NULL-terminated within
+    // MAX_ARG_COUNT entries, a string without a terminator within
+    // MAX_ARG_STRLEN bytes, or an argv/envp above ARG_MAX fails with
+    // -E2BIG, instead of walking user memory unbounded and overflowing
+    // kernel state (#196).
+    int argc;
+    int envc;
+    int argv_bytes;
+    int envp_bytes;
+    if (((argc = __count_args(origin_argv, MAX_ARG_COUNT)) < 0) ||
+        ((envc = __count_args(origin_envp, MAX_ARG_COUNT)) < 0)) {
+        pr_err("sys_execve failed: too many arguments or environment entries.\n");
+        return -E2BIG;
+    }
+    if ((__count_args_bytes(origin_argv, argc, &argv_bytes) < 0) ||
+        (__count_args_bytes(origin_envp, envc, &envp_bytes) < 0)) {
+        pr_err("sys_execve failed: arguments or environment exceed ARG_MAX.\n");
         return -E2BIG;
     }
     void *args_mem = kmalloc(argv_bytes + envp_bytes);
@@ -701,10 +780,37 @@ int sys_execve(pt_regs_t *f)
             argv_bytes + envp_bytes, argv_bytes, envp_bytes);
         return -ENOMEM;
     }
-    // Copy the arguments.
+    // The arrays of string positions are sized from the validated counts:
+    // the argv one also covers the interpreter path, which shifts argv by
+    // two entries and therefore needs argc + 2 slots.
+    char **argv_locations = kmalloc((argc + 2) * sizeof(char *));
+    char **envp_locations = kmalloc(((envc > 0) ? envc : 1) * sizeof(char *));
+    if (!argv_locations || !envp_locations) {
+        pr_err("Failed to allocate memory for the argument positions.\n");
+        kfree(argv_locations);
+        kfree(envp_locations);
+        kfree(args_mem);
+        return -ENOMEM;
+    }
+    // Copy the arguments (raw user strings, bounded per string: one that
+    // grew after the counting fails here instead of overflowing).
     uint32_t args_mem_ptr = (uint32_t)args_mem + (argv_bytes + envp_bytes);
-    saved_argv            = __push_args_on_stack(&args_mem_ptr, origin_argv);
-    saved_envp            = __push_args_on_stack(&args_mem_ptr, origin_envp);
+    if (__push_user_strings_on_stack(&args_mem_ptr, origin_argv, argc, argv_locations) < 0) {
+        pr_err("sys_execve failed: an argument is not terminated within the limit.\n");
+        kfree(argv_locations);
+        kfree(envp_locations);
+        kfree(args_mem);
+        return -E2BIG;
+    }
+    saved_argv = __push_vector_on_stack(&args_mem_ptr, argv_locations, argc);
+    if (__push_user_strings_on_stack(&args_mem_ptr, origin_envp, envc, envp_locations) < 0) {
+        pr_err("sys_execve failed: an environment entry is not terminated within the limit.\n");
+        kfree(argv_locations);
+        kfree(envp_locations);
+        kfree(args_mem);
+        return -E2BIG;
+    }
+    saved_envp = __push_vector_on_stack(&args_mem_ptr, envp_locations, envc);
     // Check the memory pointer.
     assert(args_mem_ptr == (uint32_t)args_mem);
     // ------------------------------------------------------------------------
@@ -749,7 +855,20 @@ int sys_execve(pt_regs_t *f)
 
         // Rebuild the saved argv and envp pointers. The buffer must hold both
         // the new argv and the whole environment (#227).
-        int int_argv_bytes = __count_args_bytes(int_argv);
+        int int_argc      = argc;
+        int int_argv_bytes = 0;
+        if (__count_args_bytes(int_argv, int_argc, &int_argv_bytes) < 0) {
+            pr_err("sys_execve failed: interpreter arguments exceed ARG_MAX.\n");
+            // Rollback: the old image is still the current one.
+            kfree(int_argv);
+            mm_destroy(new_mm);
+            current->uid = prev_uid;
+            current->gid = prev_gid;
+            kfree(argv_locations);
+            kfree(envp_locations);
+            kfree(args_mem);
+            return -E2BIG;
+        }
         void *int_args_mem = kmalloc(int_argv_bytes + envp_bytes);
         if (!int_args_mem) {
             pr_err(
@@ -761,13 +880,17 @@ int sys_execve(pt_regs_t *f)
             mm_destroy(new_mm);
             current->uid = prev_uid;
             current->gid = prev_gid;
+            kfree(argv_locations);
+            kfree(envp_locations);
             kfree(args_mem);
             return -ENOMEM;
         }
-        // Copy the arguments.
+        // Copy the arguments (kernel strings: lengths were validated on copy).
         uint32_t int_args_mem_ptr = (uint32_t)int_args_mem + (int_argv_bytes + envp_bytes);
-        saved_argv                = __push_args_on_stack(&int_args_mem_ptr, int_argv);
-        saved_envp                = __push_args_on_stack(&int_args_mem_ptr, saved_envp);
+        __push_strings_on_stack(&int_args_mem_ptr, int_argv, int_argc, argv_locations);
+        saved_argv                = __push_vector_on_stack(&int_args_mem_ptr, argv_locations, int_argc);
+        __push_strings_on_stack(&int_args_mem_ptr, saved_envp, envc, envp_locations);
+        saved_envp                = __push_vector_on_stack(&int_args_mem_ptr, envp_locations, envc);
         // Check the memory pointer.
         assert(int_args_mem_ptr == (uint32_t)int_args_mem);
         // Free the interpreter argv array and the old argument and environ memory block.
@@ -789,14 +912,18 @@ int sys_execve(pt_regs_t *f)
     uintptr_t useresp = new_mm->start_stack + DEFAULT_STACK_SIZE;
     // Save where the arguments start.
     new_mm->arg_start = useresp;
-    // Push the arguments on the stack.
-    final_argv        = __push_args_on_stack(&useresp, saved_argv);
+    // Push the arguments on the stack (kernel strings, argc reflects the
+    // interpreter shift when a script was loaded).
+    final_argv        = __push_args_on_stack(&useresp, saved_argv, argc, argv_locations);
     // Save where the arguments end, and the env starts.
     new_mm->env_start = new_mm->arg_end = useresp;
     // Push the environment on the stack.
-    final_envp                           = __push_args_on_stack(&useresp, saved_envp);
+    final_envp                           = __push_args_on_stack(&useresp, saved_envp, envc, envp_locations);
     // Save where the environmental variables end.
     new_mm->env_end                      = useresp;
+    // The string positions are no longer needed.
+    kfree(argv_locations);
+    kfree(envp_locations);
     // Push the `main` arguments on the stack (argc, argv, envp).
     stack_push_ptr(&useresp, final_envp);
     stack_push_ptr(&useresp, final_argv);

--- a/lib/inc/limits.h
+++ b/lib/inc/limits.h
@@ -57,7 +57,19 @@
 #define PATH_MAX 4096
 
 /// Maximum length of arguments provided to exec function.
-#define ARG_MAX 256
+/// The maximum total size, in bytes, of one argv or envp vector passed to
+/// exec: the sum of the string bytes (each including its terminator) plus
+/// the pointer array. A vector above this limit fails with `E2BIG`.
+#define ARG_MAX 65536
+
+/// Maximum number of entries in an argv or envp vector passed to exec.
+/// A vector that is not NULL-terminated within this many entries fails
+/// with `E2BIG`.
+#define MAX_ARG_COUNT 1024
+
+/// Maximum length, in bytes including the terminator, of a single argv or
+/// envp string. A longer (or non-terminated) string fails with `E2BIG`.
+#define MAX_ARG_STRLEN 8192
 
 /// Maximum pid number.
 #define PID_MAX_LIMIT 32768

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -33,6 +33,7 @@ static char *all_tests[] = {
     "t_environ",
     "t_exec",
     "t_execve_bounds",
+    "t_execve_bigargv",
     "t_execve_fail",
     "t_elf_short",
     "t_exit",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_LIST
     t_shmget.c
     t_exec.c
     t_execve_bounds.c
+    t_execve_bigargv.c
     t_execve_fail.c
     t_elf_short.c
     t_gid.c

--- a/userspace/tests/t_execve_bigargv.c
+++ b/userspace/tests/t_execve_bigargv.c
@@ -1,0 +1,238 @@
+/// @file t_execve_bigargv.c
+/// @brief Regression test for #196: sys_execve must handle argv/envp of any
+/// size safely — bounded counts, bounded per-string copies, and a dynamically
+/// sized array of string positions — rejecting oversized vectors with E2BIG
+/// instead of overflowing the kernel stack (`char *args_location[256]`) or
+/// walking user memory unbounded.
+/// @details Boundaries exercised (limits from limits.h):
+///   - 257 and 300 entries: must EXECUTE correctly (previously a kernel-stack
+///     out-of-bounds write);
+///   - exactly MAX_ARG_COUNT (1024): allowed;
+///   - MAX_ARG_COUNT + 1 (1025): -E2BIG;
+///   - a single string of MAX_ARG_STRLEN - 1 (8191) chars: allowed;
+///   - a single string of MAX_ARG_STRLEN (8192) chars: -E2BIG;
+///   - total bytes at the ARG_MAX boundary: 900 x 64-byte entries allowed,
+///     1000 x 64-byte entries (68004 > 65536) rejected;
+///   - the same total-bytes boundary through envp.
+/// The successful cases re-execute this binary and verify argc, the content
+/// of every entry and (for envp) the `environ` array, so the full
+/// kernel-push -> userspace-main round trip is checked.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// Path of this test binary inside the guest.
+#define SELF_PATH "/bin/tests/t_execve_bigargv"
+
+/// The per-entry filler length used by the byte-boundary cases: 63 chars
+/// plus the terminator make 64 bytes per entry.
+#define MED_FILLER_LEN 62
+
+/// Storage for the argv vector built by the parent.
+static char *big_argv[MAX_ARG_COUNT + 4];
+/// Storage for the envp vector built by the parent.
+static char *big_envp[MAX_ARG_COUNT + 4];
+/// One shared filler string (all entries may alias it).
+static char filler[MAX_ARG_STRLEN + 4];
+/// The tag describing the expected layout: `N<count>L<filler-length>`.
+static char tag[32];
+
+/// @brief Fills the shared filler string with `len` 'f' characters.
+static void make_filler(int len)
+{
+    memset(filler, 'f', len);
+    filler[len] = '\0';
+}
+
+/// @brief Builds the vector for an argv case: tag, `count - 2` fillers, "p2".
+static void build_argv(int count, int filler_len)
+{
+    make_filler(filler_len);
+    snprintf(tag, sizeof(tag), "N%dL%d", count, filler_len);
+    big_argv[0] = tag;
+    for (int i = 1; i <= count - 2; ++i) {
+        big_argv[i] = filler;
+    }
+    big_argv[count - 1] = (char *)"p2";
+    big_argv[count]     = NULL;
+}
+
+/// @brief Forks and execs SELF with `argv`; the child image verifies the
+/// round trip. A zero status means success (the child verified everything).
+static int run_case(char *argv[], char *envp[], const char *label)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        syslog(LOG_ERR, "[t_execve_bigargv] fork: %s", strerror(errno));
+        return -1;
+    }
+    if (pid == 0) {
+        execve(SELF_PATH, argv, envp);
+        // The exec must not return; report the errno to the parent.
+        if (errno == E2BIG) {
+            exit(0);
+        }
+        syslog(LOG_ERR, "[t_execve_bigargv] %s: execve returned %s", label, strerror(errno));
+        exit(100 + (errno & 0x7f));
+    }
+    int st;
+    if (waitpid(pid, &st, 0) < 0) {
+        syslog(LOG_ERR, "[t_execve_bigargv] waitpid: %s", strerror(errno));
+        return -1;
+    }
+    if (!WIFEXITED(st) || WEXITSTATUS(st) != 0) {
+        syslog(
+            LOG_ERR, "[t_execve_bigargv] %s: bad child status %d (sig %d)", label,
+            WIFEXITED(st) ? WEXITSTATUS(st) : -1, WIFSIGNALED(st) ? WTERMSIG(st) : 0);
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Phase 2 for the argv cases: verifies argc, the tag and every entry.
+static int phase2_argv(int argc, char *argv[])
+{
+    if ((argc < 3) || (argv[0][0] != 'N')) {
+        return 1;
+    }
+    int count = atoi(argv[0] + 1);
+    char *l   = strchr(argv[0], 'L');
+    if ((count != argc) || (l == NULL)) {
+        syslog(LOG_ERR, "[t_execve_bigargv] phase2: argc %d, tag `%s`", argc, argv[0]);
+        return 1;
+    }
+    int filler_len = atoi(l + 1);
+    if ((int)strlen(filler) != filler_len) {
+        // The parent and the child share the same binary: recompute it.
+        make_filler(filler_len);
+    }
+    for (int i = 1; i <= argc - 2; ++i) {
+        if ((argv[i] == NULL) || ((int)strlen(argv[i]) != filler_len) || (argv[i][0] != 'f')) {
+            syslog(LOG_ERR, "[t_execve_bigargv] phase2: entry %d wrong (len %u)", i, argv[i] ? (unsigned)strlen(argv[i]) : 0u);
+            return 1;
+        }
+    }
+    if ((strcmp(argv[argc - 1], "p2") != 0) || (argv[argc] != NULL)) {
+        syslog(LOG_ERR, "[t_execve_bigargv] phase2: terminator entry wrong");
+        return 1;
+    }
+    return 0;
+}
+
+/// @brief Phase 2 for the envp case: verifies the `environ` array.
+static int phase2_envp(int argc, char *argv[])
+{
+    extern char **environ;
+    if ((argc != 2) || (argv[0][0] != 'E')) {
+        return 1;
+    }
+    int count = atoi(argv[0] + 1);
+    int envc  = 0;
+    while ((environ[envc] != NULL) && (envc < count + 8)) {
+        if ((environ[envc][0] != 'e') || ((int)strlen(environ[envc]) != MED_FILLER_LEN)) {
+            syslog(LOG_ERR, "[t_execve_bigargv] phase2 env: entry %d wrong", envc);
+            return 1;
+        }
+        ++envc;
+    }
+    if (envc != count) {
+        syslog(LOG_ERR, "[t_execve_bigargv] phase2 env: %d entries, expected %d", envc, count);
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    // Phase 2: started by run_case with a crafted argv (and possibly envp).
+    if ((argc >= 2) && (strcmp(argv[argc - 1], "p2") == 0)) {
+        if (argv[0][0] == 'E') {
+            return phase2_envp(argc, argv);
+        }
+        return phase2_argv(argc, argv);
+    }
+
+    char *envp_none[1]  = {NULL};
+    char *envp_two[3]   = {(char *)"PATH=/bin", (char *)"HOME=/", NULL};
+    static char efill[MED_FILLER_LEN + 1];
+    memset(efill, 'e', MED_FILLER_LEN);
+    efill[MED_FILLER_LEN] = '\0';
+
+    int failures = 0;
+
+    // Previously a kernel-stack out-of-bounds write: 257 and 300 entries.
+    build_argv(257, MED_FILLER_LEN);
+    if (run_case(big_argv, envp_none, "argv 257") < 0) {
+        ++failures;
+    }
+    build_argv(300, 8);
+    if (run_case(big_argv, envp_two, "argv 300") < 0) {
+        ++failures;
+    }
+
+    // Exact entry-count boundary.
+    build_argv(MAX_ARG_COUNT, 8);
+    if (run_case(big_argv, envp_none, "argv MAX_ARG_COUNT") < 0) {
+        ++failures;
+    }
+    build_argv(MAX_ARG_COUNT + 1, 8);
+    if (run_case(big_argv, envp_none, "argv MAX_ARG_COUNT+1") < 0) {
+        ++failures;
+    }
+
+    // Single-string length boundary (count 3: tag, the long string, "p2").
+    build_argv(3, MAX_ARG_STRLEN - 1);
+    if (run_case(big_argv, envp_none, "string MAX_ARG_STRLEN-1") < 0) {
+        ++failures;
+    }
+    build_argv(3, MAX_ARG_STRLEN);
+    if (run_case(big_argv, envp_none, "string MAX_ARG_STRLEN") < 0) {
+        ++failures;
+    }
+
+    // Total-bytes boundary through argv: 900 entries fit, 1000 exceed.
+    build_argv(900, MED_FILLER_LEN);
+    if (run_case(big_argv, envp_none, "argv 900x64B") < 0) {
+        ++failures;
+    }
+    build_argv(1000, MED_FILLER_LEN);
+    if (run_case(big_argv, envp_none, "argv 1000x64B") < 0) {
+        ++failures;
+    }
+
+    // The same total-bytes boundary through envp.
+    {
+        char *av[3] = {(char *)"E500", (char *)"p2", NULL};
+        for (int i = 0; i < 500; ++i) {
+            big_envp[i] = efill;
+        }
+        big_envp[500] = NULL;
+        if (run_case(av, big_envp, "envp 500x64B") < 0) {
+            ++failures;
+        }
+        for (int i = 0; i < 1000; ++i) {
+            big_envp[i] = efill;
+        }
+        big_envp[1000] = NULL;
+        if (run_case(av, big_envp, "envp 1000x64B") < 0) {
+            ++failures;
+        }
+    }
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_execve_bigargv] all argv/envp bound checks passed");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_execve_bigargv] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Fixes #196 (v0.9.6 milestone, severity high): `sys_execve` trusted the user argv/envp vectors completely, and the mentos libc `execve()` passes them straight through, so any program could reach:

1. **Kernel-stack out-of-bounds write** — `__push_args_on_stack` declared `char *args_location[256]` and indexed it with the user-controlled argc: vectors with more than 256 entries wrote kernel-heap pointers past the array, inside an inlined helper of `sys_execve`.
2. **Unbounded kernel walks** — `__count_args` walked the vector until NULL (a non-terminated vector ran off the user mappings inside the kernel); `__count_args_bytes` `strlen`'d every raw user string.

The issue's reproduction sketch was executed in-guest for the first time here (details below).

## Fix

- **Limits** (`lib/inc/limits.h`, shared kernel+userspace): `ARG_MAX` = 65536 bytes per vector (strings + pointer array; the constant already existed with value 256 but was referenced nowhere), `MAX_ARG_COUNT` = 1024 entries, `MAX_ARG_STRLEN` = 8192 bytes per string.
- `__count_args(args, max_count)` — bounded walk; a vector not NULL-terminated within the cap returns `-E2BIG`.
- `__count_args_bytes(args, argc, &bytes)` — takes the validated argc, bounds every string with `strnlen`, fails with `-E2BIG` past `MAX_ARG_STRLEN` or `ARG_MAX` (accumulation is capped, so no int overflow).
- The fixed position array is replaced by **caller-owned arrays sized from the validated counts** (`argv_locations`/`envp_locations`; the argv one covers the interpreter path, which shifts argv by two entries).
- **Two push variants**: user strings go through `__push_user_strings_on_stack`, which re-checks each string with `strnlen` (a string that grew after the counting fails with `-E2BIG` instead of overflowing); kernel copies keep the trusted fast path.
- The **interpreter rebuild** re-checks its combined budget against `ARG_MAX`, with full rollback (credentials, candidate mm, all allocations).
- `process_create_init` adapts to the new signatures (static literals, small stack arrays).

Net behavior change: vectors of 257–1024 entries **now exec correctly** (previously a kernel-stack smash); oversized vectors/strings/totals fail with `E2BIG`, matching the direction recorded in `docs/maintainer/known-bugs.md` and `execve.md` (both updated).

## Regression coverage (`t_execve_bigargv`)

Re-executes this binary through the full kernel-push → `main` round trip and verifies `argc`, **every** entry's content, and `environ`:

- 257 and 300 entries: must exec correctly (the old kernel-stack overflow);
- exactly `MAX_ARG_COUNT` (1024): allowed; 1025: `E2BIG`;
- a single `MAX_ARG_STRLEN-1` (8191) char string: allowed; 8192 chars: `E2BIG`;
- total-bytes boundary: 900×64 B entries allowed, 1000×64 B (68004 > 65536) rejected — through **both** argv and envp.

## Validation

* **Negative control**: with only this PR's `process.c` reverted (test kept), the suite dies during `t_execve_bigargv` — `PANIC: Assertion failed` in `sys_execve` (the stack smash corrupts the accounting variables before the existing assert trips; in Release it is a silent kernel-stack corruption), guest exit 35, mid-suite.
* **With the fix**: `56/56` tests (`ok 10 - t_execve_bigargv`), **0 panics**, Debug and Release, `git diff --check` clean, both builds warning-free.

## Out of scope (unchanged)

- The count-then-copy double fetch on the vectors themselves remains (same class as #287, which covers the filename double-fetch).
- General user-pointer validation remains #191; a malformed pointer can still fault in the kernel while being walked.

Fixes #196
