### PR TITLE
fix(ext2): bound the truncation writes to the size of the buffer

### DIFF
--- a/kernel/src/fs/ext2/ext2_blockmap.c
+++ b/kernel/src/fs/ext2/ext2_blockmap.c
@@ -661,7 +661,11 @@ int ext2_clean_inode_content(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_
         return 1;
     }
     // Allocate the cache.
-    uint8_t *cache    = ext2_alloc_cache(fs);
+    uint8_t *cache = ext2_alloc_cache(fs);
+    if (cache == NULL) {
+        pr_err("Failed to allocate the cache to clean inode %u\n", inode_index);
+        return -1;
+    }
     // Get the cache size.
     size_t cache_size = fs->block_size;
     //
@@ -670,8 +674,12 @@ int ext2_clean_inode_content(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_
         pr_debug(
             "ext2_clean_inode_content(%p, %p, %u): offset = %6u of size = %u\n", fs, inode, inode_index, offset,
             inode->size);
-        // We do not want to extend the size of the inode.
-        to_write = max(min(offset + cache_size, inode->size), 0);
+        // How many bytes are left to clean. The cache holds a single block, so
+        // that is the most one call can store: asking for more made the driver
+        // copy whatever followed the cache into the file, and the last request
+        // reached past the end of the file and extended it (#315).
+        size_t remaining = (size_t)(inode->size - (uint32_t)offset);
+        to_write         = (ssize_t)min(cache_size, remaining);
         pr_debug("ext2_clean_inode_content(%p, %p, %u): to_write = %6u\n", fs, inode, inode_index, to_write);
         // Override the content.
         ssize_t written = ext2_write_inode_data(fs, inode, inode_index, offset, to_write, (char *)cache);

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -44,6 +44,7 @@ static char *all_tests[] = {
     "t_file_blocks",
     "t_fhs",
     "t_file_blocks_free",
+    "t_trunc_content",
     "t_font",
     "t_fork",
     "t_getcwd",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_LIST
     t_fflush.c
     t_file_blocks.c
     t_file_blocks_free.c
+    t_trunc_content.c
     t_font.c
     t_sigusr.c
     t_kill.c

--- a/userspace/tests/t_trunc_content.c
+++ b/userspace/tests/t_trunc_content.c
@@ -1,0 +1,181 @@
+/// @file t_trunc_content.c
+/// @brief Regression test for #315: truncating a file larger than one block
+/// must not write anything but zeroes, and must not make the file grow.
+/// @details ext2_clean_inode_content walked the file one block at a time with
+/// a one-block buffer, but computed the length of each write as
+/// `max(min(offset + cache_size, inode->size), 0)`, which is the offset of the
+/// end of the window rather than its length. The first iteration was right by
+/// accident, since its offset is 0; from the second on it asked
+/// ext2_write_inode_data for more bytes than the buffer held, so the driver
+/// copied whatever followed the one-block slab object into the file, and the
+/// last iteration wrote past the end of the file and grew it.
+///
+/// The file therefore has to be larger than one block for the defect to show:
+/// t_write_read already truncates a file, but a 6-byte one, so its single
+/// iteration never leaves the range where the arithmetic happens to work.
+///
+/// Both consequences are checked. The growth is the deterministic one and does
+/// not depend on what the kernel heap happens to hold; the non-zero bytes are
+/// the reason the defect matters, because they are kernel memory that a
+/// program can read back.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The file used by the check.
+#define PATH "/home/user/t_trunc_content.bin"
+
+/// Size of a filesystem block in the image.
+#define BLOCK_SIZE 4096
+
+/// Size of the file. Three blocks and a bit, so the loop inside the driver
+/// runs four times and the last one lands past the end of the file.
+#define FILE_SIZE ((3 * BLOCK_SIZE) + 100)
+
+/// Byte written everywhere, so that anything left over is visible.
+#define FILLER 0xAB
+
+/// Buffer used for writing and for reading back, one block at a time.
+static char buffer[BLOCK_SIZE];
+
+/// @brief Creates the file and fills it with FILLER.
+/// @return 0 on success, -1 on failure.
+static int __create_and_fill(void)
+{
+    int fd = open(PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_trunc_content] open for filling: %s", strerror(errno));
+        return -1;
+    }
+    memset(buffer, FILLER, sizeof(buffer));
+    for (size_t done = 0; done < FILE_SIZE;) {
+        size_t chunk    = ((FILE_SIZE - done) < sizeof(buffer)) ? (FILE_SIZE - done) : sizeof(buffer);
+        ssize_t written = write(fd, buffer, chunk);
+        if (written != (ssize_t)chunk) {
+            syslog(LOG_ERR, "[t_trunc_content] write at %u returned %zd: %s", (unsigned)done, written, strerror(errno));
+            close(fd);
+            return -1;
+        }
+        done += chunk;
+    }
+    close(fd);
+    return 0;
+}
+
+/// @brief Reads the size of the file.
+/// @param size where the size is stored.
+/// @return 0 on success, -1 on failure.
+static int __size_of(unsigned *size)
+{
+    stat_t st;
+    if (stat(PATH, &st) < 0) {
+        syslog(LOG_ERR, "[t_trunc_content] stat: %s", strerror(errno));
+        return -1;
+    }
+    *size = (unsigned)st.st_size;
+    return 0;
+}
+
+/// @brief Counts the bytes of the file that are not zero.
+/// @param nonzero where the count is stored.
+/// @param first where the offset of the first non-zero byte is stored.
+/// @return 0 on success, -1 on failure.
+static int __count_nonzero(unsigned *nonzero, unsigned *first)
+{
+    int fd = open(PATH, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_trunc_content] open for reading: %s", strerror(errno));
+        return -1;
+    }
+    *nonzero      = 0;
+    *first        = 0;
+    unsigned seen = 0;
+    ssize_t bytes;
+    while ((bytes = read(fd, buffer, sizeof(buffer))) > 0) {
+        for (ssize_t i = 0; i < bytes; ++i) {
+            if (buffer[i] != 0) {
+                if (*nonzero == 0) {
+                    *first = seen + (unsigned)i;
+                }
+                ++(*nonzero);
+            }
+        }
+        seen += (unsigned)bytes;
+    }
+    close(fd);
+    if (bytes < 0) {
+        syslog(LOG_ERR, "[t_trunc_content] read: %s", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    unsigned before  = 0;
+    unsigned after   = 0;
+    unsigned nonzero = 0;
+    unsigned first   = 0;
+    int failures     = 0;
+
+    if (__create_and_fill() < 0) {
+        return EXIT_FAILURE;
+    }
+    if (__size_of(&before) < 0) {
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+    if (before != FILE_SIZE) {
+        syslog(LOG_ERR, "[t_trunc_content] the file is %u bytes, expected %u", before, (unsigned)FILE_SIZE);
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+
+    // Truncating happens while the file is being opened, so opening and
+    // closing it is the whole operation under test.
+    int fd = open(PATH, O_WRONLY | O_TRUNC, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_trunc_content] open with O_TRUNC: %s", strerror(errno));
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+    close(fd);
+
+    // Truncating a file cannot make it longer. #320 tracks the fact that it
+    // does not shorten it either, which is why this is not an equality.
+    if (__size_of(&after) < 0) {
+        ++failures;
+    } else if (after > before) {
+        syslog(LOG_ERR, "[t_trunc_content] truncating grew the file from %u bytes to %u", before, after);
+        ++failures;
+    }
+
+    // Whatever length is left, none of it may be anything but zero: a non-zero
+    // byte here came from kernel memory past the one-block buffer.
+    if (__count_nonzero(&nonzero, &first) < 0) {
+        ++failures;
+    } else if (nonzero != 0) {
+        syslog(
+            LOG_ERR, "[t_trunc_content] %u bytes of the truncated file are not zero, the first at offset %u", nonzero,
+            first);
+        ++failures;
+    }
+
+    unlink(PATH);
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_trunc_content] truncating %u bytes left only zeroes and did not grow the file", before);
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_trunc_content] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #315

## The defect

`ext2_clean_inode_content` walks the file one block at a time through a one-block buffer, and computed the length of each write as

```c
to_write = max(min(offset + cache_size, inode->size), 0);
```

That is the offset of the end of the window, not its length. The first iteration is right by accident, because its offset is zero. From the second on the function asks `ext2_write_inode_data` for more bytes than the buffer holds, so the driver copies whatever follows the one-block slab object into the file, and the last iteration asks for a range reaching past the end of the file and extends it.

For a 12388-byte file with 4096-byte blocks the loop does:

| iteration | offset | `to_write` | what happens |
| --- | --- | --- | --- |
| 1 | 0 | 4096 | correct |
| 2 | 4096 | 8192 | 8192 bytes copied out of a 4096-byte buffer |
| 3 | 12288 | 12388 | writes to offset 24676, growing the file |

## Reachability, wider than the issue first said

The guard in `ext2_open` reads as read-write or read-only truncating opens:

```c
bitmask_exact(flags, O_RDWR | O_TRUNC) || bitmask_exact(flags, O_RDONLY | O_TRUNC)
```

`bitmask_exact(V, M)` is `((V) & (M)) == (M)` and `O_RDONLY` is `0`, so the second half is `((flags & O_TRUNC) == O_TRUNC)`: **any** truncating open reaches this, including the ordinary `O_WRONLY | O_CREAT | O_TRUNC` that `creat()` and every shell redirection use. `kernel/src/process/scheduler_feedback.c:136` opens its file that way too, so the kernel is itself a caller. The only real precondition is a file larger than one block.

## The fix

```c
size_t remaining = (size_t)(inode->size - (uint32_t)offset);
to_write         = (ssize_t)min(cache_size, remaining);
```

The function also used its buffer without checking the allocation, and `ext2_alloc_cache` returns `NULL` on failure, so that pointer went into `ext2_write_inode_data` to be dereferenced. It now returns `-1`, the way the rest of the driver does.

## Evidence

`t_trunc_content` fills a 12388-byte file with `0xAB`, truncates it with `O_WRONLY | O_TRUNC`, and requires that the file did not grow and that every remaining byte is zero. Written before the fix, it failed on the unpatched driver:

```
not ok 21 - t_trunc_content: Exit: 1
[t_trunc_content] truncating grew the file from 12388 bytes to 24676
[t_trunc_content] 1317 bytes of the truncated file are not zero, the first at offset 8200
[t_trunc_content] 2 FAILURES
```

Offset 8200 is eight bytes past the 8192 boundary, exactly where the oversized write starts reading beyond the buffer: **those 1317 bytes are kernel memory a program can read back out of its own file.** The growth from 12388 to 24676 is the deterministic half of the failure and does not depend on what the heap happened to hold, which is what makes the test reliable rather than dependent on the allocator's state.

After the fix:

```
[t_trunc_content] truncating 12388 bytes left only zeroes and did not grow the file
```

That reproduction run is the negative control: the test predates the fix, so there was no need to revert anything to see it fail.

## Why the suite did not catch it

`t_write_read`'s `test_truncate` does exactly the right kind of open, but on a 6-byte file. Its loop runs once and never leaves the range where the arithmetic happens to work. The defect needs a second iteration to appear.

## Verification

- Debug build, `-Wall -Werror`: clean.
- Full suite with a freshly built `rootfs.img`: **62 tests, 0 failures, 0 panics**.
- `clang-format` clean, `git diff --check` clean.

## Related, not fixed here

`O_TRUNC` never sets the file size to zero at all, which is a POSIX problem in the same path and needs the guard above rewritten rather than patched: #320.