### PR TITLE
fix(ext2): append the new block of a growing directory instead of replacing the first

### DIFF
--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -2442,47 +2442,51 @@ static inline int ext2_create_new_direntry(
         pr_err("Failed to read the parent inode `%u`.\n", parent_inode_index);
         return 0;
     }
-    // Prepare iterator.
-    ext2_direntry_iterator_t it = ext2_direntry_iterator_begin(fs, cache, &parent_inode);
-    // Find the last entry.
-    while (ext2_direntry_iterator_valid(&it)) {
-        ext2_direntry_iterator_next(&it);
-    }
-    // Allocate a new block.
-    if (ext2_allocate_inode_block(fs, &parent_inode, parent_inode_index, it.block_index) == -1) {
+    // The new block goes after the ones the directory already has. Walking
+    // the entries to find it does not work: the iterator stops as soon as it
+    // reaches the size of the directory, so its block index is the last block
+    // in use rather than the first free one, and allocating there replaced
+    // the block holding every existing entry (#309).
+    uint32_t old_size    = parent_inode.size;
+    uint32_t block_index = parent_inode.size / fs->block_size;
+    uint32_t real_index  = 0;
+
+    // Allocate the new block and map it at that index.
+    if (ext2_allocate_inode_block(fs, &parent_inode, parent_inode_index, block_index) == -1) {
         pr_err("Failed to allocate a new block for an inode.\n");
         return 0;
     }
-    // Update the inode block.
-    if (ext2_write_inode_block(fs, &parent_inode, parent_inode_index, it.block_index, cache) == -1) {
-        pr_err("Failed to update the block of the father directory.\n");
-        return 0;
-    }
-    // Move to new block inted.
-    it.block_index += 1;
-    // Update the inode size.
-    parent_inode.size = it.block_index * fs->block_size;
-    // Update the inode.
+    // The directory now covers one block more.
+    parent_inode.size = (block_index + 1) * fs->block_size;
     if (ext2_write_inode(fs, &parent_inode, parent_inode_index) == -1) {
         pr_err("Failed to update the inode of the father directory.\n");
-        return 0;
+        goto free_block_and_fail;
     }
-    // Initialize the iterato once again, with the new block..
-    it              = ext2_direntry_iterator_begin(fs, cache, &parent_inode);
-    // Move back at the beginning of the block.
-    it.block_offset = 0;
-    // Set the iterator pointer to the new free location.
-    it.direntry     = ext2_direntry_iterator_get(&it);
-    // Initialize the new directory entry.
-    ext2_initialize_direntry(it.direntry, name, inode_index, fs->block_size - it.block_offset, file_type);
-    // Update the inode block.
-    if (ext2_write_inode_block(fs, &parent_inode, parent_inode_index, it.block_index, cache) == -1) {
+    // The new block holds one entry, spanning the whole block: the next
+    // append splits it, the same way the first block of a directory works.
+    memset(cache, 0, fs->block_size);
+    ext2_initialize_direntry((ext2_dirent_t *)cache, name, inode_index, fs->block_size, file_type);
+    // Write the new block.
+    if (ext2_write_inode_block(fs, &parent_inode, parent_inode_index, block_index, cache) == -1) {
         pr_err("Failed to update the block of the father directory.\n");
-        return 0;
+        goto free_block_and_fail;
     }
     pr_debug("Created new directory entry:\n");
-    ext2_dump_dirent(it.direntry);
+    ext2_dump_dirent((ext2_dirent_t *)cache);
     return 1;
+
+free_block_and_fail:
+    // Give the block back and leave the directory the size it had, so a
+    // failed append changes nothing.
+    real_index = ext2_get_real_block_index(fs, &parent_inode, block_index);
+    if (real_index != 0) {
+        ext2_free_block(fs, real_index);
+    }
+    parent_inode.size = old_size;
+    if (ext2_write_inode(fs, &parent_inode, parent_inode_index) == -1) {
+        pr_err("Failed to restore the inode of the father directory.\n");
+    }
+    return 0;
 }
 
 /// @brief Allocates a directory entry.

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -29,6 +29,7 @@ static char *all_tests[] = {
     // "t_big_write",
     "t_chdir",
     "t_creat",
+    "t_dir_entries",
     "t_dup",
     "t_environ",
     "t_exec",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # List of programs.
 set(TEST_LIST
     t_aab_pipe.c
+    t_dir_entries.c
     t_dup.c
     t_hashmap.c
     t_procfs_read.c

--- a/userspace/tests/t_dir_entries.c
+++ b/userspace/tests/t_dir_entries.c
@@ -1,0 +1,163 @@
+/// @file t_dir_entries.c
+/// @brief Regression test for #309: a directory that grows past one block must
+/// keep the entries it already held.
+/// @details When the entries no longer fit the first block,
+/// ext2_create_new_direntry allocated the new block at index 0, replacing the
+/// mapping of the block that held every existing name, and then set the
+/// directory size to a single block. The names in the first block were lost,
+/// the block itself was leaked, and the new entry sat at a block index the
+/// size did not cover, so no directory walk could reach it. Creating a few
+/// hundred files in one directory therefore kept only the most recent ones,
+/// with no error reported anywhere.
+///
+/// The files are empty, so no data block is involved and the filesystem never
+/// runs out of space: the only thing under test is how the directory grows.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The directory holding the entries, created by the test.
+#define DIR_PATH "/home/user/t_dir_entries.d"
+
+/// How many files to create. With 4096-byte blocks and these names the first
+/// block holds a little under two hundred entries, so this spans three.
+#define FILE_COUNT 400
+
+/// @brief Builds the path of one of the files.
+/// @param path the destination buffer.
+/// @param index the index of the file.
+static void __file_path(char *path, int index) { sprintf(path, DIR_PATH "/f.%04d", index); }
+
+/// @brief Creates an empty file.
+/// @param path the file to create.
+/// @return 0 on success, -1 on failure.
+static int __create(const char *path)
+{
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_dir_entries] open %s: %s", path, strerror(errno));
+        return -1;
+    }
+    close(fd);
+    return 0;
+}
+
+/// @brief Counts how many of the created files can be reached by name.
+/// @param count how many files were created.
+/// @return the number of files found.
+static int __count_by_name(int count)
+{
+    char path[64];
+    stat_t st;
+    int found = 0;
+    for (int index = 0; index < count; ++index) {
+        __file_path(path, index);
+        if (stat(path, &st) == 0) {
+            ++found;
+        }
+    }
+    return found;
+}
+
+/// @brief Counts the entries the directory lists, excluding `.` and `..`.
+/// @return the number of entries listed, or -1 on failure.
+static int __count_by_listing(void)
+{
+    static dirent_t entries[16];
+    int fd = open(DIR_PATH, O_RDONLY | O_DIRECTORY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_dir_entries] open %s: %s", DIR_PATH, strerror(errno));
+        return -1;
+    }
+    // The records come back one after the other, each the size of a dirent_t,
+    // which is how ls walks them.
+    int listed = 0;
+    ssize_t bytes;
+    while ((bytes = getdents(fd, entries, sizeof(entries))) > 0) {
+        for (size_t i = 0; i < (size_t)bytes / sizeof(dirent_t); ++i) {
+            if ((strcmp(entries[i].d_name, ".") != 0) && (strcmp(entries[i].d_name, "..") != 0)) {
+                ++listed;
+            }
+        }
+    }
+    close(fd);
+    if (bytes < 0) {
+        syslog(LOG_ERR, "[t_dir_entries] getdents: %s", strerror(errno));
+        return -1;
+    }
+    return listed;
+}
+
+/// @brief Removes the files and the directory.
+/// @param count how many files were created.
+static void __cleanup(int count)
+{
+    char path[64];
+    for (int index = 0; index < count; ++index) {
+        __file_path(path, index);
+        unlink(path);
+    }
+    rmdir(DIR_PATH);
+}
+
+int main(void)
+{
+    char path[64];
+    int failures = 0;
+    int created  = 0;
+
+    if ((mkdir(DIR_PATH, 0755) < 0) && (errno != EEXIST)) {
+        syslog(LOG_ERR, "[t_dir_entries] mkdir %s: %s", DIR_PATH, strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    // The first name is the one that used to disappear: it lives in the block
+    // that the directory replaced when it grew.
+    for (int index = 0; index < FILE_COUNT; ++index) {
+        __file_path(path, index);
+        if (__create(path) < 0) {
+            break;
+        }
+        ++created;
+    }
+    if (created != FILE_COUNT) {
+        syslog(LOG_ERR, "[t_dir_entries] created %d files out of %d", created, FILE_COUNT);
+        ++failures;
+    }
+
+    // Every file created must still be reachable by name.
+    int found = __count_by_name(created);
+    if (found != created) {
+        syslog(LOG_ERR, "[t_dir_entries] %d of the %d files created can be found by name", found, created);
+        ++failures;
+    }
+
+    // And the directory must list them all, which needs its size to cover
+    // every block it uses.
+    int listed = __count_by_listing();
+    if (listed < 0) {
+        ++failures;
+    } else if (listed != created) {
+        syslog(LOG_ERR, "[t_dir_entries] the directory lists %d entries, %d were created", listed, created);
+        ++failures;
+    }
+
+    __cleanup(created);
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_dir_entries] the directory kept all %d entries across its blocks", created);
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_dir_entries] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Fixes #309. When a directory's entries no longer fit its first block, `ext2_create_new_direntry()` walked the directory to decide where the new block goes. That walk stops as soon as it reaches the size of the directory, before the step that moves to the next block, so for a directory of one block it ended with block index **0** rather than 1.

Three things followed from that index:

1. the new block was mapped at index 0, replacing the pointer to the block that held every existing entry, which stayed allocated and unreachable;
2. the cache was written over that new block;
3. the size was then set to one block, so the new entry, written at index 1, sat outside the range any directory walk honours.

All of it silent: `open(O_CREAT)` reported success throughout. Of 400 files created in one directory, 145 could be found afterwards.

## Change

The new block goes at `size / block_size`, the size grows to cover it, and the block is initialized with a single entry spanning it, the same shape the first block of a directory has. A failure while doing so frees the block and restores the size, so a failed append changes nothing.

## Test

`t_dir_entries` creates 400 empty files in a directory of its own, then checks that every one of them is reachable by name and that the directory lists them all with `getdents`, which needs the size to cover every block in use. The files are empty, so no data block is involved and the filesystem never runs out of space: the only thing under test is how the directory grows. It costs a couple of seconds, so it runs in the suite.

## Validation

- Warning-free; `60/60` tests with 0 panics.
- Negative control: reverting only the kernel change makes the test report `145 of the 400 files created can be found by name` and `the directory lists 145 entries`.
- `git diff --check` clean.

## How it was found

While writing the regression test for #303, a file created before filling the filesystem had vanished by the time the test looked for it. Isolating that with 400 **empty** files, no full disk involved, showed the sentinel disappearing after 198 creations, which is where the first block runs out.
