### PR TITLE
fix(ext2): fail and roll back mkdir when the directory cannot be completed

### DIFF
--- a/docs/maintainer/false-positives-and-dismissed-findings.md
+++ b/docs/maintainer/false-positives-and-dismissed-findings.md
@@ -77,11 +77,17 @@ Baselines: `BASE` 82f4314 / `MAIN` 62c638a.
 
 ## 7. Tests skipped in runtests / TEST_LIST
 
-- `t_big_write`, `t_periodic1/2/3` commented out of `all_tests[]`;
-  `t_time` disabled in CMake TEST_LIST.
+- `t_big_write`, `t_periodic1/2/3`, `t_mkdir_nospace` commented out of
+  `all_tests[]`; `t_time` disabled in CMake TEST_LIST.
 - **Verdict**: INTENTIONAL (explicit comments), not infrastructure rot.
   Do not "fix" silently; re-enabling changes CI meaning (and t_big_write
   predates the #192 panic boundary anyway — it sorts after t_gid).
+- `t_mkdir_nospace` (#264) is the one skipped for runtime rather than
+  meaning: it fills the 32 MB image block by block to force an allocation
+  failure, ~2 min of guest time, because ext2 rewrites the block bitmap,
+  the group descriptor and the superblock per allocated block and
+  `ext2_find_free_block` rescans from the start each time. Run it by hand
+  when touching the ext2 allocation paths.
 
 ## 8. Byte-identical `debugfs dump` of t_gid "disproving" the hole
 

--- a/docs/maintainer/testing-and-ci.md
+++ b/docs/maintainer/testing-and-ci.md
@@ -23,8 +23,11 @@ Verified against `MAIN` = `62c638a` (line refs for `MAIN` unless noted).
 
 1. `userspace/tests/CMakeLists.txt` → `TEST_LIST`.
 2. `userspace/bin/runtests.c` → `all_tests[]` (order = execution order).
-   Intentionally skipped there: `t_big_write`, `t_periodic1/2/3`;
-   `t_time` disabled in CMake TEST_LIST.
+   Intentionally skipped there: `t_big_write`, `t_periodic1/2/3`,
+   `t_mkdir_nospace`; `t_time` disabled in CMake TEST_LIST.
+   `t_mkdir_nospace` fills the image to force an allocation failure, which
+   costs about two minutes of guest time: run it by hand when touching the
+   ext2 allocation paths.
 
 ## Guest output routing (critical for debugging)
 

--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -2995,6 +2995,9 @@ static int ext2_create_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, mode_t 
     // Get the inode associated with the directory entry.
     if (ext2_read_inode(fs, inode, inode_index) == -1) {
         pr_err("Failed to read the newly created inode.\n");
+        // The inode is already marked as used on disk: give it back, it owns
+        // no block yet, so a zeroed inode is enough to free it (#264).
+        ext2_free_inode(fs, inode, inode_index);
         return -1;
     }
     // Get the UID and GID.
@@ -3754,6 +3757,49 @@ static ssize_t ext2_readlink(const char *path, char *buffer, size_t bufsize)
 /// @param path The path of the new directory.
 /// @param mode The mode with which we create the directory.
 /// @return Returns a negative value on failure.
+/// @brief Clears the directory entry of an incomplete directory.
+/// @param fs the filesystem.
+/// @param path the path of the directory being created.
+/// @return 0 on success, -1 on failure.
+/// @details Used when mkdir cannot finish: the entry it added to the parent
+///          must go away before the inode is freed, otherwise the parent
+///          keeps a name pointing at a free inode (#264).
+static int __ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path)
+{
+    ext2_direntry_search_t search;
+    memset(&search, 0, sizeof(ext2_direntry_search_t));
+    // Locate the entry we added, so we know which block holds it.
+    if (ext2_resolve_path(fs->root, path, &search)) {
+        pr_err("Failed to locate the directory entry of `%s`.\n", path);
+        return -1;
+    }
+    ext2_inode_t parent;
+    if (ext2_read_inode(fs, &parent, search.parent_inode) == -1) {
+        pr_err("Failed to read the parent inode of `%s`.\n", path);
+        return -1;
+    }
+    // Allocate the cache.
+    uint8_t *cache = ext2_alloc_cache(fs);
+    // Read the block where the entry resides.
+    if (ext2_read_inode_block(fs, &parent, search.block_index, cache) == -1) {
+        pr_err("Failed to read block `%u` of inode `%u`.\n", search.block_index, (uint32_t)search.parent_inode);
+        ext2_dealloc_cache(cache);
+        return -1;
+    }
+    // An entry pointing at inode 0 is a free entry.
+    ext2_dirent_t *dirent = (ext2_dirent_t *)((uintptr_t)cache + search.block_offset);
+    dirent->inode         = 0;
+    // Write the block back.
+    int ret               = 0;
+    if (ext2_write_inode_block(fs, &parent, search.parent_inode, search.block_index, cache) == -1) {
+        pr_err("Failed to write block `%u` of inode `%u`.\n", search.block_index, (uint32_t)search.parent_inode);
+        ret = -1;
+    }
+    // Free the cache.
+    ext2_dealloc_cache(cache);
+    return ret;
+}
+
 static int ext2_mkdir(const char *path, mode_t mode)
 {
     pr_debug("ext2_mkdir(path: %s, mode: %u)\n", path, mode);
@@ -3774,7 +3820,7 @@ static int ext2_mkdir(const char *path, mode_t mode)
     ext2_filesystem_t *fs = get_ext2_filesystem(path);
     if (fs == NULL) {
         pr_err("ext2_mkdir(path: %s): Failed to get the EXT2 filesystem.\n", path);
-        return -ENOENT;
+        return -ENODEV;
     }
     // Prepare the structure for the search.
     ext2_direntry_search_t search;
@@ -3797,14 +3843,21 @@ static int ext2_mkdir(const char *path, mode_t mode)
             "ext2_mkdir(path: %s): Failed to create a new inode (group index: "
             "%d).\n",
             path, group_index);
-        return -ENOENT;
+        return -ENOSPC;
     }
+    // The inode bitmap and the group counters are on disk from here on, so
+    // every failure below has to undo them: the directory does not exist for
+    // the caller, and nothing of it may survive on the filesystem (#264).
+    int ret           = 0;
+    int has_direntry  = 0;
+    int parent_bumped = 0;
     // Increase the number of directories inside the group.
     fs->block_groups[group_index].used_dirs_count += 1;
     // Write the inode.
     if (ext2_write_inode(fs, &inode, inode_index) == -1) {
         pr_err("Failed to write the newly created inode.\n");
-        return -ENOENT;
+        ret = -EIO;
+        goto rollback;
     }
     // Get the directory name.
     const char *directory_name = basename(path);
@@ -3814,15 +3867,18 @@ static int ext2_mkdir(const char *path, mode_t mode)
             "ext2_mkdir(path: %s): Failed to allocate the new direntry `%s` "
             "for the inode.\n",
             path, directory_name);
-        return -ENOENT;
+        ret = -ENOSPC;
+        goto rollback;
     }
+    has_direntry = 1;
     // Allocate a new block.
     if (!ext2_initialize_new_direntry_block(fs, inode_index, 0)) {
         pr_err(
             "ext2_mkdir(path: %s): Failed to allocate a new block for an "
             "inode.\n",
             path);
-        return 0;
+        ret = -ENOSPC;
+        goto rollback;
     }
     // Create a directory entry, inside the new directory, pointing to itself.
     if (ext2_allocate_direntry(fs, inode_index, inode_index, ".", ext2_file_type_directory) == -1) {
@@ -3830,17 +3886,64 @@ static int ext2_mkdir(const char *path, mode_t mode)
             "ext2_mkdir(path: %s): Failed to allocate a new direntry for the "
             "inode.\n",
             path);
-        return -ENOENT;
+        ret = -ENOSPC;
+        goto rollback;
     }
     // Create a directory entry, inside the new directory, pointing to its parent.
+    // This one adds a link to the parent, which the rollback has to remove.
+    parent_bumped = 1;
     if (ext2_allocate_direntry(fs, inode_index, search.parent_inode, "..", ext2_file_type_directory) == -1) {
         pr_err(
             "ext2_mkdir(path: %s): Failed to allocate a new direntry for the "
             "inode.\n",
             path);
-        return -ENOENT;
+        ret = -ENOSPC;
+        goto rollback;
     }
     return 0;
+
+rollback:
+    // The `..` entry counts as a link to the parent, and the link is added
+    // before the entry is placed: assume it went through, since the only way
+    // it did not is a failed inode write, which already left the parent
+    // untouched on disk.
+    if (parent_bumped) {
+        ext2_inode_t parent_inode;
+        if (ext2_read_inode(fs, &parent_inode, search.parent_inode) != -1) {
+            if (parent_inode.links_count > 0) {
+                parent_inode.links_count -= 1;
+                if (ext2_write_inode(fs, &parent_inode, search.parent_inode) == -1) {
+                    pr_err("ext2_mkdir(path: %s): Failed to restore the links of the parent.\n", path);
+                }
+            }
+        }
+    }
+    // Take the name out of the parent before the inode goes away, so no entry
+    // is left pointing at a free inode.
+    if (has_direntry && (__ext2_clear_direntry_for_path(fs, path) < 0)) {
+        pr_err("ext2_mkdir(path: %s): Failed to remove the incomplete directory entry.\n", path);
+    }
+    // Re-read the inode: initializing its entry block may have given it a
+    // data block, and freeing the inode has to free that block as well.
+    ext2_inode_t stale;
+    if (ext2_read_inode(fs, &stale, inode_index) != -1) {
+        stale.links_count = 0;
+        stale.dtime       = sys_time(NULL);
+        if (ext2_write_inode(fs, &stale, inode_index) == -1) {
+            pr_err("ext2_mkdir(path: %s): Failed to update the inode being freed.\n", path);
+        }
+        if (ext2_free_inode(fs, &stale, inode_index) < 0) {
+            pr_err("ext2_mkdir(path: %s): Failed to free the inode.\n", path);
+        }
+    }
+    // Give back the directory count taken above.
+    if (fs->block_groups[group_index].used_dirs_count > 0) {
+        fs->block_groups[group_index].used_dirs_count -= 1;
+    }
+    if (ext2_write_bgdt_for_group(fs, group_index) < 0) {
+        pr_warning("ext2_mkdir(path: %s): Failed to write BGDT for group %u.\n", path, group_index);
+    }
+    return ret;
 }
 
 /// @brief Removes the given directory.

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -53,6 +53,10 @@ static char *all_tests[] = {
     "t_list",
     "t_mem",
     "t_mkdir",
+    // Skipped on purpose: filling the image to make the allocation fail takes
+    // about two minutes of guest time, too much for every CI run. Run it by
+    // hand when touching the ext2 allocation paths (#264).
+    // "t_mkdir_nospace",
     "t_msgget",
     "t_ndtree",
     "t_periodic1",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_LIST
     t_execve_bigargv.c
     t_userfault.c
     t_path_bounds.c
+    t_mkdir_nospace.c
     t_execve_fail.c
     t_elf_short.c
     t_gid.c

--- a/userspace/tests/t_mkdir_nospace.c
+++ b/userspace/tests/t_mkdir_nospace.c
@@ -1,0 +1,205 @@
+/// @file t_mkdir_nospace.c
+/// @brief Regression test for #264: mkdir must fail, and leave nothing
+/// behind, when the filesystem has no room for the new directory.
+/// @details ext2_mkdir allocates an inode, adds the entry to the parent and
+/// only then allocates the data block that holds `.` and `..`. When that
+/// last allocation failed the function returned 0, so user space saw a
+/// successful mkdir for a directory with no data block and no entries at
+/// all. Every failure after the inode allocation also reported -ENOENT
+/// regardless of the cause, and none of them freed the inode that
+/// ext2_allocate_inode had already persisted, so each attempt stranded an
+/// allocated-but-unreferenced inode and left the group counters drifted.
+///
+/// The filesystem is filled with small files, each of them below the twelve
+/// direct blocks of an inode, so the fill needs no index blocks: that keeps
+/// it clear of #301 (the block-pointer boundary defect) and #302 (index
+/// blocks leaked on free). The fill is driven by the free-block count from
+/// statfs rather than by the result of write, because a write that cannot
+/// allocate its block still reports success (#303). When mkdir wrongly
+/// reports success, the directory it claims to have created is left in
+/// place: removing it walks a zeroed directory block and never returns
+/// (#304).
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// Where the checks operate.
+#define BASE_DIR "/home/user"
+
+/// The directory the test tries to create with no space left.
+#define DIR_PATH BASE_DIR "/t_mkdir_nospace.d"
+
+/// Size of a single write, one block of the image.
+#define CHUNK 4096
+
+/// Blocks per fill file, the direct blocks of an inode.
+#define BLOCKS_PER_FILE 12
+
+/// Upper bound on the number of fill files.
+#define MAX_FILES 2000
+
+/// Buffer used for the fill writes.
+static char buffer[CHUNK];
+
+/// @brief Builds the path of a fill file.
+/// @param path the destination buffer.
+/// @param index the index of the fill file.
+static void __fill_path(char *path, int index) { sprintf(path, BASE_DIR "/t_mkdir_nospace.%04d", index); }
+
+/// @brief Reads the free counters of the filesystem.
+/// @param blocks where the free block count is stored, may be NULL.
+/// @param inodes where the free inode count is stored, may be NULL.
+/// @return 0 on success, -1 on failure.
+static int __read_free(unsigned long *blocks, unsigned long *inodes)
+{
+    statfs_t buf;
+    if (statfs(BASE_DIR, &buf) < 0) {
+        syslog(LOG_ERR, "[t_mkdir_nospace] statfs: %s", strerror(errno));
+        return -1;
+    }
+    if (blocks) {
+        *blocks = (unsigned long)buf.f_bfree;
+    }
+    if (inodes) {
+        *inodes = (unsigned long)buf.f_ffree;
+    }
+    return 0;
+}
+
+/// @brief Consumes every free block of the filesystem.
+/// @param files where the number of created files is stored.
+/// @return 0 when no free block is left, -1 on failure.
+static int __fill_filesystem(int *files)
+{
+    char path[64];
+    unsigned long blocks = 0;
+    memset(buffer, 'f', sizeof(buffer));
+    *files = 0;
+    for (int index = 0; index < MAX_FILES; ++index) {
+        if (__read_free(&blocks, NULL) < 0) {
+            return -1;
+        }
+        if (blocks == 0) {
+            return 0;
+        }
+        __fill_path(path, index);
+        int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fd < 0) {
+            syslog(LOG_ERR, "[t_mkdir_nospace] open %s: %s", path, strerror(errno));
+            return -1;
+        }
+        ++(*files);
+        for (int block = 0; block < BLOCKS_PER_FILE; ++block) {
+            if (write(fd, buffer, sizeof(buffer)) != (ssize_t)sizeof(buffer)) {
+                break;
+            }
+        }
+        close(fd);
+    }
+    syslog(LOG_ERR, "[t_mkdir_nospace] the filesystem still has free blocks after %d files", MAX_FILES);
+    return -1;
+}
+
+/// @brief Removes the fill files.
+/// @param files the number of fill files created.
+static void __remove_fill(int files)
+{
+    char path[64];
+    for (int index = 0; index < files; ++index) {
+        __fill_path(path, index);
+        unlink(path);
+    }
+}
+
+int main(void)
+{
+    unsigned long blocks_before = 0;
+    unsigned long inodes_before = 0;
+    unsigned long blocks_full   = 0;
+    unsigned long inodes_full   = 0;
+    unsigned long inodes_after  = 0;
+    int files                   = 0;
+    int failures                = 0;
+
+    if (__read_free(&blocks_before, &inodes_before) < 0) {
+        return EXIT_FAILURE;
+    }
+    syslog(LOG_INFO, "[t_mkdir_nospace] before: %lu free blocks, %lu free inodes", blocks_before, inodes_before);
+
+    if (__fill_filesystem(&files) < 0) {
+        __remove_fill(files);
+        return EXIT_FAILURE;
+    }
+    if (__read_free(&blocks_full, &inodes_full) < 0) {
+        __remove_fill(files);
+        return EXIT_FAILURE;
+    }
+    syslog(
+        LOG_INFO, "[t_mkdir_nospace] full after %d files: %lu free blocks, %lu free inodes", files, blocks_full,
+        inodes_full);
+
+    // With no room for the directory data block, mkdir must fail, and it must
+    // say why: every cause used to be reported as ENOENT.
+    errno                            = 0;
+    int ret                          = mkdir(DIR_PATH, 0755);
+    unsigned long inodes_after_mkdir = 0;
+    if (__read_free(NULL, &inodes_after_mkdir) < 0) {
+        __remove_fill(files);
+        return EXIT_FAILURE;
+    }
+    if (ret == 0) {
+        syslog(LOG_ERR, "[t_mkdir_nospace] mkdir succeeded with a full filesystem");
+        ++failures;
+        // The directory it claims to have created has no entries at all, and
+        // it is not removed here: rmdir walks its zeroed block and never
+        // comes back (#304).
+        int fd = open(DIR_PATH, O_RDONLY | O_DIRECTORY, 0);
+        syslog(
+            LOG_ERR, "[t_mkdir_nospace] open of the claimed directory returned %d (%s)", fd,
+            (fd < 0) ? strerror(errno) : "no error");
+        if (fd >= 0) {
+            close(fd);
+        }
+    } else if (errno != ENOSPC) {
+        syslog(LOG_ERR, "[t_mkdir_nospace] mkdir failed with %s, expected ENOSPC", strerror(errno));
+        ++failures;
+    }
+
+    // The failed mkdir must have given back the inode it had allocated. The
+    // count is compared against the one taken right before the call, so that
+    // whatever the fill itself consumed or stranded stays out of the check.
+    if (inodes_after_mkdir != inodes_full) {
+        syslog(
+            LOG_ERR, "[t_mkdir_nospace] free inodes went from %lu to %lu across the failed mkdir: it stranded one",
+            inodes_full, inodes_after_mkdir);
+        ++failures;
+    }
+
+    // Give the space back. Free blocks and inodes are only reported here:
+    // the parent directory keeps the blocks it grew to hold the fill entries,
+    // and ext2 never shrinks a directory.
+    __remove_fill(files);
+    if (__read_free(NULL, &inodes_after) < 0) {
+        return EXIT_FAILURE;
+    }
+    syslog(
+        LOG_INFO, "[t_mkdir_nospace] after the fill was removed: %lu free inodes (%lu before the test)", inodes_after,
+        inodes_before);
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_mkdir_nospace] mkdir reported ENOSPC and left nothing behind");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_mkdir_nospace] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Fixes #264. `ext2_mkdir()` allocates the inode, adds the entry to the parent and only then allocates the data block that holds `.` and `..`. Three defects sat on those failure paths:

- a failed allocation of that block **returned 0**, so user space saw a successful `mkdir` for a directory with no data block and no entries. It could even be opened, and removing it walks a zeroed directory block, which never returns (#304);
- every failure after the inode allocation reported `-ENOENT`, so a full disk was indistinguishable from a missing path;
- none of them freed the inode that `ext2_allocate_inode()` had already persisted, nor the directory count taken for the group, so every attempt stranded an allocated-but-unreferenced inode and left the group counters drifted.

## Change

Each failure now reports its own cause and unwinds what it did, in reverse order.

| Failure | Before | After |
| --- | --- | --- |
| Missing filesystem | `-ENOENT` | `-ENODEV` |
| Inode creation | `-ENOENT` | `-ENOSPC` |
| Inode write | `-ENOENT` | `-EIO` |
| Entry in the parent | `-ENOENT` | `-ENOSPC` |
| Data block for `.` and `..` | **`0`, success** | `-ENOSPC` |
| Entries `.` and `..` | `-ENOENT` | `-ENOSPC` |

The rollback removes the link the `..` entry added to the parent, clears the entry added to the parent, frees the inode (re-read from disk first, so the block its entry table got is freed too) and gives back the directory count of the group. `ext2_create_inode()` also frees the inode it had just allocated when it cannot read it back, which otherwise leaked one inode per failure for `mkdir` and `creat` alike.

## Test

`t_mkdir_nospace` fills the filesystem and checks that `mkdir` reports `ENOSPC`, and that the free-inode count across the failed call is unchanged, so the check covers what `mkdir` did and nothing else. The fill uses files of twelve blocks, the direct blocks of an inode, so it needs no index blocks and stays clear of #301 and #302, and it is driven by the free-block count from `statfs` rather than by the result of `write`, because a write that cannot allocate its block still reports success (#303).

The test is registered in the CMake test list but **commented out of `all_tests[]`**, like `t_big_write`: filling the image costs about two minutes of guest time, since ext2 rewrites the block bitmap, the group descriptor and the superblock for every allocated block, and `ext2_find_free_block()` rescans from the start each time. Both documents that track the intentionally skipped tests record it, with the note to run it by hand when touching the ext2 allocation paths.

## Validation

- Warning-free on Debug and Release.
- Suite as committed, with the test skipped: `58/58`, 0 panics. With the test enabled: `60/60`, 0 panics.
- Negative control: before the fix the same test reports that `mkdir` succeeded on a full filesystem and that the directory it claims to have created can be opened.
- `git diff --check` clean.

## Found while doing this, filed separately

Five defects surfaced from the same investigation, each with in-guest evidence and none of them touched here:

- #301 the block-pointer setter and reader disagree on the direct/indirect boundaries, so block 12 of a guest-written file is repurposed as its index block and block 1036 is lost;
- #302 `ext2_free_inode()` never frees the index blocks;
- #303 `ext2_write_inode_data()` tests the block write as a boolean, so a full filesystem silently discards data while `write()` reports success;
- #304 the direntry iterator loops forever on a zeroed directory block, so one `rmdir` hangs the kernel;
- #305 `ext2_creat()` leaks the allocated inode and sets no `errno` when the creation cannot be completed, the `creat` half of this issue's pattern.
