### PR TITLE
fix(ext2): align the block-pointer setter with the reader at the region boundaries

### DIFF
--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -1529,16 +1529,19 @@ static int ext2_set_real_block_index(
     // Result of the operation.
     int ret = 0;
 
-    // Are we setting a DIRECT block pointer.
+    // Are we setting a DIRECT block pointer. The comparison has to match the
+    // one in ext2_get_real_block_index: with `<= 0` the first index of each
+    // region was stored one element past the end of the region before it,
+    // where the reader never looks (#301).
     a = ((int)block_index) - EXT2_DIRECT_BLOCKS;
-    if (a <= 0) {
+    if (a < 0) {
         inode->data.blocks.dir_blocks[block_index] = real_index;
     } else {
         // Allocate the cache.
         uint8_t *cache = ext2_alloc_cache(fs);
         // Are we setting an INDIRECT block pointer.
         b              = a - p;
-        if (b <= 0) {
+        if (b < 0) {
             // Check that the indirect block points to a valid block.
             if (__ext2_allocate_indexing_block_for_inode(fs, &inode->data.blocks.indir_block)) {
                 ret = -1;
@@ -1554,7 +1557,7 @@ static int ext2_set_real_block_index(
         } else {
             // Are we setting a DOUBLY-INDIRECT block.
             c = b - p * p;
-            if (c <= 0) {
+            if (c < 0) {
                 c = b / p;
                 d = b - c * p;
                 // Check that the indirect block points to a valid block.
@@ -1578,7 +1581,7 @@ static int ext2_set_real_block_index(
 
             } else {
                 d = c - p * p * p;
-                if (d <= 0) {
+                if (d < 0) {
                     e = c / (p * p);
                     f = (c - e * p * p) / p;
                     g = (c - e * p * p - f * p);

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -40,6 +40,7 @@ static char *all_tests[] = {
     "t_elf_short",
     "t_exit",
     "t_fflush",
+    "t_file_blocks",
     "t_fhs",
     "t_font",
     "t_fork",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_LIST
     t_ndtree.c
     t_pwd.c
     t_fflush.c
+    t_file_blocks.c
     t_font.c
     t_sigusr.c
     t_kill.c

--- a/userspace/tests/t_file_blocks.c
+++ b/userspace/tests/t_file_blocks.c
@@ -1,0 +1,207 @@
+/// @file t_file_blocks.c
+/// @brief Regression test for #301: every block of a file must read back what
+/// was written into it, including the ones at the boundaries between the
+/// direct, indirect and doubly-indirect regions of the inode.
+/// @details ext2_set_real_block_index used `<= 0` where
+/// ext2_get_real_block_index used `< 0` to decide which region a block index
+/// belongs to, so the two disagreed on the first index of each region. Block
+/// 12 had its pointer stored into dir_blocks[12], one past the array, which
+/// is the single-indirect pointer that follows it: the data block of block 12
+/// then served as the file's index block. Block 1036 had its pointer stored
+/// one element past the end of the index block, so it was lost and the block
+/// read back as zeros. Both were silent, with write reporting success.
+///
+/// The blocks are written at their own offsets with lseek, so only the blocks
+/// under test are allocated and the test stays fast: the interesting indices
+/// are the last of each region and the first of the next.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The file used by the checks.
+#define PATH "/home/user/t_file_blocks.bin"
+
+/// Size of a filesystem block in the image.
+#define BLOCK_SIZE 4096
+
+/// Number of block pointers in one block, with 4-byte pointers.
+#define POINTERS_PER_BLOCK (BLOCK_SIZE / 4)
+
+/// Number of direct block pointers in an inode.
+#define DIRECT_BLOCKS 12
+
+/// The block indices under test: around the end of the direct region and
+/// around the end of the single-indirect region.
+static const unsigned block_indices[] = {
+    0,
+    DIRECT_BLOCKS - 1,
+    DIRECT_BLOCKS,
+    DIRECT_BLOCKS + 1,
+    DIRECT_BLOCKS + POINTERS_PER_BLOCK - 1,
+    DIRECT_BLOCKS + POINTERS_PER_BLOCK,
+    DIRECT_BLOCKS + POINTERS_PER_BLOCK + 1,
+};
+
+/// Number of block indices under test.
+#define BLOCK_COUNT (sizeof(block_indices) / sizeof(block_indices[0]))
+
+/// Buffer holding one block.
+static char buffer[BLOCK_SIZE];
+
+/// @brief Fills the buffer with the marker of the given block index.
+/// @param index the block index to encode.
+static void __fill_marker(unsigned index)
+{
+    memset(buffer, 0, sizeof(buffer));
+    buffer[0] = (char)(index & 0xFF);
+    buffer[1] = (char)((index >> 8) & 0xFF);
+    buffer[2] = (char)((index >> 16) & 0xFF);
+    buffer[3] = (char)((index >> 24) & 0xFF);
+    buffer[4] = 'M';
+    buffer[5] = 'K';
+}
+
+/// @brief Checks that the buffer holds the marker of the given block index.
+/// @param index the expected block index.
+/// @return 0 when the marker matches, -1 otherwise.
+static int __check_marker(unsigned index)
+{
+    unsigned found = (unsigned char)buffer[0];
+    found |= ((unsigned)(unsigned char)buffer[1]) << 8;
+    found |= ((unsigned)(unsigned char)buffer[2]) << 16;
+    found |= ((unsigned)(unsigned char)buffer[3]) << 24;
+    if ((buffer[4] != 'M') || (buffer[5] != 'K') || (found != index)) {
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Writes a contiguous run of blocks and reads it back.
+/// @param first the first block index of the run.
+/// @param count how many blocks the run holds.
+/// @return the number of blocks that did not read back correctly.
+static int check_contiguous_run(unsigned first, unsigned count)
+{
+    int failures = 0;
+    int fd       = open(PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_file_blocks] open for writing the run: %s", strerror(errno));
+        return 1;
+    }
+    if (lseek(fd, (off_t)first * BLOCK_SIZE, SEEK_SET) < 0) {
+        syslog(LOG_ERR, "[t_file_blocks] lseek to block %u: %s", first, strerror(errno));
+        close(fd);
+        return 1;
+    }
+    for (unsigned index = first; index < (first + count); ++index) {
+        __fill_marker(index);
+        if (write(fd, buffer, sizeof(buffer)) != (ssize_t)sizeof(buffer)) {
+            syslog(LOG_ERR, "[t_file_blocks] write of block %u in the run: %s", index, strerror(errno));
+            ++failures;
+        }
+    }
+    close(fd);
+
+    fd = open(PATH, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_file_blocks] open for reading the run: %s", strerror(errno));
+        return failures + 1;
+    }
+    if (lseek(fd, (off_t)first * BLOCK_SIZE, SEEK_SET) < 0) {
+        syslog(LOG_ERR, "[t_file_blocks] lseek to block %u: %s", first, strerror(errno));
+        close(fd);
+        return failures + 1;
+    }
+    for (unsigned index = first; index < (first + count); ++index) {
+        memset(buffer, 0, sizeof(buffer));
+        if (read(fd, buffer, sizeof(buffer)) != (ssize_t)sizeof(buffer)) {
+            syslog(LOG_ERR, "[t_file_blocks] read of block %u in the run: %s", index, strerror(errno));
+            ++failures;
+            continue;
+        }
+        if (__check_marker(index) < 0) {
+            syslog(LOG_ERR, "[t_file_blocks] block %u of the run does not hold what was written into it", index);
+            ++failures;
+        }
+    }
+    close(fd);
+    unlink(PATH);
+    return failures;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    int fd = open(PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_file_blocks] open for writing: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    for (unsigned i = 0; i < BLOCK_COUNT; ++i) {
+        unsigned index = block_indices[i];
+        off_t offset   = (off_t)index * BLOCK_SIZE;
+        if (lseek(fd, offset, SEEK_SET) != offset) {
+            syslog(LOG_ERR, "[t_file_blocks] lseek to block %u: %s", index, strerror(errno));
+            ++failures;
+            continue;
+        }
+        __fill_marker(index);
+        ssize_t written = write(fd, buffer, sizeof(buffer));
+        if (written != (ssize_t)sizeof(buffer)) {
+            syslog(LOG_ERR, "[t_file_blocks] write of block %u returned %zd: %s", index, written, strerror(errno));
+            ++failures;
+        }
+    }
+    close(fd);
+
+    fd = open(PATH, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_file_blocks] open for reading: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    for (unsigned i = 0; i < BLOCK_COUNT; ++i) {
+        unsigned index = block_indices[i];
+        off_t offset   = (off_t)index * BLOCK_SIZE;
+        if (lseek(fd, offset, SEEK_SET) != offset) {
+            syslog(LOG_ERR, "[t_file_blocks] lseek to block %u: %s", index, strerror(errno));
+            ++failures;
+            continue;
+        }
+        memset(buffer, 0, sizeof(buffer));
+        ssize_t bytes = read(fd, buffer, sizeof(buffer));
+        if (bytes != (ssize_t)sizeof(buffer)) {
+            syslog(LOG_ERR, "[t_file_blocks] read of block %u returned %zd: %s", index, bytes, strerror(errno));
+            ++failures;
+            continue;
+        }
+        if (__check_marker(index) < 0) {
+            syslog(LOG_ERR, "[t_file_blocks] block %u does not hold what was written into it", index);
+            ++failures;
+        }
+    }
+    close(fd);
+    unlink(PATH);
+
+    // The defect showed up while allocating blocks in order: the pointer of
+    // block 12 landed on the single-indirect pointer, and the block after it
+    // then used block 12 as its index block. A contiguous run across that
+    // boundary covers it.
+    failures += check_contiguous_run(0, DIRECT_BLOCKS + 4);
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_file_blocks] every block read back what was written");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_file_blocks] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Fixes #301. `ext2_set_real_block_index()` decided which region a block index belongs to with `<= 0`, while `ext2_get_real_block_index()` uses `< 0` for the same tests. The two disagreed on the **first index of every region**, and the setter stored those pointers one element past the end of the region before it, where the reader never looks.

With twelve direct blocks and 4 KiB blocks:

| Block index | Setter stored the pointer in | Reader looked in | Result |
| --- | --- | --- | --- |
| 12 | `dir_blocks[12]`, one past the array, which is the `indir_block` field that follows it | the indirect block, entry 0 | the data block of block 12 became the file's index block, so its contents were destroyed |
| 1036 | entry 1024 of the index block, 4 bytes past the end of the 4096-byte cache buffer | the doubly-indirect block, unallocated | the pointer was lost and the block read back as zeros |

Both were silent, with `write()` reporting success. Only files written by the guest were affected: images built by `mke2fs` carry correct pointers, so shipped binaries were never damaged.

## Change

The three comparisons in the setter now match the reader, so each pointer goes where the reader looks and every store stays inside its destination. Nothing else changed: the index arithmetic of the doubly and trebly regions was already identical in the two functions.

## Test

`t_file_blocks` writes a marker into the last block of each region and the first two of the next, using `lseek` so that only those blocks are allocated and the test stays fast. It then reads them back and compares. A second phase writes a contiguous run across the direct boundary, which is how the defect showed up in the first place: the pointer of block 12 landed on the single-indirect pointer, and the next block used block 12 as its index block.

## Validation

- Warning-free on Debug and Release; `59/59` tests with 0 panics on both.
- Negative control: reverting only the three comparisons makes the test report block 12 and block 1036 of the sparse file, and block 12 of the contiguous run.
- `git diff --check` clean.

## Notes for review

- The measurement that produced the issue wrote 1100 blocks with per-block markers and found exactly two bad blocks, 12 and 1036, which is what the mechanism above predicts.
- Two neighbouring defects stay open and are not touched here: #302, the index blocks are never freed when an inode is freed, and #303, `ext2_write_inode_data()` tests the block write as a boolean so a full filesystem discards data while `write()` reports success.
