### PR TITLE
fix(fs): reject over-long path components instead of truncating them

### DIFF
--- a/docs/maintainer/syscall-boundaries.md
+++ b/docs/maintainer/syscall-boundaries.md
@@ -20,7 +20,7 @@ investigation touched)
 | `write` | buf | passed to fs `write_f`; authorized by per-fd `flags_mask` ONLY (read_write.c:63) |
 | `pipe` | fds[2] | written directly (kernel writes two ints to user pointer) |
 | `waitpid` | status | `*status = child->exit_code` direct store (not deeply audited) |
-| open/close/chdir/etc. | path strings | `resolve_path` copies into kernel `PATH_MAX` buffers (bounded), but the SOURCE `path` is walked unbounded by tokenizers/strlen inside resolve and fs layers (INFERENCE: same class, not separately reproduced) |
+| open/close/chdir/etc. | path strings | `resolve_path` copies into kernel `PATH_MAX` buffers (bounded), but the SOURCE `path` is walked unbounded by tokenizers/strlen inside resolve and fs layers (INFERENCE: same class, not separately reproduced). Since #284 the walk no longer truncates: a component longer than `NAME_MAX - 1` characters, or a token that does not fit the caller buffer, fails with `-ENAMETOOLONG` instead of resolving to a shorter name |
 
 ## Contracts a future syscall must NOT assume exist
 

--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -2782,11 +2782,18 @@ static int ext2_resolve_path(vfs_file_t *directory, const char *path, ext2_diren
     ino_t ino            = directory->ino;
     char token[NAME_MAX] = {0};
     size_t offset        = 0;
-    while (tokenize(path, "/", &offset, token, NAME_MAX)) {
+    int tokens;
+    while ((tokens = tokenize(path, "/", &offset, token, NAME_MAX)) > 0) {
         if (ext2_find_direntry(fs, ino, token, search)) {
             return -1;
         }
         ino = search->direntry.inode;
+    }
+    // A component that does not fit the token buffer is rejected, never
+    // truncated: a truncated component would resolve to a different name.
+    if (tokens < 0) {
+        pr_err("Path component too long in `%s`.\n", path);
+        return -1;
     }
     pr_debug(
         "ext2_resolve_path(directory: %s, path: %s) -> (%s, %d)\n", directory->name, path, search->direntry.name,

--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -2839,7 +2839,21 @@ static ext2_filesystem_t *get_ext2_filesystem(const char *absolute_path)
 /// @param name the name of the file.
 /// @param name_len the length of the name.
 /// @return 0 on success, -errno on failure.
-static int ext2_init_vfs_file(
+/// @brief Copies into the VFS file the properties that describe the on-disk
+///        object, leaving every field that tracks the life of the open file
+///        (`count`, `refcount`, `f_pos`, the sibling links) untouched.
+/// @param fs a pointer to the filesystem.
+/// @param file the file we want to update.
+/// @param inode the inode we take the properties from.
+/// @param inode_index the inode index.
+/// @param name the name of the file.
+/// @param name_len the length of the name.
+/// @details This is also used to refresh an entry found in the list of open
+///          files: that list is keyed by inode number, and a freed inode can
+///          be reused by an unrelated file, whose name and permissions would
+///          otherwise be those of the file that held the number before it
+///          (#297).
+static void __ext2_set_vfs_file_properties(
     ext2_filesystem_t *fs,
     vfs_file_t *file,
     ext2_inode_t *inode,
@@ -2847,9 +2861,10 @@ static int ext2_init_vfs_file(
     const char *name,
     size_t name_len)
 {
-    // Copy the name
-    memcpy(file->name, name, name_len);
-    file->name[name_len] = 0;
+    // Copy the name, keeping room for the terminator inside the field.
+    size_t copy_len = (name_len < NAME_MAX) ? name_len : (NAME_MAX - 1);
+    memcpy(file->name, name, copy_len);
+    file->name[copy_len] = 0;
     // Set the device.
     file->device         = (void *)fs;
     // Set the mask.
@@ -2881,10 +2896,6 @@ static int ext2_init_vfs_file(
     file->ino            = inode_index;
     // Set the size of the file.
     file->length         = inode->size;
-    //uint32_t impl;
-    //uint32_t open_flags;
-    // Set the open count.
-    file->count          = 0;
     // Set the timing information.
     file->atime          = inode->atime;
     file->mtime          = inode->mtime;
@@ -2892,10 +2903,34 @@ static int ext2_init_vfs_file(
     // Set the FS specific operations.
     file->sys_operations = &ext2_sys_operations;
     file->fs_operations  = &ext2_fs_operations;
-    // Set the read offest.
-    file->f_pos          = 0;
     // Set the number of links.
     file->nlink          = inode->links_count;
+}
+
+/// @brief Initializes the VFS file.
+/// @param fs a pointer to the filesystem.
+/// @param file the file we want to initialize.
+/// @param inode the inode we use to initialize the VFS file.
+/// @param inode_index the inode index.
+/// @param name the name of the file.
+/// @param name_len the length of the name.
+/// @return 0 on success, -errno on failure.
+static int ext2_init_vfs_file(
+    ext2_filesystem_t *fs,
+    vfs_file_t *file,
+    ext2_inode_t *inode,
+    uint32_t inode_index,
+    const char *name,
+    size_t name_len)
+{
+    // Set everything that comes from the inode.
+    __ext2_set_vfs_file_properties(fs, file, inode, inode_index, name, name_len);
+    //uint32_t impl;
+    //uint32_t open_flags;
+    // Set the open count.
+    file->count = 0;
+    // Set the read offest.
+    file->f_pos = 0;
     // Initialize the list of siblings.
     list_head_init(&file->siblings);
     // Set the refcount to zero.
@@ -3059,6 +3094,12 @@ static vfs_file_t *ext2_creat(const char *path, mode_t mode)
             }
             // Add the vfs_file to the list of associated files.
             list_head_insert_before(&file->siblings, &fs->opened_files);
+        } else {
+            // The list of open files is keyed by inode number, and the entry
+            // may describe a file that was deleted while its number got
+            // reused: refresh it from the inode we just read (#297).
+            __ext2_set_vfs_file_properties(
+                fs, file, &inode, search.direntry.inode, search.direntry.name, search.direntry.name_len);
         }
         return file;
     }
@@ -3189,6 +3230,13 @@ static vfs_file_t *ext2_open(const char *path, int flags, mode_t mode)
     }
 
     vfs_file_t *file = ext2_find_vfs_file_with_inode(fs, search.direntry.inode);
+    if (file != NULL) {
+        // The list of open files is keyed by inode number, and the entry may
+        // describe a file that was deleted while its number got reused:
+        // refresh it from the inode we just read (#297).
+        __ext2_set_vfs_file_properties(
+            fs, file, &inode, search.direntry.inode, search.direntry.name, search.direntry.name_len);
+    }
     if (file == NULL) {
         // Allocate the memory for the file.
         file = vfs_alloc_file();

--- a/kernel/src/fs/namei.c
+++ b/kernel/src/fs/namei.c
@@ -147,7 +147,8 @@ int __resolve_path(const char *path, char *abspath, size_t buflen, int flags, in
         pr_debug("|%-32s|%-32s| (INIT)\n", path, buffer);
     }
 
-    while (tokenize(path, "/", &offset, token, NAME_MAX)) {
+    int tokens;
+    while ((tokens = tokenize(path, "/", &offset, token, NAME_MAX)) > 0) {
         tokenlen = strlen(token);
         if ((strcmp(token, "..") == 0) && (tokenlen == 2)) {
             // Handle parent directory token "..".
@@ -201,6 +202,12 @@ int __resolve_path(const char *path, char *abspath, size_t buflen, int flags, in
                 }
             }
         }
+    }
+    // A component that does not fit the token buffer is rejected, never
+    // truncated: a truncated component would resolve to a different name.
+    if (tokens < 0) {
+        pr_err("Path component too long while resolving a path.\n");
+        return -ENAMETOOLONG;
     }
     if (contains_links) {
         pr_debug("|%-32s|%-32s| (RECU)\n", path, buffer);

--- a/kernel/src/fs/vfs.c
+++ b/kernel/src/fs/vfs.c
@@ -730,7 +730,7 @@ vfs_file_t *vfs_creat(const char *path, mode_t mode)
     int ret           = resolve_path(path, absolute_path, PATH_MAX, resolve_flags);
     if (ret < 0) {
         pr_err("vfs_creat(%s): Cannot get the absolute path.\n", path);
-        errno = ret;
+        errno = -ret;
         return NULL;
     }
     super_block_t *sb = vfs_get_superblock(absolute_path);

--- a/kernel/src/klib/string.c
+++ b/kernel/src/klib/string.c
@@ -221,35 +221,45 @@ char *strpbrk(const char *string, const char *control)
 
 int tokenize(const char *string, const char *separators, size_t *offset, char *buffer, ssize_t buflen)
 {
-    // If we reached the end of the parsed string, stop.
-    if ((*offset >= buflen) || (string[*offset] == 0)) {
+    // We need room for at least one character and the terminator.
+    if ((buffer == NULL) || (buflen <= 1)) {
+        return -1;
+    }
+    // If we reached the end of the parsed string, stop. The buffer length
+    // bounds the token only: using it on the offset would stop the parse in
+    // the middle of a long string and silently drop its tail.
+    if (string[*offset] == 0) {
         return 0;
     }
     // Skip any leading (multiple) separators.
-    while (string[*offset] != 0 && strchr(separators, string[*offset])) {
+    while ((string[*offset] != 0) && strchr(separators, string[*offset])) {
         ++(*offset);
     }
     // If we reach the end after skipping, return 0.
     if (string[*offset] == 0) {
         return 0;
     }
-    // Keep copying character until we either reach 1) the end of the buffer, 2) a
-    // separator, or 3) the end of the string we are parsing.
-    do {
-        // Check if the character is a separator.
-        if (strchr(separators, string[*offset])) {
-            // Skip the character.
-            ++(*offset);
-            // Close the buffer.
+    // Room left in the buffer, keeping one byte for the terminator.
+    ssize_t available = buflen - 1;
+    // Keep copying characters until we either reach a separator or the end of
+    // the string we are parsing.
+    while ((string[*offset] != 0) && (strchr(separators, string[*offset]) == NULL)) {
+        // The token does not fit the buffer: report it instead of truncating,
+        // since a truncated token names something else than what was asked.
+        if (available == 0) {
             *buffer = '\0';
-            return 1;
+            return -1;
         }
         // Save the character.
         *buffer = string[*offset];
-        // Advance the offset, decrese the available size in the buffer, and advance
-        // the buffer.
-        ++(*offset), --buflen, ++buffer;
-    } while ((buflen > 0) && (string[*offset] != 0));
+        // Advance the offset, decrease the available size in the buffer, and
+        // advance the buffer.
+        ++(*offset), --available, ++buffer;
+    }
+    // Consume the separator that closed the token, if any.
+    if (string[*offset] != 0) {
+        ++(*offset);
+    }
     // Close the buffer.
     *buffer = '\0';
     return 1;

--- a/lib/inc/string.h
+++ b/lib/inc/string.h
@@ -171,13 +171,21 @@ char *strtok(char *str, const char *delim);
 char *strtok_r(char *str, const char *delim, char **saveptr);
 
 /// @brief Parses the string using the separator, and at each call it saves the
-/// parsed token in buffer. The pointer `string` will be modified.
-/// @param string cursor used to parse the string, it will be modified.
+/// parsed token in buffer.
+/// @param string the string we are parsing, it is not modified.
 /// @param separators the list of separators we are using.
 /// @param offset the offset character from which we start extracting the next token.
 /// @param buffer the buffer where we save the parsed token.
-/// @param buflen the length of the buffer.
-/// @return 1 if we still have things to parse, 0 if we finished parsing.
+/// @param buflen the length of the buffer, it bounds the token only and never
+///        the offset into `string`.
+/// @return 1 if we still have things to parse, 0 if we finished parsing, -1 if
+///         the next token does not fit in `buffer`.
+/// @details A token longer than `buflen - 1` characters is reported with -1
+///          rather than truncated, because a truncated token names something
+///          else than what the caller asked for. Callers must therefore test
+///          the result against 0 explicitly, since a plain `while (tokenize(...))`
+///          treats the error as another token. The parse state is undefined
+///          after an error.
 int tokenize(const char *string, const char *separators, size_t *offset, char *buffer, ssize_t buflen);
 
 /// @brief Copies the values of num bytes from the location pointed by source

--- a/lib/src/string.c
+++ b/lib/src/string.c
@@ -220,35 +220,45 @@ char *strpbrk(const char *string, const char *control)
 
 int tokenize(const char *string, const char *separators, size_t *offset, char *buffer, ssize_t buflen)
 {
-    // If we reached the end of the parsed string, stop.
-    if ((*offset >= buflen) || (string[*offset] == 0)) {
+    // We need room for at least one character and the terminator.
+    if ((buffer == NULL) || (buflen <= 1)) {
+        return -1;
+    }
+    // If we reached the end of the parsed string, stop. The buffer length
+    // bounds the token only: using it on the offset would stop the parse in
+    // the middle of a long string and silently drop its tail.
+    if (string[*offset] == 0) {
         return 0;
     }
     // Skip any leading (multiple) separators.
-    while (string[*offset] != 0 && strchr(separators, string[*offset])) {
+    while ((string[*offset] != 0) && strchr(separators, string[*offset])) {
         ++(*offset);
     }
     // If we reach the end after skipping, return 0.
     if (string[*offset] == 0) {
         return 0;
     }
-    // Keep copying character until we either reach 1) the end of the buffer, 2) a
-    // separator, or 3) the end of the string we are parsing.
-    do {
-        // Check if the character is a separator.
-        if (strchr(separators, string[*offset])) {
-            // Skip the character.
-            ++(*offset);
-            // Close the buffer.
+    // Room left in the buffer, keeping one byte for the terminator.
+    ssize_t available = buflen - 1;
+    // Keep copying characters until we either reach a separator or the end of
+    // the string we are parsing.
+    while ((string[*offset] != 0) && (strchr(separators, string[*offset]) == NULL)) {
+        // The token does not fit the buffer: report it instead of truncating,
+        // since a truncated token names something else than what was asked.
+        if (available == 0) {
             *buffer = '\0';
-            return 1;
+            return -1;
         }
         // Save the character.
         *buffer = string[*offset];
-        // Advance the offset, decrese the available size in the buffer, and advance
-        // the buffer.
-        ++(*offset), --buflen, ++buffer;
-    } while ((buflen > 0) && (string[*offset] != 0));
+        // Advance the offset, decrease the available size in the buffer, and
+        // advance the buffer.
+        ++(*offset), --available, ++buffer;
+    }
+    // Consume the separator that closed the token, if any.
+    if (string[*offset] != 0) {
+        ++(*offset);
+    }
     // Close the buffer.
     *buffer = '\0';
     return 1;

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -35,6 +35,7 @@ static char *all_tests[] = {
     "t_execve_bounds",
     "t_execve_bigargv",
     "t_userfault",
+    "t_path_bounds",
     "t_execve_fail",
     "t_elf_short",
     "t_exit",

--- a/userspace/bin/shell.c
+++ b/userspace/bin/shell.c
@@ -161,11 +161,17 @@ static inline int __search_in_path(const char *entry, dirent_t *result)
     char token[NAME_MAX] = {0}; // Buffer to hold each token (directory).
     size_t offset        = 0;   // Offset for the tokenizer.
     // Iterate through each directory in the PATH.
-    while (tokenize(PATH_VAR, ":", &offset, token, NAME_MAX)) {
+    int tokens;
+    while ((tokens = tokenize(PATH_VAR, ":", &offset, token, NAME_MAX)) > 0) {
         // Search for the entry in the current directory (tokenized directory).
         if (__folder_contains(token, entry, DT_REG, result)) {
             return 1; // Return 1 if the entry is found.
         }
+    }
+    // An entry of PATH longer than the token buffer is skipped, and the rest
+    // of the variable cannot be parsed after the error.
+    if (tokens < 0) {
+        fprintf(stderr, "__search_in_path: a PATH entry is too long.\n");
     }
     return 0; // Return 0 if the entry was not found.
 }

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_LIST
     t_execve_bounds.c
     t_execve_bigargv.c
     t_userfault.c
+    t_path_bounds.c
     t_execve_fail.c
     t_elf_short.c
     t_gid.c

--- a/userspace/tests/t_execve_bounds.c
+++ b/userspace/tests/t_execve_bounds.c
@@ -169,9 +169,13 @@ static int check_filename_too_long(void)
     return 0;
 }
 
-/// @brief A filename of exactly PATH_MAX - 1 characters fits: it must be
-/// walked safely and fail with ENOENT (it cannot exist), not with a crash
-/// or a memory error.
+/// @brief A filename of exactly PATH_MAX - 1 characters fits the buffer, but
+/// its single component is far longer than NAME_MAX: it must be walked safely
+/// and rejected with ENAMETOOLONG, not with a crash or a memory error.
+/// @details Until #284 the resolver truncated the component to NAME_MAX
+/// characters and looked that up instead, so this case reported ENOENT: the
+/// truncated name happened not to exist. A name that does exist at the
+/// truncation point would have been executed in its place.
 /// @return 0 on success, -1 on failure.
 static int check_filename_longest_valid(void)
 {
@@ -183,8 +187,8 @@ static int check_filename_longest_valid(void)
         syslog(LOG_ERR, "[t_execve_bounds] execve of a 4095-char filename unexpectedly succeeded");
         return -1;
     }
-    if (errno != ENOENT) {
-        syslog(LOG_ERR, "[t_execve_bounds] 4095-char filename: expected ENOENT, got %s", strerror(errno));
+    if (errno != ENAMETOOLONG) {
+        syslog(LOG_ERR, "[t_execve_bounds] 4095-char filename: expected ENAMETOOLONG, got %s", strerror(errno));
         return -1;
     }
     return 0;

--- a/userspace/tests/t_path_bounds.c
+++ b/userspace/tests/t_path_bounds.c
@@ -1,0 +1,234 @@
+/// @file t_path_bounds.c
+/// @brief Regression test for #284: path resolution must never silently
+/// truncate a path or one of its components.
+/// @details `tokenize()` used the capacity of the token buffer as the bound
+/// for the offset into the *path*, so any component starting past byte 255 of
+/// the path was dropped and a component longer than the buffer was truncated.
+/// A request for a path then resolved to a different, shorter name: the file
+/// named by a prefix of the request was opened or executed instead of the one
+/// asked for. The checks below cover the three observable consequences:
+///   - a file whose path is longer than 255 bytes can be created and read;
+///   - a request for a name below an existing 255-byte-plus path fails
+///     instead of resolving to that path;
+///   - a component of exactly NAME_MAX characters or longer is rejected with
+///     ENAMETOOLONG instead of being truncated to a name that exists.
+/// The longest usable component, NAME_MAX - 1 characters, must keep working.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// Parent directory used by the checks. Every artifact lives in a directory
+/// of its own, so the long names never share a directory with other tests.
+#define BASE_DIR "/home/user/t_path_bounds.d"
+
+/// Length of the directory component that pushes the path past 255 bytes.
+#define LONG_DIR_LEN 250
+
+/// @brief Fills the buffer with a repeated character and terminates it.
+/// @param buffer the destination buffer.
+/// @param c the character to repeat.
+/// @param count how many times to repeat it.
+static void __fill_name(char *buffer, char c, size_t count)
+{
+    memset(buffer, c, count);
+    buffer[count] = 0;
+}
+
+/// @brief Creates a file and writes the given content into it.
+/// @param path the file to create.
+/// @param content the content to write.
+/// @return 0 on success, -1 on failure.
+static int __write_file(const char *path, const char *content)
+{
+    int fd = creat(path, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_path_bounds] creat(%zu-byte path): %s", strlen(path), strerror(errno));
+        return -1;
+    }
+    size_t length   = strlen(content);
+    ssize_t written = write(fd, content, length);
+    close(fd);
+    if (written != (ssize_t)length) {
+        syslog(LOG_ERR, "[t_path_bounds] write returned %zd, expected %zu", written, length);
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Reads a file and compares its content with the expected string.
+/// @param path the file to read.
+/// @param expected the expected content.
+/// @return 0 when the content matches, -1 otherwise.
+static int __check_content(const char *path, const char *expected)
+{
+    char buffer[64] = {0};
+    int fd          = open(path, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_path_bounds] open(%zu-byte path): %s", strlen(path), strerror(errno));
+        return -1;
+    }
+    ssize_t bytes = read(fd, buffer, sizeof(buffer) - 1);
+    close(fd);
+    if (bytes < 0) {
+        syslog(LOG_ERR, "[t_path_bounds] read: %s", strerror(errno));
+        return -1;
+    }
+    buffer[bytes] = 0;
+    if (strcmp(buffer, expected) != 0) {
+        syslog(LOG_ERR, "[t_path_bounds] content is `%s`, expected `%s`", buffer, expected);
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief A file whose path exceeds 255 bytes must be created and read back.
+/// @param dir the directory holding the file, its path is already over 255
+///        bytes so the file component starts past the old truncation point.
+/// @param file the resulting file path, filled by this function.
+/// @return 0 on success, -1 on failure.
+static int check_long_path(const char *dir, char *file)
+{
+    strcpy(file, dir);
+    strcat(file, "/deep.txt");
+    if (__write_file(file, "DEEPFILE") < 0) {
+        return -1;
+    }
+    if (__check_content(file, "DEEPFILE") < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief A name below an existing over-255-byte path must not resolve to
+///        that path: the trailing component used to be dropped, so the
+///        request silently reached the prefix instead.
+/// @param dir the existing directory, over 255 bytes long.
+/// @return 0 on success, -1 on failure.
+static int check_no_prefix_resolution(const char *dir)
+{
+    char path[PATH_MAX] = {0};
+    strcpy(path, dir);
+    strcat(path, "/nonexistent");
+    int fd = open(path, O_RDONLY, 0);
+    if (fd >= 0) {
+        close(fd);
+        syslog(LOG_ERR, "[t_path_bounds] open of a nonexistent name below a long path succeeded");
+        return -1;
+    }
+    if (errno != ENOENT) {
+        syslog(LOG_ERR, "[t_path_bounds] expected ENOENT below a long path, got %s", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief The longest usable component, NAME_MAX - 1 characters, must work.
+/// @param file the resulting file path, filled by this function.
+/// @return 0 on success, -1 on failure.
+static int check_max_component(char *file)
+{
+    char name[NAME_MAX + 1] = {0};
+    __fill_name(name, 'm', NAME_MAX - 1);
+    strcpy(file, BASE_DIR "/");
+    strcat(file, name);
+    if (__write_file(file, "MAXNAME") < 0) {
+        return -1;
+    }
+    if (__check_content(file, "MAXNAME") < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief A component of NAME_MAX characters or longer must be rejected with
+///        ENAMETOOLONG instead of being truncated to an existing name.
+/// @param length the component length to test.
+/// @return 0 on success, -1 on failure.
+static int check_component_rejected(size_t length)
+{
+    char name[PATH_MAX] = {0};
+    char path[PATH_MAX] = {0};
+    __fill_name(name, 'x', length);
+    strcpy(path, BASE_DIR "/");
+    strcat(path, name);
+    int fd = creat(path, 0644);
+    if (fd >= 0) {
+        close(fd);
+        unlink(path);
+        syslog(LOG_ERR, "[t_path_bounds] creat of a %zu-character component succeeded", length);
+        return -1;
+    }
+    if (errno != ENAMETOOLONG) {
+        syslog(
+            LOG_ERR, "[t_path_bounds] %zu-character component: expected ENAMETOOLONG, got %s", length,
+            strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    char dir[PATH_MAX]       = {0};
+    char deep_file[PATH_MAX] = {0};
+    char max_file[PATH_MAX]  = {0};
+    char name[NAME_MAX + 1]  = {0};
+    int failures             = 0;
+
+    // The directory path is 27 + LONG_DIR_LEN bytes, over the 255-byte mark,
+    // while the component itself stays below NAME_MAX.
+    if ((mkdir(BASE_DIR, 0755) < 0) && (errno != EEXIST)) {
+        syslog(LOG_ERR, "[t_path_bounds] mkdir(%s): %s", BASE_DIR, strerror(errno));
+        return EXIT_FAILURE;
+    }
+    __fill_name(name, 'a', LONG_DIR_LEN);
+    strcpy(dir, BASE_DIR "/");
+    strcat(dir, name);
+    if (mkdir(dir, 0755) < 0) {
+        syslog(LOG_ERR, "[t_path_bounds] mkdir(%zu-byte path): %s", strlen(dir), strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    if (check_long_path(dir, deep_file) < 0) {
+        ++failures;
+    }
+    if (check_no_prefix_resolution(dir) < 0) {
+        ++failures;
+    }
+    if (check_max_component(max_file) < 0) {
+        ++failures;
+    }
+    if (check_component_rejected(NAME_MAX) < 0) {
+        ++failures;
+    }
+    if (check_component_rejected(NAME_MAX + 45) < 0) {
+        ++failures;
+    }
+
+    // Best-effort cleanup, so a second run on the same image starts clean.
+    if (deep_file[0]) {
+        unlink(deep_file);
+    }
+    if (max_file[0]) {
+        unlink(max_file);
+    }
+    rmdir(dir);
+    rmdir(BASE_DIR);
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_path_bounds] all path boundary checks passed");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_path_bounds] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Fixes #284, plus the two defects its regression test uncovered (#298 and #297). Three commits, one per defect, each leaving the suite green.

`tokenize()` used the capacity of the **token buffer** as the bound for the offset into the **path**. Any component starting past byte 255 of the path was dropped, so a request silently resolved to a prefix of itself, and a component longer than the buffer was truncated after a 1-byte write past the array on the kernel stack. Every path-based syscall was affected, and for `execve` it meant running a file the caller never asked for.

## The three commits

**1. `fix(vfs)`: positive errno in `vfs_creat` (#298).** `vfs_creat` stored the already-negative result of `resolve_path` into `errno`, and `sys_creat` returns `-errno`. The negations cancelled, so a failed resolution made `creat()` return a positive number that user space takes for a valid descriptor, one that `sys_creat` never installed. `vfs_open` and `realpath` already used `-ret`. Latent before this branch, because the resolver truncated instead of failing.

**2. `fix(ext2)`: refresh cached file properties on inode reuse (#297).** The list of open files is searched by inode number alone and nothing removes an entry when a name is unlinked, so a new file reusing a freed inode number was opened **as the deleted file**, inheriting its name, mask, uid, gid and length. A 0644 file whose inode last held an executable passed `vfs_valid_exec_permission`. Instrumenting the reuse branch showed 13 mismatched reuses out of 70 in one suite run. The on-disk properties now live in `__ext2_set_vfs_file_properties`, called both when initializing a new file object and when the lookup finds an existing one; the fields tracking the life of the open file are left alone.

**3. `fix(fs)`: reject over-long components (#284).** `buflen` bounds the token only, and a token that does not fit returns -1 instead of being truncated. The callers in namei, ext2 and the shell test the result explicitly and turn it into `-ENAMETOOLONG`. Components of `NAME_MAX` characters or longer are rejected; the longest usable name, `NAME_MAX - 1`, keeps working.

## Test

`t_path_bounds` covers the three observable consequences:

| Check | Before | After |
| --- | --- | --- |
| File at a 263-byte path, created and read back | final component dropped, `read` hit the directory | content matches |
| Nonexistent name below that path | resolved to the prefix, `open` succeeded | `ENOENT` |
| Component of 255 and of 300 characters | `creat` succeeded on a truncated name | `ENAMETOOLONG` |
| Component of `NAME_MAX - 1` characters | works | works |

Its artifacts live in a directory of their own, so the long names never share a directory with other tests.

`t_execve_bounds` expected `ENOENT` for a 4095-character single-component filename, which is what the truncating resolver returned once the shortened name did not exist. That case now reports `ENAMETOOLONG`, the answer POSIX prescribes for a component longer than `NAME_MAX`. The stale expectation is updated with a note explaining why.

## Validation

- Debug and Release both warning-free: `58/58` tests, 0 panics on each.
- Negative control: reverting only the tokenizer makes `t_path_bounds` report all four truncation checks as failures; reverting only the errno fix makes the two `ENAMETOOLONG` checks report a successful `creat`; reverting only the ext2 cache fix makes `t_execve_fail` and `t_shebang` report `ENOEXEC` and `ENOENT` where they expect `EACCES`.
- `git diff --check` clean.

## Notes for review

- The `tokenize` contract changed: callers must compare against 0 explicitly, since a plain `while (tokenize(...))` would treat the error as another token. All three in-tree callers are updated and the header documents it.
- The name copy in the new ext2 helper is clamped to the field size so the added call site cannot write past it. #285 still covers the policy for 255-character on-disk names and the sibling copy in `ext2_find_direntry`.
- Both copies of `tokenize`, the kernel one and the libc one, are kept in sync.
