### PR TITLE
refactor(ext2): give every exported symbol of the driver an ext2_ prefix

### DIFF
--- a/docs/maintainer/ext2.md
+++ b/docs/maintainer/ext2.md
@@ -84,7 +84,7 @@ for a new issue on recurrence → #192.
 ## Open path and the per-inode file cache
 
 `ext2_open` (ext2_file.c @`MAIN`):
-- `get_ext2_filesystem(path)` → `ext2_resolve_path(fs->root, path, &search)`.
+- `ext2_get_filesystem(path)` → `ext2_resolve_path(fs->root, path, &search)`.
 - O_CREAT → `ext2_creat`; O_DIRECTORY/O_EXCL validation; inode read;
   `vfs_valid_open_permissions` (root/pid-0 bypass; owner/group/other bits);
   O_TRUNC on regular files → `ext2_clean_inode_content`.

--- a/kernel/src/fs/ext2/ext2_attr.c
+++ b/kernel/src/fs/ext2/ext2_attr.c
@@ -74,7 +74,7 @@ int ext2_stat(const char *path, stat_t *stat)
 {
     pr_debug("ext2_stat(path: %s)\n", path);
     // Get the EXT2 filesystem.
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (fs == NULL) {
         pr_err("ext2_stat(path: %s): Failed to get the EXT2 filesystem.\n", path);
         return -ENOENT;
@@ -98,7 +98,7 @@ int ext2_stat(const char *path, stat_t *stat)
 
 int ext2_statfs(const char *path, statfs_t *statfs)
 {
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (fs == NULL) {
         pr_err("ext2_statfs(path: %s): Failed to get the EXT2 filesystem.\n", path);
         return -ENOENT;
@@ -193,7 +193,7 @@ int ext2_setattr(const char *path, struct iattr *attr)
 {
     pr_debug("ext2_setattr(file: %s)\n", path);
     // Get the EXT2 filesystem.
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (fs == NULL) {
         pr_err(
             "setattr(%s): Failed to get the EXT2 filesystem for absolute path "

--- a/kernel/src/fs/ext2/ext2_dir.c
+++ b/kernel/src/fs/ext2/ext2_dir.c
@@ -590,7 +590,7 @@ int ext2_find_direntry(ext2_filesystem_t *fs, ino_t ino, const char *name, ext2_
     }
 
     // Check that we are allowed to reach through the directory
-    if (!__valid_x_permission(scheduler_get_current_process(), &inode)) {
+    if (!ext2_valid_x_permission(scheduler_get_current_process(), &inode)) {
         pr_err(
             "The parent inode has no x permission (ino: %d, mode: %d, name: "
             "%s).\n",

--- a/kernel/src/fs/ext2/ext2_file.c
+++ b/kernel/src/fs/ext2/ext2_file.c
@@ -98,7 +98,7 @@ vfs_file_t *ext2_creat(const char *path, mode_t mode)
             // The list of open files is keyed by inode number, and the entry
             // may describe a file that was deleted while its number got
             // reused: refresh it from the inode we just read (#297).
-            __ext2_set_vfs_file_properties(
+            ext2_set_vfs_file_properties(
                 fs, file, &inode, search.direntry.inode, search.direntry.name, search.direntry.name_len);
         }
         result = file;
@@ -158,7 +158,7 @@ done:
 rollback:
     // Take the name out of the parent before the inode goes away, so that no
     // entry is left pointing at a free inode.
-    if (has_direntry && (__ext2_clear_direntry_for_path(fs, path) < 0)) {
+    if (has_direntry && (ext2_clear_direntry_for_path(fs, path) < 0)) {
         pr_err("ext2_creat(path: %s): Failed to remove the incomplete directory entry.\n", path);
     }
     // Give the inode back. Re-read it, because cleaning its content may have
@@ -197,7 +197,7 @@ vfs_file_t *ext2_open(const char *path, int flags, mode_t mode)
 {
     pr_debug("ext2_open(path: '%s', flags: %d, mode: %d)\n", path, flags, mode);
     // Get the EXT2 filesystem.
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (fs == NULL) {
         pr_err(
             "ext2_open(path: '%s', flags: %d, mode: %d): Failed to get the "
@@ -276,7 +276,7 @@ vfs_file_t *ext2_open(const char *path, int flags, mode_t mode)
         // The list of open files is keyed by inode number, and the entry may
         // describe a file that was deleted while its number got reused:
         // refresh it from the inode we just read (#297).
-        __ext2_set_vfs_file_properties(
+        ext2_set_vfs_file_properties(
             fs, file, &inode, search.direntry.inode, search.direntry.name, search.direntry.name_len);
     }
     if (file == NULL) {
@@ -541,7 +541,7 @@ ssize_t ext2_readlink(const char *path, char *buffer, size_t bufsize)
     pr_debug("ext2_readlink(path: %s)\n", path);
 
     // Get the EXT2 filesystem associated with the given path
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (!fs) {
         pr_err("ext2_readlink(path: %s): Failed to get the EXT2 filesystem.\n", path);
         return -ENOENT;

--- a/kernel/src/fs/ext2/ext2_internal.h
+++ b/kernel/src/fs/ext2/ext2_internal.h
@@ -529,12 +529,12 @@ int ext2_destroy_direntry(ext2_filesystem_t *fs, ext2_inode_t parent, ext2_inode
 int ext2_find_direntry(ext2_filesystem_t *fs, ino_t ino, const char *name, ext2_direntry_search_t *search);
 
 // Defined in ext2_namei.c.
-int __ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path);
-int __valid_x_permission(task_struct *task, ext2_inode_t *inode);
+int ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path);
+int ext2_valid_x_permission(task_struct *task, ext2_inode_t *inode);
 int ext2_file_type_to_vfs_file_type(int ext2_type);
 int ext2_resolve_path(vfs_file_t *directory, const char *path, ext2_direntry_search_t *search);
-ext2_filesystem_t *get_ext2_filesystem(const char *absolute_path);
-void __ext2_set_vfs_file_properties(ext2_filesystem_t *fs, vfs_file_t *file, ext2_inode_t *inode, uint32_t inode_index, const char *name, size_t name_len);
+ext2_filesystem_t *ext2_get_filesystem(const char *absolute_path);
+void ext2_set_vfs_file_properties(ext2_filesystem_t *fs, vfs_file_t *file, ext2_inode_t *inode, uint32_t inode_index, const char *name, size_t name_len);
 int ext2_init_vfs_file(ext2_filesystem_t *fs, vfs_file_t *file, ext2_inode_t *inode, uint32_t inode_index, const char *name, size_t name_len);
 vfs_file_t *ext2_find_vfs_file_with_inode(ext2_filesystem_t *fs, ino_t inode);
 int ext2_create_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, mode_t mode, uint32_t preferred_group);

--- a/kernel/src/fs/ext2/ext2_namei.c
+++ b/kernel/src/fs/ext2/ext2_namei.c
@@ -44,7 +44,7 @@ int ext2_file_type_to_vfs_file_type(int ext2_type)
 /// @param task the task to check permission for.
 /// @param inode the inode to check permission.
 /// @return 1 on success, 0 otherwise.
-int __valid_x_permission(task_struct *task, ext2_inode_t *inode)
+int ext2_valid_x_permission(task_struct *task, ext2_inode_t *inode)
 {
     // Init, and all root processes always have permission
     if (!task || (task->pid == 0) || (task->uid == 0)) {
@@ -120,7 +120,7 @@ int ext2_resolve_path(vfs_file_t *directory, const char *path, ext2_direntry_sea
 /// @brief Get the ext2 filesystem object starting from a path.
 /// @param absolute_path the absolute path for which we want to find the associated EXT2 filesystem.
 /// @return a pointer to the EXT2 filesystem, NULL otherwise.
-ext2_filesystem_t *get_ext2_filesystem(const char *absolute_path)
+ext2_filesystem_t *ext2_get_filesystem(const char *absolute_path)
 {
     if (absolute_path == NULL) {
         pr_err("We received a NULL absolute path.\n");
@@ -176,7 +176,7 @@ ext2_filesystem_t *get_ext2_filesystem(const char *absolute_path)
 ///          be reused by an unrelated file, whose name and permissions would
 ///          otherwise be those of the file that held the number before it
 ///          (#297).
-void __ext2_set_vfs_file_properties(
+void ext2_set_vfs_file_properties(
     ext2_filesystem_t *fs,
     vfs_file_t *file,
     ext2_inode_t *inode,
@@ -247,7 +247,7 @@ int ext2_init_vfs_file(
     size_t name_len)
 {
     // Set everything that comes from the inode.
-    __ext2_set_vfs_file_properties(fs, file, inode, inode_index, name, name_len);
+    ext2_set_vfs_file_properties(fs, file, inode, inode_index, name, name_len);
     //uint32_t impl;
     //uint32_t open_flags;
     // Set the open count.
@@ -373,7 +373,7 @@ int ext2_unlink(const char *path)
         return -ENOENT;
     }
     // Get the EXT2 filesystem.
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (fs == NULL) {
         pr_err("ext2_unlink(%s): Failed to get the EXT2 filesystem.\n", path);
         return -ENOENT;
@@ -457,7 +457,7 @@ early_exit:
 /// @details Used when mkdir cannot finish: the entry it added to the parent
 ///          must go away before the inode is freed, otherwise the parent
 ///          keeps a name pointing at a free inode (#264).
-int __ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path)
+int ext2_clear_direntry_for_path(ext2_filesystem_t *fs, const char *path)
 {
     ext2_direntry_search_t search;
     memset(&search, 0, sizeof(ext2_direntry_search_t));
@@ -510,7 +510,7 @@ int ext2_mkdir(const char *path, mode_t mode)
         return -ENOENT;
     }
     // Get the EXT2 filesystem.
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (fs == NULL) {
         pr_err("ext2_mkdir(path: %s): Failed to get the EXT2 filesystem.\n", path);
         return -ENODEV;
@@ -613,7 +613,7 @@ rollback:
     }
     // Take the name out of the parent before the inode goes away, so no entry
     // is left pointing at a free inode.
-    if (has_direntry && (__ext2_clear_direntry_for_path(fs, path) < 0)) {
+    if (has_direntry && (ext2_clear_direntry_for_path(fs, path) < 0)) {
         pr_err("ext2_mkdir(path: %s): Failed to remove the incomplete directory entry.\n", path);
     }
     // Re-read the inode: initializing its entry block may have given it a
@@ -652,7 +652,7 @@ int ext2_rmdir(const char *path)
         return -ENOENT;
     }
     // Get the EXT2 filesystem.
-    ext2_filesystem_t *fs = get_ext2_filesystem(path);
+    ext2_filesystem_t *fs = ext2_get_filesystem(path);
     if (fs == NULL) {
         pr_err("ext2_rmdir(path: %s): Failed to get the EXT2 filesystem.\n", path);
         return -ENOENT;


### PR DESCRIPTION
Fixes #319

## What the issue asked

Rename `__valid_x_permission` and `get_ext2_filesystem`, and check the rest of the newly exported set for the same problem while there.

## The two names the issue reported

```
__valid_x_permission  ->  ext2_valid_x_permission
get_ext2_filesystem   ->  ext2_get_filesystem
```

## What the audit of the rest of the set turned up

The module exports 64 symbols. After the two renames above, two were still not `ext2_`-prefixed:

```
__ext2_clear_direntry_for_path
__ext2_set_vfs_file_properties
```

These are namespaced, so they carry none of the collision risk that motivated the issue, and a `__` prefix on an external symbol is not unique to ext2 — the kernel has nine others (`__assert_fail`, `__geterrno`, `__resolve_path`, `__send_sig_info`, `__vfs_find_filesystem`, `__dump_runqueue`, `__sem_id`, `__shm_id`). On that evidence alone, renaming them would be a style change against a live convention.

What decided it is the convention *inside this module*, which is narrower and consistent: `__` means static. Six `__ext2_*` names remain in `kernel/src/fs/ext2/`, and every one of them is a static function; these two were the only ones with external linkage, both because of the split and #324. The prefix was describing a scope they no longer have, which is the same defect the issue reports — a name that lies about the symbol — pointing the other way. So they are renamed too:

```
__ext2_clear_direntry_for_path  ->  ext2_clear_direntry_for_path
__ext2_set_vfs_file_properties  ->  ext2_set_vfs_file_properties
```

The exported set is now 64 symbols, all `ext2_`-prefixed, with nothing added or removed:

```
$ nm --defined-only -g build/kernel/CMakeFiles/kernel.dir/src/fs/ext2/*.o \
    | awk '$2=="T"||$2=="D"||$2=="B"{print $3}' | sort -u | grep -cv '^ext2_'
0
```

Nothing in the build enforces this, and I did not add a lint step for it — that is a separate decision from the rename, and worth making on its own terms rather than smuggling in here.

## This is a rename and nothing else

Undoing the four substitutions with `sed` reproduces every touched file byte for byte against the parent commit. That is a mechanical proof there is no other edit hidden in the diff, `clang-format` collateral included — the check was run *after* formatting, and it came back empty.

`docs/maintainer/ext2.md` mentions `get_ext2_filesystem` in the description of the open path, so it is updated with it.

## Verification

A rename carries no new test: `-Wall -Werror` plus the link step are the regression check, because an incomplete rename either fails to compile or fails to link, and a partial one cannot pass both. The existing suite is what proves behaviour is untouched.

- Debug builds clean.
- `-DENABLE_EXT2_TRACE=ON` builds clean too. It is the module's only conditional variant and the trace counter is a shared symbol since the split, so it is the one configuration a symbol change could break without the default build noticing.
- Full suite on the finished tree: **64 tests, 0 failures, 0 panics**, the same as `develop`.

No negative control applies here. There is no defect to reproduce: the issue records that nothing collides today and that the kernel links, so this is a namespace change, not a bug fix. Manufacturing a failing run would misrepresent what was verified.