### PR TITLE
fix(mem): signal user-mode page faults instead of panicking the kernel

### DIFF
--- a/docs/maintainer/memory-management.md
+++ b/docs/maintainer/memory-management.md
@@ -60,9 +60,17 @@ alloc/free pairs and resource tracking (used by `register_resource` /
 - `paging_switch_pgd` used when loading init and during exec; user stack
   pointers (`thread.regs.useresp`) are then re-based by pushing args.
 - Page-fault handler (mem/page_fault.c): prints decode
-  `ERR(user rw present)` as `(%d%d%d)`; user-mode fault with non-present
-  directory entry → SIGSEGV + scheduler_run; kernel-mode fault →
-  `__page_fault_panic` → `kernel_panic`.
+  `ERR(user rw present)` as `(%d%d%d)`; **any** user-mode fault the kernel
+  cannot resolve → SIGSEGV + scheduler_run via
+  `__send_sigsegv_to_current` (non-present directory entry, kernel mapping
+  window, failed copy-on-write handling, present non-CoW page); kernel-mode
+  fault → `__page_fault_panic` → `kernel_panic`. Before #237 only the
+  non-present-directory and the user+write+present CoW cases signalled, so
+  a null dereference (PDE 0 is present and supervisor-only) panicked the
+  kernel; `t_userfault` is the regression test.
+- Caveat: a process whose SIGSEGV handler returns normally resumes at the
+  faulting instruction and faults again; the kernel does not reset the
+  handler to the default action the way Linux `force_sig_info` does.
 - Kernel heap/virtual layout observations: kernel EIP ~0xc00026f9, kernel
   ESP ~0xf75eec48, user stack top ~0xbfffxxxx in the repro runs (useful
   sanity anchors when reading panic logs).

--- a/kernel/src/mem/page_fault.c
+++ b/kernel/src/mem/page_fault.c
@@ -150,6 +150,32 @@ static int __page_handle_cow(page_table_entry_t *entry)
     return 1;
 }
 
+/// @brief Delivers SIGSEGV to the current user task, if any.
+/// @param f the interrupt stack frame of the fault.
+/// @return 0 if the signal was queued and the context switch was performed,
+///         1 if there is no current task (the caller must panic).
+/// @details A user-mode fault the kernel cannot resolve must kill the
+///          faulting process, not the kernel: sys_kill queues the signal,
+///          and scheduler_run delivers it through the stored frame (running
+///          the handler or the default terminating action) before this
+///          task runs again.
+static int __send_sigsegv_to_current(pt_regs_t *f)
+{
+    task_struct *task = scheduler_get_current_process();
+    if (task) {
+        pr_err("User-mode fault: delivering SIGSEGV to pid %d.\n", task->pid);
+        // Notifies current process.
+        sys_kill(task->pid, SIGSEGV);
+        // Now, we know the process needs to be removed from the list of
+        // running processes. We pushed the SEGV signal in the queues of
+        // signal to send to the process. To properly handle the signal,
+        // just run scheduler.
+        scheduler_run(f);
+        return 0;
+    }
+    return 1;
+}
+
 int init_page_fault(void)
 {
     // Install the page fault interrupt service routine (ISR) handler.
@@ -253,17 +279,10 @@ void page_fault_handler(pt_regs_t *f)
 
         // If the fault was caused by a user process, send a SIGSEGV signal.
         if (err_user) {
-            task_struct *task = scheduler_get_current_process();
-            if (task) {
-                // Notifies current process.
-                sys_kill(task->pid, SIGSEGV);
-                // Now, we know the process needs to be removed from the list of
-                // running processes. We pushed the SEGV signal in the queues of
-                // signal to send to the process. To properly handle the signal,
-                // just run scheduler.
-                scheduler_run(f);
+            if (__send_sigsegv_to_current(f) == 0) {
                 return;
             }
+            pr_crit("No task found for current process, unable to send SIGSEGV.\n");
         }
         pr_crit("ERR(0): So, it is not present, and it was not the user.\n");
         __page_fault_panic(f, faulting_addr);
@@ -299,6 +318,14 @@ void page_fault_handler(pt_regs_t *f)
     // There was a page fault on a virtual mapped address, so we must first
     // update the original mapped page
     if (is_valid_virtual_address(faulting_addr)) {
+        // The mapping window belongs to the kernel: a user-mode fault inside
+        // it is a protection violation to signal, not something the kernel
+        // demand paging should service (#237).
+        if (err_user) {
+            if (__send_sigsegv_to_current(f) == 0) {
+                return;
+            }
+        }
         // Get the original page table entry from the virtually mapped one.
         page_table_entry_t *orig_entry = (page_table_entry_t *)(*(uint32_t *)entry);
         if (!orig_entry) {
@@ -328,22 +355,12 @@ void page_fault_handler(pt_regs_t *f)
                     "rw=%d, present=%d\n",
                     err_user, err_rw, err_present);
 
-                // Handle based on fault context
-                // For user-mode faults with write access to present pages: send SIGSEGV
-                if (err_user && err_rw && err_present) {
-                    // Get the current process.
-                    task_struct *task = scheduler_get_current_process();
-                    if (task) {
-                        // Notifies current process.
-                        sys_kill(task->pid, SIGSEGV);
-                        // Now, we know the process needs to be removed from the list of
-                        // running processes. We pushed the SEGV signal in the queues of
-                        // signal to send to the process. To properly handle the signal,
-                        // just run scheduler.
-                        scheduler_run(f);
+                // Any user-mode fault we cannot resolve (the CoW handling
+                // failed) kills the process, not the kernel (#237).
+                if (err_user) {
+                    if (__send_sigsegv_to_current(f) == 0) {
                         return;
                     }
-                    pr_crit("No task found for current process, unable to send SIGSEGV.\n");
                 } else {
                     // For kernel-mode or non-write faults, log and continue
                     // The page might not be CoW but still valid for this fault pattern
@@ -355,7 +372,16 @@ void page_fault_handler(pt_regs_t *f)
                 __page_fault_panic(f, faulting_addr);
             }
         } else {
-            // Page is not marked as CoW, this is a different fault type (e.g., demand paging)
+            // Page is not marked as CoW: if the fault comes from user mode
+            // (a present, privileged page: null dereferences and wild
+            // pointers into any kernel-mapped region land here), the
+            // process dies with SIGSEGV; only kernel-mode faults panic
+            // (#237).
+            if (err_user) {
+                if (__send_sigsegv_to_current(f) == 0) {
+                    return;
+                }
+            }
             pr_debug("Page fault is not Copy-on-Write, likely demand paging or other fault type.\n");
             __page_fault_panic(f, faulting_addr);
         }

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -34,6 +34,7 @@ static char *all_tests[] = {
     "t_exec",
     "t_execve_bounds",
     "t_execve_bigargv",
+    "t_userfault",
     "t_execve_fail",
     "t_elf_short",
     "t_exit",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_LIST
     t_exec.c
     t_execve_bounds.c
     t_execve_bigargv.c
+    t_userfault.c
     t_execve_fail.c
     t_elf_short.c
     t_gid.c

--- a/userspace/tests/t_userfault.c
+++ b/userspace/tests/t_userfault.c
@@ -1,0 +1,147 @@
+/// @file t_userfault.c
+/// @brief Regression test for #237: user-mode page faults on kernel-mapped
+/// addresses (and on present, non-CoW pages in general) must deliver
+/// SIGSEGV to the faulting process instead of panicking the kernel.
+/// @details Before the fix, a NULL dereference landed on the present,
+/// supervisor-only PDE 0 (the first 1 MiB is identity-mapped), fell through
+/// the copy-on-write branches of page_fault() and reached the unconditional
+/// __page_fault_panic(): any program could take down the kernel with a wild
+/// pointer. The test forks children that:
+///   - dereference NULL (read and write);
+///   - read and write the kernel image region (0xC0000000+), which also
+///     covers the kernel mapping window branch of the handler;
+/// and expects each child to die with SIGSEGV (WIFSIGNALED/WTERMSIG), or to
+/// exit from an installed SIGSEGV handler. The suite continuing after the
+/// children proves the kernel survived every fault.
+/// A write to the child's own code page is not covered: PT_LOAD segments are
+/// mapped writable regardless of their ELF permissions, so such a write
+/// succeeds today (issue #210).
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// Exit code used by the installed handler to prove delivery.
+#define HANDLER_EXIT 42
+
+/// The kernel image region, supervisor-only for user mode.
+#define KERNEL_REGION ((volatile int *)0xC0000000)
+
+/// @brief SIGSEGV handler: exits with a marker code.
+static void segv_handler(int sig)
+{
+    (void)sig;
+    exit(HANDLER_EXIT);
+}
+
+/// @brief Runs the faulting operation in a child and checks the outcome.
+/// @param label description of the case.
+/// @param fault the faulting operation (executed by the child).
+/// @param install_handler whether the child installs a SIGSEGV handler.
+/// @return 0 on success (SIGSEGV death or handler exit), -1 on failure.
+static int check_case(const char *label, void (*fault)(void), int install_handler)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        syslog(LOG_ERR, "[t_userfault] fork: %s", strerror(errno));
+        return -1;
+    }
+    if (pid == 0) {
+        if (install_handler && (signal(SIGSEGV, segv_handler) == SIG_ERR)) {
+            syslog(LOG_ERR, "[t_userfault] signal: %s", strerror(errno));
+            exit(90);
+        }
+        fault();
+        // Reaching this point means the fault did not happen or was silently
+        // serviced: both are wrong.
+        exit(91);
+    }
+    int status;
+    if (waitpid(pid, &status, 0) < 0) {
+        syslog(LOG_ERR, "[t_userfault] waitpid: %s", strerror(errno));
+        return -1;
+    }
+    if (install_handler) {
+        if (WIFEXITED(status) && (WEXITSTATUS(status) == HANDLER_EXIT)) {
+            return 0;
+        }
+        syslog(
+            LOG_ERR, "[t_userfault] %s: expected handler exit %d, got raw status 0x%x", label, HANDLER_EXIT, status);
+        return -1;
+    }
+    if (WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV)) {
+        return 0;
+    }
+    syslog(LOG_ERR, "[t_userfault] %s: expected SIGSEGV, got raw status 0x%x", label, status);
+    return -1;
+}
+
+/// @brief Reads through a NULL pointer.
+static void fault_null_read(void)
+{
+    volatile int *p = (volatile int *)0;
+    int v           = *p;
+    (void)v;
+}
+
+/// @brief Writes through a NULL pointer.
+static void fault_null_write(void)
+{
+    volatile int *p = (volatile int *)0;
+    *p              = 1;
+}
+
+/// @brief Reads from the kernel image region.
+static void fault_kernel_read(void)
+{
+    int v = *KERNEL_REGION;
+    (void)v;
+}
+
+/// @brief Writes to the kernel image region.
+static void fault_kernel_write(void)
+{
+    *KERNEL_REGION = 1;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    // Without a handler, each fault must kill the child with SIGSEGV.
+    if (check_case("null read", fault_null_read, 0) < 0) {
+        ++failures;
+    }
+    if (check_case("null write", fault_null_write, 0) < 0) {
+        ++failures;
+    }
+    if (check_case("kernel read", fault_kernel_read, 0) < 0) {
+        ++failures;
+    }
+    if (check_case("kernel write", fault_kernel_write, 0) < 0) {
+        ++failures;
+    }
+    // With a handler installed, the signal must be delivered through the
+    // faulting frame and the handler must run.
+    if (check_case("null read, handled", fault_null_read, 1) < 0) {
+        ++failures;
+    }
+    if (check_case("kernel read, handled", fault_kernel_read, 1) < 0) {
+        ++failures;
+    }
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_userfault] all user-mode fault checks passed");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_userfault] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Fixes #237: `page_fault()` panicked the kernel on user-mode faults it could not resolve. Only two cases signalled the process (non-present directory entry, and user+write+present copy-on-write); everything else fell through to an unconditional `__page_fault_panic()`. Because the first 1 MiB is identity-mapped supervisor-only in the main page directory and every process inherits it, PDE 0 is always present, so a plain null dereference from an unprivileged program took down the kernel — as did any wild pointer into a kernel-mapped region.

## Change

The SIGSEGV delivery is extracted into `__send_sigsegv_to_current()` (`sys_kill` + `scheduler_run`, exactly the sequence the working branch already used) and applied to every user-mode fault the kernel cannot legitimately resolve:

| Case | Before | After |
| --- | --- | --- |
| Non-present directory entry | SIGSEGV | SIGSEGV (shared code) |
| Kernel mapping window (`is_valid_virtual_address`) | serviced by the demand-paging fixup on behalf of user mode | SIGSEGV |
| Copy-on-write handling failed | SIGSEGV only for write faults on present pages | SIGSEGV for any user fault |
| Present, non-copy-on-write page (null deref) | **panic** | SIGSEGV |

Kernel-mode faults still panic, since those are kernel bugs, and the stack-overflow guard-page path is untouched.

## Test

`t_userfault` forks children that read and write through NULL and read and write the kernel image region at `0xC0000000` (which also exercises the mapping-window branch), first with no handler, then with a `SIGSEGV` handler installed. It expects each child to die with `SIGSEGV` (`WIFSIGNALED`/`WTERMSIG`) or to exit from its handler, which also proves delivery through the faulting frame. A write to the child's own code page is deliberately not covered: PT_LOAD segments are mapped writable regardless of their ELF permissions, so that write succeeds today (#210).

## Validation

- Debug build warning-free; full suite `57/57`, 0 panics.
- Negative control: reverting only `page_fault.c` panics the run at `t_userfault` with `cr2 0x0`, the exact signature in the issue report.
- `git diff --check` clean, `clang-format` applied.

## Known limitation

A process whose `SIGSEGV` handler returns normally resumes at the faulting instruction and faults again, since the kernel does not reset the handler to the default action the way Linux `force_sig_info` does. Pre-existing on the signalling paths and now reachable from more of them; noted in `docs/maintainer/memory-management.md` and filed separately.

Refs #223, #219, #212, #121.
