### PR TITLE
fix(ext2): report why a creation failed, and undo what it allocated

### DIFF
--- a/kernel/src/fs/ext2/ext2_file.c
+++ b/kernel/src/fs/ext2/ext2_file.c
@@ -23,10 +23,14 @@ vfs_file_t *ext2_creat(const char *path, mode_t mode)
     // Get the name of the directory.
     char parent_path[PATH_MAX];
     if (!dirname(path, parent_path, sizeof(parent_path))) {
+        errno = ENAMETOOLONG;
         return NULL;
     }
     const char *file_name = basename(path);
     if (strcmp(parent_path, path) == 0) {
+        // A path that is its own parent directory is the root, and creating
+        // the root means creating a directory: EISDIR is what POSIX asks for.
+        errno = EISDIR;
         return NULL;
     }
     // Get the parent VFS node.
@@ -35,12 +39,28 @@ vfs_file_t *ext2_creat(const char *path, mode_t mode)
         errno = ENOENT;
         return NULL;
     }
+    // What has to be undone when a later step fails. The inode is allocated
+    // in the bitmap before anything points at it, and its name is placed
+    // before the VFS file exists, so a failure in between used to leave the
+    // inode marked used with no name, or the name on disk while creat
+    // reported failure (#305).
+    int inode_index      = -1;
+    int has_direntry     = 0;
+    vfs_file_t *new_file = NULL;
+    // The error to report, as a negative errno. Every path out of here used
+    // to return NULL without touching errno, leaving the caller to read
+    // whatever the last unrelated failure had set.
+    int failure          = 0;
+    // The file to hand back on success.
+    vfs_file_t *result   = NULL;
+
     // flags = O_WRONLY | O_CREAT | O_TRUNC
     // Get the filesystem.
     ext2_filesystem_t *fs = (ext2_filesystem_t *)parent->device;
     if (fs == NULL) {
         pr_err("The parent does not belong to an EXT2 filesystem `%s`.\n", parent->name);
-        goto close_parent_return_null;
+        failure = -ENODEV;
+        goto rollback;
     }
     // Prepare an inode, it will come in handy either way.
     ext2_inode_t inode;
@@ -51,7 +71,8 @@ vfs_file_t *ext2_creat(const char *path, mode_t mode)
     if (!ext2_find_direntry(fs, parent->ino, file_name, &search)) {
         if (ext2_read_inode(fs, &inode, search.direntry.inode) == -1) {
             pr_err("Failed to read the inode of `%s`.\n", search.direntry.name);
-            goto close_parent_return_null;
+            failure = -EIO;
+            goto rollback;
         }
         vfs_file_t *file = ext2_find_vfs_file_with_inode(fs, search.direntry.inode);
         if (file == NULL) {
@@ -59,15 +80,20 @@ vfs_file_t *ext2_creat(const char *path, mode_t mode)
             file = vfs_alloc_file();
             if (file == NULL) {
                 pr_err("Failed to allocate memory for the EXT2 file.\n");
-                goto close_parent_return_null;
+                failure = -ENOMEM;
+                goto rollback;
             }
+            // From here the file is ours to release if the next step fails.
+            new_file = file;
             if (ext2_init_vfs_file(
                     fs, file, &inode, search.direntry.inode, search.direntry.name, search.direntry.name_len) == -1) {
                 pr_err("Failed to properly set the VFS file.\n");
-                goto close_parent_return_null;
+                failure = -EIO;
+                goto rollback;
             }
             // Add the vfs_file to the list of associated files.
             list_head_insert_before(&file->siblings, &fs->opened_files);
+            new_file = NULL;
         } else {
             // The list of open files is keyed by inode number, and the entry
             // may describe a file that was deleted while its number got
@@ -75,48 +101,90 @@ vfs_file_t *ext2_creat(const char *path, mode_t mode)
             __ext2_set_vfs_file_properties(
                 fs, file, &inode, search.direntry.inode, search.direntry.name, search.direntry.name_len);
         }
-        return file;
+        result = file;
+        goto done;
     }
     // Set the inode mode.
     mode                 = S_IFREG | (0xFFF & mode);
     // Get the group index of the parent.
     uint32_t group_index = ext2_inode_index_to_group_index(fs, parent->ino);
     // Create and initialize the new inode.
-    int inode_index      = ext2_create_inode(fs, &inode, mode, group_index);
+    inode_index          = ext2_create_inode(fs, &inode, mode, group_index);
     if (inode_index == -1) {
         pr_err("Failed to create a new inode inside `%s` (group index: %d).\n", parent->name, group_index);
-        goto close_parent_return_null;
+        failure = -ENOSPC;
+        goto rollback;
     }
     // Write the inode.
     if (ext2_write_inode(fs, &inode, inode_index) == -1) {
         pr_err("Failed to write the newly created inode.\n");
-        goto close_parent_return_null;
+        failure = -EIO;
+        goto rollback;
     }
 
     // Clean the content of the newly created file.
     if (ext2_clean_inode_content(fs, &inode, inode_index) < 0) {
         pr_err("Failed to clean the content of the newly created inode.\n");
-        goto close_parent_return_null;
+        failure = -EIO;
+        goto rollback;
     }
 
     // Initialize the file.
     if (ext2_allocate_direntry(fs, parent->ino, inode_index, file_name, ext2_file_type_regular_file) == -1) {
         pr_err("Failed to allocate a new direntry for the inode.\n");
-        goto close_parent_return_null;
+        failure = -ENOSPC;
+        goto rollback;
     }
+    has_direntry = 1;
     // Allocate the memory for the file.
-    vfs_file_t *new_file = vfs_alloc_file();
+    new_file     = vfs_alloc_file();
     if (new_file == NULL) {
         pr_err("Failed to allocate memory for the EXT2 file.\n");
-        goto close_parent_return_null;
+        failure = -ENOMEM;
+        goto rollback;
     }
     if (ext2_init_vfs_file(fs, new_file, &inode, inode_index, file_name, strlen(file_name)) == -1) {
         pr_err("Failed to properly set the VFS file.\n");
-        goto close_parent_return_null;
+        failure = -EIO;
+        goto rollback;
     }
-    return new_file;
-close_parent_return_null:
+    result   = new_file;
+    new_file = NULL;
+done:
+    // The reference taken on the parent is released on the way out, on this
+    // path as much as on the failing one (#323).
     vfs_close(parent);
+    return result;
+rollback:
+    // Take the name out of the parent before the inode goes away, so that no
+    // entry is left pointing at a free inode.
+    if (has_direntry && (__ext2_clear_direntry_for_path(fs, path) < 0)) {
+        pr_err("ext2_creat(path: %s): Failed to remove the incomplete directory entry.\n", path);
+    }
+    // Give the inode back. Re-read it, because cleaning its content may have
+    // given it blocks that have to be released along with it.
+    if (inode_index >= 0) {
+        ext2_inode_t stale;
+        if (ext2_read_inode(fs, &stale, (uint32_t)inode_index) != -1) {
+            stale.links_count = 0;
+            stale.dtime       = sys_time(NULL);
+            if (ext2_write_inode(fs, &stale, (uint32_t)inode_index) == -1) {
+                pr_err("ext2_creat(path: %s): Failed to update the inode being freed.\n", path);
+            }
+            if (ext2_free_inode(fs, &stale, (uint32_t)inode_index) < 0) {
+                pr_err("ext2_creat(path: %s): Failed to free the inode.\n", path);
+            }
+        } else {
+            pr_err("ext2_creat(path: %s): Failed to re-read the inode to free it.\n", path);
+        }
+    }
+    // Release the VFS file only when it is one we allocated and never handed
+    // to anybody.
+    if (new_file != NULL) {
+        vfs_dealloc_file(new_file);
+    }
+    vfs_close(parent);
+    errno = -failure;
     return NULL;
 }
 

--- a/kernel/src/fs/ext2/ext2_internal.h
+++ b/kernel/src/fs/ext2/ext2_internal.h
@@ -529,6 +529,7 @@ int ext2_destroy_direntry(ext2_filesystem_t *fs, ext2_inode_t parent, ext2_inode
 int ext2_find_direntry(ext2_filesystem_t *fs, ino_t ino, const char *name, ext2_direntry_search_t *search);
 
 // Defined in ext2_namei.c.
+int __ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path);
 int __valid_x_permission(task_struct *task, ext2_inode_t *inode);
 int ext2_file_type_to_vfs_file_type(int ext2_type);
 int ext2_resolve_path(vfs_file_t *directory, const char *path, ext2_direntry_search_t *search);

--- a/kernel/src/fs/ext2/ext2_namei.c
+++ b/kernel/src/fs/ext2/ext2_namei.c
@@ -457,7 +457,7 @@ early_exit:
 /// @details Used when mkdir cannot finish: the entry it added to the parent
 ///          must go away before the inode is freed, otherwise the parent
 ///          keeps a name pointing at a free inode (#264).
-static int __ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path)
+int __ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path)
 {
     ext2_direntry_search_t search;
     memset(&search, 0, sizeof(ext2_direntry_search_t));

--- a/kernel/src/fs/vfs.c
+++ b/kernel/src/fs/vfs.c
@@ -754,8 +754,15 @@ vfs_file_t *vfs_creat(const char *path, mode_t mode)
     // Retrieve the file.
     vfs_file_t *file = sb_root->sys_operations->creat_f(absolute_path, mode);
     if (file == NULL) {
-        pr_err("vfs_creat(%s): Cannot find the given file (%s)!\n", path, strerror(errno));
-        errno = ENOENT;
+        // Keep what the filesystem reported. Overwriting it with ENOENT
+        // turned every creation failure into "no such file", so a full
+        // filesystem, a read-only device and a name that is too long were
+        // indistinguishable from user space; the line below used to print
+        // the right reason and then throw it away (#289).
+        if (errno == 0) {
+            errno = ENOENT;
+        }
+        pr_err("vfs_creat(%s): Cannot create the given file (%s)!\n", path, strerror(errno));
         return NULL;
     }
     // Increment file reference counter.

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -29,6 +29,7 @@ static char *all_tests[] = {
     // "t_big_write",
     "t_chdir",
     "t_creat",
+    "t_creat_errno",
     "t_dir_entries",
     "t_dup",
     "t_environ",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # List of programs.
 set(TEST_LIST
     t_aab_pipe.c
+    t_creat_errno.c
     t_dir_entries.c
     t_dup.c
     t_hashmap.c

--- a/userspace/tests/t_creat_errno.c
+++ b/userspace/tests/t_creat_errno.c
@@ -1,0 +1,128 @@
+/// @file t_creat_errno.c
+/// @brief Regression test for #305: a creation that fails must say why.
+/// @details Every path out of ext2_creat returned NULL without touching
+/// errno, and vfs_creat then overwrote whatever was there with ENOENT, so a
+/// full filesystem, a read-only device, a name that is too long and a request
+/// to create the root directory were all reported to user space as "no such
+/// file or directory". vfs_creat even printed the right reason on the line
+/// above and threw it away on the next one (#289, item 1).
+///
+/// The two halves have to be fixed together to be observable at all: giving
+/// ext2_creat correct errnos changes nothing while vfs_creat replaces them,
+/// and keeping vfs_creat's value changes nothing while ext2_creat leaves it
+/// unset.
+///
+/// The failures checked here are the ones that need no particular state of
+/// the filesystem, so they are cheap and deterministic. The rollback of the
+/// inode itself, which needs a filesystem with no room left, is exercised by
+/// t_nospace.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// A file that the test creates and removes, to check the happy path.
+#define GOOD_PATH "/home/user/t_creat_errno.tmp"
+
+/// A path whose parent directory does not exist.
+#define NO_PARENT_PATH "/home/user/t_creat_errno.d/file"
+
+/// @brief Checks that creating the given path fails with the given errno.
+/// @param path the path to create.
+/// @param expected the errno the attempt has to report.
+/// @param what a description of the case, for the log.
+/// @return 0 when the attempt failed as expected, -1 otherwise.
+static int check_failure(const char *path, int expected, const char *what)
+{
+    errno  = 0;
+    int fd = creat(path, 0644);
+    if (fd >= 0) {
+        close(fd);
+        unlink(path);
+        syslog(LOG_ERR, "[t_creat_errno] creating %s (%s) succeeded, it had to fail", path, what);
+        return -1;
+    }
+    if (errno != expected) {
+        // One strerror per line: it returns a single static buffer, so two
+        // calls in the same message both show the second string and the log
+        // reads as though the test compared a value with itself.
+        int reported = errno;
+        syslog(LOG_ERR, "[t_creat_errno] creating %s (%s) reported errno %d: %s", path, what, reported, strerror(reported));
+        syslog(LOG_ERR, "[t_creat_errno] the expected errno was %d: %s", expected, strerror(expected));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Checks that an ordinary creation still works.
+/// @return 0 on success, -1 on failure.
+static int check_success(void)
+{
+    int fd = creat(GOOD_PATH, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_creat_errno] creating %s failed: %s", GOOD_PATH, strerror(errno));
+        return -1;
+    }
+    // The file has to be usable, not merely created: the rollback added to
+    // ext2_creat must not release anything on the way out of a success.
+    const char *content = "creat";
+    ssize_t written     = write(fd, content, strlen(content));
+    close(fd);
+    if (written != (ssize_t)strlen(content)) {
+        syslog(LOG_ERR, "[t_creat_errno] write returned %zd, expected %u", written, (unsigned)strlen(content));
+        unlink(GOOD_PATH);
+        return -1;
+    }
+    char buffer[16] = {0};
+    fd              = open(GOOD_PATH, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_creat_errno] reopening %s failed: %s", GOOD_PATH, strerror(errno));
+        unlink(GOOD_PATH);
+        return -1;
+    }
+    ssize_t bytes = read(fd, buffer, sizeof(buffer) - 1);
+    close(fd);
+    unlink(GOOD_PATH);
+    if ((bytes != (ssize_t)strlen(content)) || (strcmp(buffer, content) != 0)) {
+        syslog(LOG_ERR, "[t_creat_errno] %s reads back `%s`, expected `%s`", GOOD_PATH, buffer, content);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    // The root is its own parent, so creating it is a request to create a
+    // directory. This is the case that used to come back as ENOENT.
+    if (check_failure("/", EISDIR, "the root directory") < 0) {
+        ++failures;
+    }
+
+    // A missing parent directory is genuinely ENOENT, and has to stay so:
+    // reporting the underlying error must not turn the common case into
+    // something else.
+    if (check_failure(NO_PARENT_PATH, ENOENT, "a missing parent directory") < 0) {
+        ++failures;
+    }
+
+    if (check_success() < 0) {
+        ++failures;
+    }
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_creat_errno] every failed creation reported its own reason");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_creat_errno] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #305
Fixes #323
Closes part of #289 (item 1)

## The defect

`ext2_creat` had eleven ways to fail and all of them did the same thing: close the parent and return `NULL`, without touching `errno`. `vfs_creat` then overwrote whatever was there:

```c
vfs_file_t *file = sb_root->sys_operations->creat_f(absolute_path, mode);
if (file == NULL) {
    pr_err("vfs_creat(%s): Cannot find the given file (%s)!\n", path, strerror(errno));
    errno = ENOENT;   // <- the line above printed the right reason
    return NULL;
}
```

A full filesystem, a name that is too long and a request to create the root all reached user space as "no such file or directory".

**The two halves had to be fixed together to be observable.** Setting correct errnos in `ext2_creat` changes nothing while `vfs_creat` replaces them; keeping `vfs_creat`'s value changes nothing while `ext2_creat` leaves it unset. That is why this PR touches both, and why #289 item 1 is closed here rather than on its own.

## The leaks

Each failure also kept what it had already allocated. The inode is taken from the bitmap before anything points at it, and the name is placed on disk before the VFS file exists, so a failure in between left either:

- an inode marked used with no name pointing at it — invisible, unreclaimable, and it is what #305 reports; or
- **a file present on disk while `creat` told the caller it had failed**, if `vfs_alloc_file` or `ext2_init_vfs_file` failed after the entry was placed.

The function now unwinds in the reverse order of acquisition:

1. the entry comes out of the parent first, so no name is ever left pointing at a free inode;
2. the inode is re-read and freed — re-read because cleaning its content may have given it blocks that have to go back too;
3. the VFS file is released only when it is one we allocated and never handed to anybody.

## The parent reference (#323)

`vfs_open` takes a reference and only the failure path gave it back, so every successful `creat` left the parent directory with a count one higher than it should have, permanently. Nothing frees a `vfs_file` while its count is above zero, so the parent could never be released and anything waiting for that count to reach zero was waiting for something impossible. Both success paths now close it.

## Two errnos worth naming

- A path that is its own parent directory is the root, and `dirname("/")` is the only case that satisfies it. Creating the root is a request to create a directory: **EISDIR**, which is what POSIX asks for.
- A path whose `dirname` does not fit now reports **ENAMETOOLONG** instead of nothing.

## A note on the split

`__ext2_clear_direntry_for_path` is no longer `static` and is declared in `ext2_internal.h`, because the rollback needs it and it lives in `ext2_namei.c`. This is the first real use of the private header #318 created, and the reason the rollback could reuse the helper `ext2_mkdir` already had instead of growing a second copy of it.

## Evidence

`t_creat_errno` checks the failures that need no particular state of the filesystem, plus a success case that writes the file and reads it back — to prove the new rollback does not fire on the way out of a success.

Negative control, with only the two kernel hunks reverted and the test left in place:

```
not ok  6 - t_creat_errno: Exit: 1
[t_creat_errno] creating / (the root directory) reported errno 2: No such file or directory
[t_creat_errno] the expected errno was 21: Is a directory
```

One thing that first negative control taught me: the test originally printed both errnos with `strerror` in a single message, and `strerror` returns a single `static char error[1024]`, so both showed the same string and the failure read as though the test had compared a value with itself. The message is now one `strerror` per line. It was the only place in the tree calling it twice in one statement.

The rollback of the inode itself needs a filesystem with no room left, which is `t_nospace`'s job; that test is registered but kept out of the default list because its fill costs about two minutes.

## Verification

- Debug build, `-Wall -Werror`: clean.
- Full suite with a freshly built `rootfs.img`: **64 tests, 0 failures, 0 panics**.
- `clang-format` clean, `git diff --check` clean.