### PR TITLE
fix(ext2): stop the directory walk on an entry that cannot be advanced past

### DIFF
--- a/kernel/src/fs/ext2.c
+++ b/kernel/src/fs/ext2.c
@@ -2113,9 +2113,23 @@ ext2_direntry_iterator_t ext2_direntry_iterator_begin(ext2_filesystem_t *fs, uin
 /// @param it the iterator.
 void ext2_direntry_iterator_next(ext2_direntry_iterator_t *it)
 {
+    uint32_t rec_len = it->direntry->rec_len;
+    // A record length of zero leaves the offsets where they are, so the walk
+    // never reaches the end of the directory and never returns: one lookup on
+    // a directory whose block reads as zeros would hang the kernel, which is
+    // not preemptible. A length that is not a multiple of four, or one that
+    // runs past the end of the block, cannot be walked either. Stop the walk
+    // instead, and let the caller report that the entry was not found (#304).
+    if ((rec_len == 0) || ((rec_len % 4) != 0) || ((it->block_offset + rec_len) > it->fs->block_size)) {
+        pr_err(
+            "Corrupt directory entry: rec_len %u at offset %u of block %u.\n", rec_len, it->block_offset,
+            it->block_index);
+        it->direntry = NULL;
+        return;
+    }
     // Advance the offsets.
-    it->block_offset += it->direntry->rec_len;
-    it->total_offset += it->direntry->rec_len;
+    it->block_offset += rec_len;
+    it->total_offset += rec_len;
     // If we reached the end of the inode, stop.
     if (it->total_offset >= it->inode->size) {
         // The iterator is not valid anymore.


### PR DESCRIPTION
## Summary

Fixes #304. `ext2_direntry_iterator_next()` advanced the walk by the `rec_len` of the current entry without checking it. A record length of zero leaves both offsets where they are, so the end-of-directory test never fires and the loop never ends. The kernel is not preemptible, so one lookup, one listing or one `rmdir` on a directory whose block reads as zeros hangs the whole system, with no panic and no diagnostic.

## Change

The walk stops, and says why, when the record length is zero, is not a multiple of four, or would run past the end of the block. Callers see the end of the directory and report that the entry was not found, which is the truthful answer for a directory that cannot be read.

## On the absence of a regression test

A directory in that state cannot be produced from user space, and the two ways the kernel used to produce one are now gone: #264 left an incomplete directory behind when it reported success, and #309 gave a growing directory a block it never initialized. What remains is a corrupt or crafted image, and the suite has no way to mount one.

What the suite does show is that the guard never fires on a healthy filesystem: `59/59` tests, no corrupt-entry report anywhere in the serial log, including the tests that walk directories with hundreds of entries across several blocks.

If a way to mount a second, crafted image ever lands, this is the first thing worth testing with it.

## Validation

- Warning-free; `59/59` tests with 0 panics.
- The hang itself was observed before #264 was fixed: the guest stopped producing output at the `rmdir` of the incomplete directory that a full-filesystem `mkdir` had claimed to create, and the run had to be killed.
- `git diff --check` clean.
