### PR TITLE
fix(ext2): stop an aligned write from allocating a block past the data

### DIFF
--- a/kernel/src/fs/ext2/ext2_blockmap.c
+++ b/kernel/src/fs/ext2/ext2_blockmap.c
@@ -542,6 +542,12 @@ ssize_t ext2_write_inode_data(
         pr_err("Integer overflow: offset + nbyte exceeds UINT32_MAX\n");
         return -1;
     }
+    // A zero-length write stores nothing and must not touch the file, the
+    // size included. It also keeps `end_offset` below from reaching zero,
+    // which the block arithmetic relies on.
+    if (nbyte == 0) {
+        return 0;
+    }
     // Keep the size the file had, so that a write which cannot store every
     // block does not leave the inode claiming bytes that were never written.
     uint32_t original_size = inode->size;
@@ -554,9 +560,15 @@ ssize_t ext2_write_inode_data(
     }
     // Get the offset to the end of the portion we are writing.
     uint32_t end_offset  = (inode->size >= offset + nbyte) ? (offset + nbyte) : (inode->size);
-    // Convert the offset/size to some starting/end iblock numbers.
+    // Convert the offset/size to some starting/end iblock numbers. The end
+    // block is the one containing the last byte to write (end_offset - 1):
+    // when end_offset is an exact multiple of the block size, dividing
+    // end_offset directly named the block after the data and left end_size at
+    // zero, so the loop ran one more time and allocated a block it then
+    // copied nothing into (#311). The read path above was corrected the same
+    // way by #242; this side was left behind.
     uint32_t start_block = offset / fs->block_size;
-    uint32_t end_block   = end_offset / fs->block_size;
+    uint32_t end_block   = (end_offset - 1) / fs->block_size;
     // What's the offset into the start block.
     uint32_t start_off   = offset % fs->block_size;
     // How much bytes to read for the end block.

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -45,6 +45,7 @@ static char *all_tests[] = {
     "t_fhs",
     "t_file_blocks_free",
     "t_trunc_content",
+    "t_write_aligned",
     "t_font",
     "t_fork",
     "t_getcwd",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_LIST
     t_file_blocks.c
     t_file_blocks_free.c
     t_trunc_content.c
+    t_write_aligned.c
     t_font.c
     t_sigusr.c
     t_kill.c

--- a/userspace/tests/t_write_aligned.c
+++ b/userspace/tests/t_write_aligned.c
@@ -1,0 +1,186 @@
+/// @file t_write_aligned.c
+/// @brief Regression test for #311: a write ending exactly on a block boundary
+/// must not allocate a block past the data.
+/// @details ext2_write_inode_data derived the last block of the transfer from
+/// `end_offset / block_size`, which for a write ending on a boundary names the
+/// block *after* the last one holding data, and leaves `end_size` at zero. The
+/// loop then ran one extra iteration whose copy length, `end_size - 1 + 1` in
+/// unsigned arithmetic, wrapped to zero: no bytes were copied, but the block
+/// was allocated and written all the same. Every aligned write therefore took
+/// one block more than it needed, permanently attributed to the file.
+///
+/// The read path had the same defect and #242 fixed it there, with a comment
+/// naming this exact case; the write path was left as it was, which is what
+/// this test pins down.
+///
+/// The file is created before the measurement starts, so that the directory
+/// entry already exists and the block the directory might need to grow cannot
+/// be counted as one of the file's. Eight blocks keeps the file inside the
+/// twelve direct pointers of the inode, so no index block is involved either
+/// and the expected count is exact.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The file used by the checks.
+#define PATH "/home/user/t_write_aligned.bin"
+
+/// Size of a filesystem block in the image.
+#define BLOCK_SIZE 4096
+
+/// How many whole blocks to write. Eight stays within the twelve direct
+/// pointers of an inode, so the file needs no index block.
+#define BLOCKS 8
+
+/// Buffer holding one block.
+static char buffer[BLOCK_SIZE];
+
+/// @brief Reads the number of free blocks of the filesystem.
+/// @param blocks where the count is stored.
+/// @return 0 on success, -1 on failure.
+static int __free_blocks(unsigned long *blocks)
+{
+    statfs_t buf;
+    if (statfs("/home/user", &buf) < 0) {
+        syslog(LOG_ERR, "[t_write_aligned] statfs: %s", strerror(errno));
+        return -1;
+    }
+    *blocks = (unsigned long)buf.f_bfree;
+    return 0;
+}
+
+/// @brief Creates the file, so that the directory entry exists before the
+///        measurement starts.
+/// @return 0 on success, -1 on failure.
+static int __create_empty(void)
+{
+    int fd = open(PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_write_aligned] open for creating: %s", strerror(errno));
+        return -1;
+    }
+    close(fd);
+    return 0;
+}
+
+/// @brief Writes whole blocks into the file, one block per call.
+/// @param count how many blocks to write.
+/// @return 0 on success, -1 on failure.
+static int __write_blocks(unsigned count)
+{
+    int fd = open(PATH, O_WRONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_write_aligned] open for writing: %s", strerror(errno));
+        return -1;
+    }
+    memset(buffer, 'A', sizeof(buffer));
+    for (unsigned block = 0; block < count; ++block) {
+        ssize_t written = write(fd, buffer, sizeof(buffer));
+        if (written != (ssize_t)sizeof(buffer)) {
+            syslog(LOG_ERR, "[t_write_aligned] write of block %u returned %zd: %s", block, written, strerror(errno));
+            close(fd);
+            return -1;
+        }
+    }
+    close(fd);
+    return 0;
+}
+
+/// @brief Checks that the file reads back what was written into it.
+/// @param count how many blocks were written.
+/// @return 0 when the content matches, -1 otherwise.
+static int __check_content(unsigned count)
+{
+    int fd = open(PATH, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_write_aligned] open for reading: %s", strerror(errno));
+        return -1;
+    }
+    for (unsigned block = 0; block < count; ++block) {
+        memset(buffer, 0, sizeof(buffer));
+        ssize_t bytes = read(fd, buffer, sizeof(buffer));
+        if (bytes != (ssize_t)sizeof(buffer)) {
+            syslog(LOG_ERR, "[t_write_aligned] read of block %u returned %zd: %s", block, bytes, strerror(errno));
+            close(fd);
+            return -1;
+        }
+        for (size_t i = 0; i < sizeof(buffer); ++i) {
+            if (buffer[i] != 'A') {
+                syslog(LOG_ERR, "[t_write_aligned] block %u differs at byte %u", block, (unsigned)i);
+                close(fd);
+                return -1;
+            }
+        }
+    }
+    close(fd);
+    return 0;
+}
+
+int main(void)
+{
+    unsigned long before = 0;
+    unsigned long after  = 0;
+    int failures         = 0;
+
+    if (__create_empty() < 0) {
+        return EXIT_FAILURE;
+    }
+    if (__free_blocks(&before) < 0) {
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+    if (__write_blocks(BLOCKS) < 0) {
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+    if (__free_blocks(&after) < 0) {
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+
+    // Writing whole blocks has to consume exactly that many blocks.
+    unsigned long consumed = before - after;
+    if (consumed != BLOCKS) {
+        syslog(
+            LOG_ERR, "[t_write_aligned] writing %u whole blocks consumed %lu blocks", (unsigned)BLOCKS, consumed);
+        ++failures;
+    }
+
+    // And the size has to match, so that a wrong count cannot be explained
+    // away by the file holding more than it was asked to.
+    stat_t st;
+    if (stat(PATH, &st) < 0) {
+        syslog(LOG_ERR, "[t_write_aligned] stat: %s", strerror(errno));
+        ++failures;
+    } else if ((unsigned)st.st_size != (unsigned)(BLOCKS * BLOCK_SIZE)) {
+        syslog(
+            LOG_ERR, "[t_write_aligned] the file is %u bytes, expected %u", (unsigned)st.st_size,
+            (unsigned)(BLOCKS * BLOCK_SIZE));
+        ++failures;
+    }
+
+    // The data still has to be there: bounding the transfer must not drop the
+    // last block of it.
+    if (__check_content(BLOCKS) < 0) {
+        ++failures;
+    }
+
+    unlink(PATH);
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_write_aligned] %u whole blocks took exactly %u blocks", (unsigned)BLOCKS, (unsigned)BLOCKS);
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_write_aligned] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #311

## The defect

`ext2_write_inode_data` derived the last block of a transfer from

```c
uint32_t end_block = end_offset / fs->block_size;
```

For a write ending exactly on a block boundary that names the block **after** the last one holding data, and leaves `end_size` at zero. The loop then runs one more iteration, and for that iteration

```c
right = end_size - 1;
```

is `0 - 1` in `uint32_t`, so `right` becomes `0xFFFFFFFF`. The copy length that follows, `right - left + 1`, wraps back to zero, so `memcpy` copies nothing and the return value stays correct. The only thing the extra iteration does is **allocate a block and write the buffer into it**. Every write ending on a boundary took one block more than it needed, attributed to the file for as long as the file existed.

Worth saying plainly: nothing was corrupted, and only because the wraparound landed on zero. A copy length of `0xFFFFFFFF + 1` is zero in 32-bit arithmetic and is not in 64-bit. The code was being saved by the width of the type, not by a check.

## The fix

The end block is the one holding the last byte:

```c
uint32_t end_block = (end_offset - 1) / fs->block_size;
```

which is exactly what #242 did to `ext2_read_inode_data`. The comment it left there names this very case:

> when `end_offset` is an exact multiple of the block size, dividing `end_offset` directly would point one block past the data and leave `end_size` at zero, wrapping the copy length of the last block

The write path was simply left behind. The two functions are near-identical and sat 80 lines apart in what used to be a 4412-line file, which is how a fix landed in one and not the other — the argument that motivated the split in #318.

A zero-length write now returns `0` before any of this, both because `write(2)` requires it to have no effect and because `end_offset` has to stay above zero for `end_offset - 1` to mean anything.

## Evidence

`t_write_aligned` writes eight whole blocks into a file that is **created before the measurement starts**, so the directory entry already exists and the block a growing directory might need cannot be counted against the file. Eight blocks stay inside the twelve direct pointers of the inode, so no index block is involved either, and the expected count is exact rather than approximate.

Before the fix:

```
not ok 22 - t_write_aligned: Exit: 1
[t_write_aligned] writing 8 whole blocks consumed 9 blocks
[t_write_aligned] 1 FAILURES
```

The size check and the content check passed in that same run, which is the evidence that this leaked space rather than losing data — a distinction worth having in the test, because the two failure modes call for different fixes.

After:

```
[t_write_aligned] 8 whole blocks took exactly 8 blocks
```

The reproduction run is the negative control: the test predates the fix.

## Verification

- Debug build, `-Wall -Werror`: clean.
- Full suite with a freshly built `rootfs.img`: **63 tests, 0 failures, 0 panics**.
- `clang-format` clean, `git diff --check` clean.