### PR TITLE
fix(ext2): free the index blocks of an inode along with its data

### DIFF
--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -1394,6 +1394,68 @@ static void ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index)
 /// @param inode the inode we free.
 /// @param inode_index its index.
 /// @return 0 on success, otherwise it is a failure.
+/// @brief Frees the blocks that hold the block pointers of an inode.
+/// @param fs the filesystem.
+/// @param inode the inode whose index blocks are freed.
+/// @details The data blocks of a file are reached through these, so they must
+///          be freed after the data blocks, and they belong to the file just
+///          as much: leaving them behind lost a block per indirection level on
+///          every deletion (#302).
+static void __ext2_free_index_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
+{
+    uint32_t pointers = fs->pointers_per_block;
+    uint8_t *outer    = ext2_alloc_cache(fs);
+    uint8_t *inner    = ext2_alloc_cache(fs);
+    if ((outer == NULL) || (inner == NULL)) {
+        pr_err("Failed to allocate the cache to free the index blocks.\n");
+        ext2_dealloc_cache(outer);
+        ext2_dealloc_cache(inner);
+        return;
+    }
+    // The single-indirect block holds pointers only.
+    if (inode->data.blocks.indir_block != 0) {
+        ext2_free_block(fs, inode->data.blocks.indir_block);
+        inode->data.blocks.indir_block = 0;
+    }
+    // The doubly-indirect block points at a level of index blocks.
+    if (inode->data.blocks.doubly_indir_block != 0) {
+        if (ext2_read_block(fs, inode->data.blocks.doubly_indir_block, outer) != -1) {
+            for (uint32_t index = 0; index < pointers; ++index) {
+                uint32_t block = ((uint32_t *)outer)[index];
+                if (block != 0) {
+                    ext2_free_block(fs, block);
+                }
+            }
+        }
+        ext2_free_block(fs, inode->data.blocks.doubly_indir_block);
+        inode->data.blocks.doubly_indir_block = 0;
+    }
+    // The trebly-indirect block points at two levels of index blocks.
+    if (inode->data.blocks.trebly_indir_block != 0) {
+        if (ext2_read_block(fs, inode->data.blocks.trebly_indir_block, outer) != -1) {
+            for (uint32_t index = 0; index < pointers; ++index) {
+                uint32_t middle = ((uint32_t *)outer)[index];
+                if (middle == 0) {
+                    continue;
+                }
+                if (ext2_read_block(fs, middle, inner) != -1) {
+                    for (uint32_t inner_index = 0; inner_index < pointers; ++inner_index) {
+                        uint32_t block = ((uint32_t *)inner)[inner_index];
+                        if (block != 0) {
+                            ext2_free_block(fs, block);
+                        }
+                    }
+                }
+                ext2_free_block(fs, middle);
+            }
+        }
+        ext2_free_block(fs, inode->data.blocks.trebly_indir_block);
+        inode->data.blocks.trebly_indir_block = 0;
+    }
+    ext2_dealloc_cache(outer);
+    ext2_dealloc_cache(inner);
+}
+
 static int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index)
 {
     // Retrieve the group index.
@@ -1418,6 +1480,9 @@ static int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t 
         }
         ext2_free_block(fs, real_index);
     }
+
+    // Free the blocks that held the pointers to those data blocks.
+    __ext2_free_index_blocks(fs, inode);
 
     // Allocate the cache.
     uint8_t *cache = ext2_alloc_cache(fs);

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -42,6 +42,7 @@ static char *all_tests[] = {
     "t_fflush",
     "t_file_blocks",
     "t_fhs",
+    "t_file_blocks_free",
     "t_font",
     "t_fork",
     "t_getcwd",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_LIST
     t_pwd.c
     t_fflush.c
     t_file_blocks.c
+    t_file_blocks_free.c
     t_font.c
     t_sigusr.c
     t_kill.c

--- a/userspace/tests/t_file_blocks_free.c
+++ b/userspace/tests/t_file_blocks_free.c
@@ -1,0 +1,113 @@
+/// @file t_file_blocks_free.c
+/// @brief Regression test for #302: deleting a file must return every block it
+/// owned, the ones holding its block pointers included.
+/// @details ext2_free_inode walked the data blocks of the file through
+/// ext2_get_real_block_index and freed those, and nothing freed the blocks
+/// that hold the pointers themselves. Any file large enough to need a level of
+/// indirection therefore leaked one block per level on deletion, and repeated
+/// create-and-delete cycles shrank the filesystem with no file left to remove
+/// to get the space back.
+///
+/// The file is written in chunks that do not end on a block boundary, so the
+/// accounting is not confounded by #311, which allocates one block too many
+/// for a write that ends exactly on one.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The file used by the check.
+#define PATH "/home/user/t_file_blocks_free.bin"
+
+/// Bytes written per call, deliberately not a multiple of the block size.
+#define CHUNK 4000
+
+/// How many chunks to write. Twenty-one chunks cover more than the twelve
+/// direct blocks of an inode, so the file needs a single-indirect block.
+#define CHUNKS 21
+
+/// Buffer holding one chunk.
+static char buffer[CHUNK];
+
+/// @brief Reads the number of free blocks of the filesystem.
+/// @param blocks where the count is stored.
+/// @return 0 on success, -1 on failure.
+static int __free_blocks(unsigned long *blocks)
+{
+    statfs_t buf;
+    if (statfs("/home/user", &buf) < 0) {
+        syslog(LOG_ERR, "[t_file_blocks_free] statfs: %s", strerror(errno));
+        return -1;
+    }
+    *blocks = (unsigned long)buf.f_bfree;
+    return 0;
+}
+
+int main(void)
+{
+    unsigned long before = 0;
+    unsigned long during = 0;
+    unsigned long after  = 0;
+
+    if (__free_blocks(&before) < 0) {
+        return EXIT_FAILURE;
+    }
+
+    memset(buffer, 'k', sizeof(buffer));
+    int fd = open(PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_file_blocks_free] open: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    for (int chunk = 0; chunk < CHUNKS; ++chunk) {
+        if (write(fd, buffer, sizeof(buffer)) != (ssize_t)sizeof(buffer)) {
+            syslog(LOG_ERR, "[t_file_blocks_free] write of chunk %d: %s", chunk, strerror(errno));
+            close(fd);
+            unlink(PATH);
+            return EXIT_FAILURE;
+        }
+    }
+    close(fd);
+
+    if (__free_blocks(&during) < 0) {
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+    // The file has to be large enough to need a level of indirection,
+    // otherwise the check would pass without exercising anything.
+    if ((before - during) <= 12) {
+        syslog(
+            LOG_ERR, "[t_file_blocks_free] the file took only %lu blocks, too few to need an index block",
+            before - during);
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+
+    if (unlink(PATH) < 0) {
+        syslog(LOG_ERR, "[t_file_blocks_free] unlink: %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    if (__free_blocks(&after) < 0) {
+        return EXIT_FAILURE;
+    }
+
+    if (after != before) {
+        syslog(
+            LOG_ERR, "[t_file_blocks_free] %lu blocks were taken and %lu given back: %lu are missing",
+            before - during, after - during, before - after);
+        return EXIT_FAILURE;
+    }
+    syslog(
+        LOG_INFO, "[t_file_blocks_free] the %lu blocks of the file came back, index blocks included",
+        before - during);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Fixes #302. `ext2_free_inode()` walked the data blocks of the file through `ext2_get_real_block_index()` and freed those. Nothing freed the blocks that hold the pointers themselves, so any file large enough to need a level of indirection leaked one block per level on deletion. Repeated create and delete cycles shrank the filesystem with no file left to remove to get the space back, and the image the test suite reuses carries the loss across runs.

## Change

The single, doubly and trebly indirect blocks are freed after the data blocks, which have to be reached through them first. For the two deeper levels the index blocks they point at are freed as well, one level at a time, so nothing is left behind at any depth.

## Test

`t_file_blocks_free` writes a file just past the twelve direct blocks of an inode, so it needs a single-indirect block, and checks that the free block count returns exactly to what it was once the file is deleted. It refuses to pass if the file turned out too small to need an index block, so the check cannot succeed without exercising anything.

The chunks are 4000 bytes, deliberately not a multiple of the block size: a write that ends exactly on a boundary allocates one block too many (#311), which would confound the accounting.

## Validation

- Warning-free; `60/60` tests with 0 panics.
- Negative control: reverting only the kernel change makes the test report `22 blocks were taken and 21 given back: 1 are missing`.
- `git diff --check` clean.

## Note

The deeper levels are freed by walking the index blocks, so a corrupt pointer there would free a block it should not. That matches what the rest of the ext2 code assumes about its own metadata, and the alternative, leaving them behind, is the leak this fixes.
