### PR TITLE
fix(ext2): report the failure when a write cannot allocate its block

### DIFF
--- a/docs/maintainer/false-positives-and-dismissed-findings.md
+++ b/docs/maintainer/false-positives-and-dismissed-findings.md
@@ -77,12 +77,12 @@ Baselines: `BASE` 82f4314 / `MAIN` 62c638a.
 
 ## 7. Tests skipped in runtests / TEST_LIST
 
-- `t_big_write`, `t_periodic1/2/3`, `t_mkdir_nospace` commented out of
+- `t_big_write`, `t_periodic1/2/3`, `t_nospace` commented out of
   `all_tests[]`; `t_time` disabled in CMake TEST_LIST.
 - **Verdict**: INTENTIONAL (explicit comments), not infrastructure rot.
   Do not "fix" silently; re-enabling changes CI meaning (and t_big_write
   predates the #192 panic boundary anyway — it sorts after t_gid).
-- `t_mkdir_nospace` (#264) is the one skipped for runtime rather than
+- `t_nospace` (#264) is the one skipped for runtime rather than
   meaning: it fills the 32 MB image block by block to force an allocation
   failure, ~2 min of guest time, because ext2 rewrites the block bitmap,
   the group descriptor and the superblock per allocated block and

--- a/docs/maintainer/testing-and-ci.md
+++ b/docs/maintainer/testing-and-ci.md
@@ -24,8 +24,8 @@ Verified against `MAIN` = `62c638a` (line refs for `MAIN` unless noted).
 1. `userspace/tests/CMakeLists.txt` → `TEST_LIST`.
 2. `userspace/bin/runtests.c` → `all_tests[]` (order = execution order).
    Intentionally skipped there: `t_big_write`, `t_periodic1/2/3`,
-   `t_mkdir_nospace`; `t_time` disabled in CMake TEST_LIST.
-   `t_mkdir_nospace` fills the image to force an allocation failure, which
+   `t_nospace`; `t_time` disabled in CMake TEST_LIST.
+   `t_nospace` fills the image to force an allocation failure, which
    costs about two minutes of guest time: run it by hand when touching the
    ext2 allocation paths.
 

--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -2045,6 +2045,9 @@ static ssize_t ext2_write_inode_data(
         pr_err("Integer overflow: offset + nbyte exceeds UINT32_MAX\n");
         return -1;
     }
+    // Keep the size the file had, so that a write which cannot store every
+    // block does not leave the inode claiming bytes that were never written.
+    uint32_t original_size = inode->size;
     if ((offset + nbyte) > inode->size) {
         inode->size = offset + nbyte;
         if (ext2_write_inode(fs, inode, inode_index) == -1) {
@@ -2072,7 +2075,9 @@ static ssize_t ext2_write_inode_data(
     uint32_t curr_off = 0;
     uint32_t left;
     uint32_t right;
-    uint32_t ret = end_offset - offset;
+    // Bytes actually stored, and the error to report if nothing could be.
+    ssize_t written = 0;
+    int failure     = 0;
 
     for (uint32_t block_index = start_block; block_index <= end_block; ++block_index) {
         // Recalculate on each iteration because ext2_write_inode_block may allocate new blocks.
@@ -2096,7 +2101,7 @@ static ssize_t ext2_write_inode_data(
             // Read existing block for partial write (preserve unmodified portions).
             if (ext2_read_inode_block(fs, inode, block_index, cache) < 0) {
                 pr_err("Failed to read block %u of inode %u for partial write\n", block_index, inode_index);
-                ret = -1;
+                failure = -EIO;
                 break;
             }
         } else if (!block_exists) {
@@ -2109,16 +2114,40 @@ static ssize_t ext2_write_inode_data(
         memcpy(cache + left, buffer + curr_off, (right - left + 1));
         // Move the offset.
         curr_off += (right - left + 1);
-        // Write the block back.
-        if (!ext2_write_inode_block(fs, inode, inode_index, block_index, cache)) {
+        // Write the block back. This returns -1 when the block could not be
+        // allocated, and the number of bytes written otherwise: testing it as
+        // a boolean let every failure through, so a full filesystem discarded
+        // the data while reporting success (#303).
+        if (ext2_write_inode_block(fs, inode, inode_index, block_index, cache) == -1) {
             pr_err("Failed to write the inode block %u of inode %u\n", block_index, inode_index);
-            ret = -1;
+            failure = -ENOSPC;
             break;
         }
+        // The block is on the device: count what it stored.
+        written += (right - left + 1);
     }
     // Free the cache.
     ext2_dealloc_cache(cache);
-    return ret;
+
+    if (failure) {
+        // Shrink the size back to what is actually stored, keeping whatever
+        // the file held before this call. A call that stored nothing leaves
+        // the file exactly as it was, offset included.
+        uint32_t stored_end = (written > 0) ? ((uint32_t)offset + (uint32_t)written) : original_size;
+        uint32_t real_size  = (stored_end > original_size) ? stored_end : original_size;
+        if (inode->size != real_size) {
+            inode->size = real_size;
+            if (ext2_write_inode(fs, inode, inode_index) == -1) {
+                pr_err("Failed to restore the size of inode `%d`\n", inode_index);
+            }
+        }
+        // A write that stored nothing is an error, one that stored part of
+        // the data reports how much, as write(2) requires.
+        if (written == 0) {
+            return failure;
+        }
+    }
+    return written;
 }
 
 // ============================================================================

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -59,7 +59,7 @@ static char *all_tests[] = {
     // Skipped on purpose: filling the image to make the allocation fail takes
     // about two minutes of guest time, too much for every CI run. Run it by
     // hand when touching the ext2 allocation paths (#264).
-    // "t_mkdir_nospace",
+    // "t_nospace",
     "t_msgget",
     "t_ndtree",
     "t_periodic1",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ set(TEST_LIST
     t_execve_bigargv.c
     t_userfault.c
     t_path_bounds.c
-    t_mkdir_nospace.c
+    t_nospace.c
     t_execve_fail.c
     t_elf_short.c
     t_gid.c

--- a/userspace/tests/t_nospace.c
+++ b/userspace/tests/t_nospace.c
@@ -1,6 +1,7 @@
-/// @file t_mkdir_nospace.c
-/// @brief Regression test for #264: mkdir must fail, and leave nothing
-/// behind, when the filesystem has no room for the new directory.
+/// @file t_nospace.c
+/// @brief Regression tests for what the filesystem does when it runs out of
+/// space: #264, mkdir must fail and leave nothing behind, and #303, a write
+/// that cannot allocate its block must not report success.
 /// @details ext2_mkdir allocates an inode, adds the entry to the parent and
 /// only then allocates the data block that holds `.` and `..`. When that
 /// last allocation failed the function returned 0, so user space saw a
@@ -37,7 +38,12 @@
 #define BASE_DIR "/home/user"
 
 /// The directory the test tries to create with no space left.
-#define DIR_PATH BASE_DIR "/t_mkdir_nospace.d"
+#define DIR_PATH BASE_DIR "/t_nospace.d"
+
+/// The file used to check what a write does with no space left. It is
+/// created before the fill, so that the check does not depend on being able
+/// to create a file on a full filesystem.
+#define TARGET_PATH BASE_DIR "/t_nospace.target"
 
 /// Size of a single write, one block of the image.
 #define CHUNK 4096
@@ -54,7 +60,7 @@ static char buffer[CHUNK];
 /// @brief Builds the path of a fill file.
 /// @param path the destination buffer.
 /// @param index the index of the fill file.
-static void __fill_path(char *path, int index) { sprintf(path, BASE_DIR "/t_mkdir_nospace.%04d", index); }
+static void __fill_path(char *path, int index) { sprintf(path, BASE_DIR "/t_nospace.%04d", index); }
 
 /// @brief Reads the free counters of the filesystem.
 /// @param blocks where the free block count is stored, may be NULL.
@@ -64,7 +70,7 @@ static int __read_free(unsigned long *blocks, unsigned long *inodes)
 {
     statfs_t buf;
     if (statfs(BASE_DIR, &buf) < 0) {
-        syslog(LOG_ERR, "[t_mkdir_nospace] statfs: %s", strerror(errno));
+        syslog(LOG_ERR, "[t_nospace] statfs: %s", strerror(errno));
         return -1;
     }
     if (blocks) {
@@ -95,7 +101,7 @@ static int __fill_filesystem(int *files)
         __fill_path(path, index);
         int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
         if (fd < 0) {
-            syslog(LOG_ERR, "[t_mkdir_nospace] open %s: %s", path, strerror(errno));
+            syslog(LOG_ERR, "[t_nospace] open %s: %s", path, strerror(errno));
             return -1;
         }
         ++(*files);
@@ -106,7 +112,7 @@ static int __fill_filesystem(int *files)
         }
         close(fd);
     }
-    syslog(LOG_ERR, "[t_mkdir_nospace] the filesystem still has free blocks after %d files", MAX_FILES);
+    syslog(LOG_ERR, "[t_nospace] the filesystem still has free blocks after %d files", MAX_FILES);
     return -1;
 }
 
@@ -119,6 +125,75 @@ static void __remove_fill(int files)
         __fill_path(path, index);
         unlink(path);
     }
+}
+
+/// @brief Creates the file used by the write check, with one block of data.
+/// @return 0 on success, -1 on failure.
+static int __prepare_target(void)
+{
+    memset(buffer, 'a', sizeof(buffer));
+    int fd = open(TARGET_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_nospace] open %s: %s", TARGET_PATH, strerror(errno));
+        return -1;
+    }
+    ssize_t written = write(fd, buffer, sizeof(buffer));
+    close(fd);
+    if (written != (ssize_t)sizeof(buffer)) {
+        syslog(LOG_ERR, "[t_nospace] preparing the target wrote %zd bytes", written);
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Appends a block to the target file with no space left.
+/// @details The block cannot be allocated, so the write has to say so: it
+///          either fails with ENOSPC or reports fewer bytes than asked. It
+///          used to return the full count and drop the data, leaving the file
+///          claiming a size it could not back (#303).
+/// @return 0 on success, -1 on failure.
+static int check_write_with_no_space(void)
+{
+    int failures = 0;
+    memset(buffer, 'b', sizeof(buffer));
+    int fd = open(TARGET_PATH, O_WRONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_nospace] open %s for appending: %s", TARGET_PATH, strerror(errno));
+        return -1;
+    }
+    // Append past the end of the file, so the write needs a block that the
+    // file does not already own.
+    if (lseek(fd, 2 * CHUNK, SEEK_SET) != (2 * CHUNK)) {
+        syslog(LOG_ERR, "[t_nospace] lseek on the target: %s", strerror(errno));
+        close(fd);
+        return -1;
+    }
+    errno           = 0;
+    ssize_t written = write(fd, buffer, CHUNK);
+    close(fd);
+    if (written == CHUNK) {
+        syslog(LOG_ERR, "[t_nospace] the write reported %zd bytes with no free block left", written);
+        ++failures;
+    } else if ((written < 0) && (errno != ENOSPC)) {
+        syslog(LOG_ERR, "[t_nospace] the write failed with %s, expected ENOSPC", strerror(errno));
+        ++failures;
+    }
+
+    // Whatever the write reported, the file must not claim bytes it does not
+    // hold: the size covers the first block plus whatever was stored.
+    stat_t st;
+    if (stat(TARGET_PATH, &st) < 0) {
+        syslog(LOG_ERR, "[t_nospace] stat %s: %s", TARGET_PATH, strerror(errno));
+        return -1;
+    }
+    unsigned long expected = ((written > 0) ? (2 * CHUNK + (unsigned long)written) : CHUNK);
+    if ((unsigned long)st.st_size != expected) {
+        syslog(
+            LOG_ERR, "[t_nospace] the target is %lu bytes, expected %lu after a write that reported %zd",
+            (unsigned long)st.st_size, expected, written);
+        ++failures;
+    }
+    return (failures == 0) ? 0 : -1;
 }
 
 int main(void)
@@ -134,10 +209,14 @@ int main(void)
     if (__read_free(&blocks_before, &inodes_before) < 0) {
         return EXIT_FAILURE;
     }
-    syslog(LOG_INFO, "[t_mkdir_nospace] before: %lu free blocks, %lu free inodes", blocks_before, inodes_before);
+    syslog(LOG_INFO, "[t_nospace] before: %lu free blocks, %lu free inodes", blocks_before, inodes_before);
 
+    if (__prepare_target() < 0) {
+        return EXIT_FAILURE;
+    }
     if (__fill_filesystem(&files) < 0) {
         __remove_fill(files);
+        unlink(TARGET_PATH);
         return EXIT_FAILURE;
     }
     if (__read_free(&blocks_full, &inodes_full) < 0) {
@@ -145,7 +224,7 @@ int main(void)
         return EXIT_FAILURE;
     }
     syslog(
-        LOG_INFO, "[t_mkdir_nospace] full after %d files: %lu free blocks, %lu free inodes", files, blocks_full,
+        LOG_INFO, "[t_nospace] full after %d files: %lu free blocks, %lu free inodes", files, blocks_full,
         inodes_full);
 
     // With no room for the directory data block, mkdir must fail, and it must
@@ -158,20 +237,25 @@ int main(void)
         return EXIT_FAILURE;
     }
     if (ret == 0) {
-        syslog(LOG_ERR, "[t_mkdir_nospace] mkdir succeeded with a full filesystem");
+        syslog(LOG_ERR, "[t_nospace] mkdir succeeded with a full filesystem");
         ++failures;
         // The directory it claims to have created has no entries at all, and
         // it is not removed here: rmdir walks its zeroed block and never
         // comes back (#304).
         int fd = open(DIR_PATH, O_RDONLY | O_DIRECTORY, 0);
         syslog(
-            LOG_ERR, "[t_mkdir_nospace] open of the claimed directory returned %d (%s)", fd,
+            LOG_ERR, "[t_nospace] open of the claimed directory returned %d (%s)", fd,
             (fd < 0) ? strerror(errno) : "no error");
         if (fd >= 0) {
             close(fd);
         }
     } else if (errno != ENOSPC) {
-        syslog(LOG_ERR, "[t_mkdir_nospace] mkdir failed with %s, expected ENOSPC", strerror(errno));
+        syslog(LOG_ERR, "[t_nospace] mkdir failed with %s, expected ENOSPC", strerror(errno));
+        ++failures;
+    }
+
+    // A write that cannot allocate its block must not report success.
+    if (check_write_with_no_space() < 0) {
         ++failures;
     }
 
@@ -180,7 +264,7 @@ int main(void)
     // whatever the fill itself consumed or stranded stays out of the check.
     if (inodes_after_mkdir != inodes_full) {
         syslog(
-            LOG_ERR, "[t_mkdir_nospace] free inodes went from %lu to %lu across the failed mkdir: it stranded one",
+            LOG_ERR, "[t_nospace] free inodes went from %lu to %lu across the failed mkdir: it stranded one",
             inodes_full, inodes_after_mkdir);
         ++failures;
     }
@@ -189,17 +273,18 @@ int main(void)
     // the parent directory keeps the blocks it grew to hold the fill entries,
     // and ext2 never shrinks a directory.
     __remove_fill(files);
+    unlink(TARGET_PATH);
     if (__read_free(NULL, &inodes_after) < 0) {
         return EXIT_FAILURE;
     }
     syslog(
-        LOG_INFO, "[t_mkdir_nospace] after the fill was removed: %lu free inodes (%lu before the test)", inodes_after,
+        LOG_INFO, "[t_nospace] after the fill was removed: %lu free inodes (%lu before the test)", inodes_after,
         inodes_before);
 
     if (failures == 0) {
-        syslog(LOG_INFO, "[t_mkdir_nospace] mkdir reported ENOSPC and left nothing behind");
+        syslog(LOG_INFO, "[t_nospace] mkdir and write both reported the full filesystem");
         return EXIT_SUCCESS;
     }
-    syslog(LOG_ERR, "[t_mkdir_nospace] %d FAILURES", failures);
+    syslog(LOG_ERR, "[t_nospace] %d FAILURES", failures);
     return EXIT_FAILURE;
 }


### PR DESCRIPTION
## Summary

Fixes #303. `ext2_write_inode_data()` tested the result of `ext2_write_inode_block()` as a boolean, but that function returns `-1` on failure and the number of bytes written on success. `!(-1)` is false, so every failure was missed: on a full filesystem `write()` returned the full byte count while no block had been allocated and nothing had been stored. The data was silently discarded and later reads returned zeros.

The sibling call site in `ext2_initialize_new_direntry_block()` already used `== -1` and got it right.

## Change

- The block write is checked with `== -1`.
- The function now counts the bytes it actually stored and returns them, which is what `write(2)` requires of a partial write. A call that could store nothing returns `-ENOSPC`, or `-EIO` when the failure came from reading a block back for a partial write.
- The size bookkeeping is fixed too. The inode size was extended to `offset + nbyte` *before* writing the data, so a write that failed partway left the file claiming bytes it did not hold. The size is now brought back to what is actually stored, never below what the file held before the call.

## Test

`t_mkdir_nospace` grows into `t_nospace`, the home for what the filesystem does when it runs out of space, and gains a second check: a file created before the fill is appended to once the disk is full. The write must either fail with `ENOSPC` or report fewer bytes than asked, and afterwards the file must not claim a size it cannot back.

The test keeps its `#264` checks, stays registered in the CMake test list and stays out of `all_tests[]`: filling the image costs about two minutes of guest time. The two documents that track the intentionally skipped tests are updated for the rename.

## Validation

- Warning-free; the suite is `60/60` with 0 panics as committed, and `61/61` with `t_nospace` enabled by hand.
- Negative control: before the fix the test reports `the write reported 4096 bytes with no free block left`.
- `git diff --check` clean.

## Stacked on #310

This pull request targets the branch of #310 so the diff shows only its own change; GitHub retargets it to `develop` when #310 merges.

The dependency is real, not just ordering: the fill creates a few hundred files in one directory, which is exactly what #309 destroyed. A file created before the fill had vanished by the time the write check looked for it, and that is how #309 was found.

## One correction to a related report

The evidence originally quoted in #305, 332 files created and only 43 inodes returned, turned out to be #309 rather than a leak in `ext2_creat`: the names were destroyed, so `unlink` could not reach the inodes. With both fixes in place the same fill accounts perfectly, `7997` free inodes before and after. #305 stays open on its code-level claim, with a note recording the correction and a repro that actually reaches the branch.
