### PR TITLE
docs: group the CI badges and record what each workflow covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,26 @@
 [![forthebadge](https://forthebadge.com/images/badges/made-with-c.svg)](https://forthebadge.com)
 [![forthebadge](https://forthebadge.com/images/badges/for-you.svg)](https://forthebadge.com)
 
-[![Ubuntu](https://github.com/mentos-team/MentOS/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/mentos-team/MentOS/actions/workflows/ubuntu.yml)
-[![Documentation](https://github.com/mentos-team/MentOS/actions/workflows/documentation.yml/badge.svg)](https://github.com/mentos-team/MentOS/actions/workflows/documentation.yml)
+<!--
+  The badges are pinned to `develop`, the default branch: that is where every change
+  lands first, so it is the state a visitor is actually looking at. The two groups are
+  kept apart because they answer different questions. The first says whether `develop`
+  builds, boots and documents itself right now, and runs on every push and pull
+  request. The second says whether the tree still builds with compilers and hosts we
+  do not gate merges on; those workflows run weekly, so a red badge there is a
+  standing report, not a broken branch.
+-->
+**Core CI**
+[![Ubuntu](https://github.com/mentos-team/MentOS/actions/workflows/ubuntu.yml/badge.svg?branch=develop)](https://github.com/mentos-team/MentOS/actions/workflows/ubuntu.yml)
+[![macOS](https://github.com/mentos-team/MentOS/actions/workflows/macos.yml/badge.svg?branch=develop)](https://github.com/mentos-team/MentOS/actions/workflows/macos.yml)
+[![Documentation](https://github.com/mentos-team/MentOS/actions/workflows/documentation.yml/badge.svg?branch=develop)](https://github.com/mentos-team/MentOS/actions/workflows/documentation.yml)
 
-> 📢 **Note:** The default branch is `main`
+**Compatibility**
+[![Compiler Compatibility](https://github.com/mentos-team/MentOS/actions/workflows/compiler-compatibility.yml/badge.svg?branch=develop)](https://github.com/mentos-team/MentOS/actions/workflows/compiler-compatibility.yml)
+[![macOS Compatibility](https://github.com/mentos-team/MentOS/actions/workflows/macos-compatibility.yml/badge.svg?branch=develop)](https://github.com/mentos-team/MentOS/actions/workflows/macos-compatibility.yml)
+
+> 📢 **Note:** The default branch is `develop`. Pull requests go there; `main` only ever
+> receives release merges.
 
 ---
 

--- a/docs/maintainer/testing-and-ci.md
+++ b/docs/maintainer/testing-and-ci.md
@@ -118,3 +118,28 @@ With the fix applied, failure detection is now automatic:
   `scripts/run-qemu-test build 600`, then a diagnostic tapview step;
   artifacts test.log/serial.log uploaded `if: always()`.
 - macos.yml exists (issue #124 tracks build problems there; not examined).
+
+## The five workflows and when they run
+
+The README groups the badges the same way, because the two groups mean
+different things when they are red.
+
+Core CI, on every push to `main`/`develop` and every pull request against
+them, all three path-filtered:
+
+- `ubuntu.yml` — the gate: build matrix plus the QEMU test job described above.
+- `macos.yml` — build only, no test job (issue #124).
+- `documentation.yml` — Doxygen build.
+
+Compatibility, weekly and on demand, never a merge gate:
+
+- `compiler-compatibility.yml` — also on pushes to `develop`; Sundays 03:00.
+- `macos-compatibility.yml` — `schedule` (Sundays 04:00) and
+  `workflow_dispatch` only, so it never sees a branch push.
+
+A scheduled run is attributed to the default branch, which is why the
+compatibility badges only started resolving once `develop` became the default:
+`macos-compatibility.yml` had no run at all in the repository's history until
+it was dispatched by hand on 2026-09-04. Until a workflow has one run on the
+branch a badge is pinned to, that badge reads "no status" rather than failing,
+which is easy to mistake for a broken link.


### PR DESCRIPTION
## What

The badge block in the README listed only `Ubuntu` and `Documentation`. Three workflows have been added since it was written, and none of the badges carried a branch, so they reported whatever the default branch happened to be. The note below them still announced `main` as the default branch.

The badges now cover all five workflows, pinned to `develop`, in two groups:

- **Core CI** — `Ubuntu`, `macOS`, `Documentation`: on every push to `main`/`develop` and every pull request against them. Red here means `develop` is broken.
- **Compatibility** — `Compiler Compatibility`, `macOS Compatibility`: weekly and on demand, never a merge gate. Red here is a standing report about a toolchain or a host, not a broken branch.

The note now also says where pull requests go and that `main` only receives release merges.

## Two things found while checking the triggers

- `macos-compatibility.yml` runs on `schedule` and `workflow_dispatch` only, and **had no run at all** in the repository's history. Its badge would have read a grey "no status", which is easy to mistake for a broken link. It was dispatched by hand on `develop` to populate it: https://github.com/mentos-team/MentOS/actions/runs/33846433893
- A scheduled run is attributed to the default branch, so both compatibility badges only resolve against `develop` now that `develop` is the default. Runs from before the switch are attributed to `main` and the badges cannot see them.

Both are written down in `docs/maintainer/testing-and-ci.md`, together with the trigger of each of the five workflows, so the grouping in the README has a reason recorded somewhere.

## Verification

Documentation-only change; no code touched. `git diff --check` clean. The `Documentation` workflow is path-filtered on `README.md`, so it runs on this pull request.