### PR TITLE
fix(ext2): make a truncating open leave the file empty and give its blocks back

### DIFF
--- a/kernel/src/fs/ext2/ext2_alloc.c
+++ b/kernel/src/fs/ext2/ext2_alloc.c
@@ -278,11 +278,6 @@ void ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index)
     }
 }
 
-/// @brief Frees the given inode.
-/// @param fs a pointer to the filesystem.
-/// @param inode the inode we free.
-/// @param inode_index its index.
-/// @return 0 on success, otherwise it is a failure.
 /// @brief Frees the blocks that hold the block pointers of an inode.
 /// @param fs the filesystem.
 /// @param inode the inode whose index blocks are freed.
@@ -345,22 +340,22 @@ static void __ext2_free_index_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
     ext2_dealloc_cache(inner);
 }
 
-int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index)
+/// @brief Frees every block that belongs to an inode, data and index alike.
+/// @param fs a pointer to the filesystem.
+/// @param inode the inode whose blocks are released.
+/// @details The block pointers and the sector count are cleared, so the inode
+///          is left describing a file with no blocks at all. `size` is the
+///          caller's: releasing the blocks of a file and declaring it empty
+///          are two different things, and only truncation does both.
+void ext2_free_inode_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
 {
-    // Retrieve the group index.
-    uint32_t group_index  = ext2_inode_index_to_group_index(fs, inode_index);
-    // Get the index of the inode inside the group.
-    uint32_t group_offset = ext2_inode_index_to_group_offset(fs, inode_index);
-    // Get the block bitmap index.
-    uint32_t inode_bitmap = fs->block_groups[group_index].inode_bitmap;
-    // Get the number of blocks we need to free.
+    // How many blocks the size says the file holds. Sparse files legally
+    // contain holes, so a null pointer inside that range is skipped rather
+    // than treated as the end.
     uint32_t block_number = (inode->size / fs->block_size) + ((inode->size % fs->block_size) != 0);
 
-    // Log the allocation of the inode.
-    pr_debug(
-        "ext2_free_inode(group: %4u, inode_index: %4u, group_offset: %4u)\n", group_index, inode_index, group_offset);
-
-    // Free its blocks.
+    // Free the data blocks first: they are reached through the index blocks,
+    // which the next step releases.
     for (uint32_t block_index = 0; block_index < block_number; ++block_index) {
         // Get the real index.
         uint32_t real_index = ext2_get_real_block_index(fs, inode, block_index);
@@ -370,8 +365,39 @@ int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_i
         ext2_free_block(fs, real_index);
     }
 
-    // Free the blocks that held the pointers to those data blocks.
+    // Free the blocks that held the pointers to those data blocks (#302).
     __ext2_free_index_blocks(fs, inode);
+
+    // Nothing points anywhere any more, and the inode owns no sector. The
+    // write path derives the blocks it still has to allocate from
+    // `blocks_count`, so leaving it set would make it skip allocating the
+    // blocks it just gave back.
+    for (uint32_t index = 0; index < EXT2_DIRECT_BLOCKS; ++index) {
+        inode->data.blocks.dir_blocks[index] = 0;
+    }
+    inode->blocks_count = 0;
+}
+
+/// @brief Frees the given inode.
+/// @param fs a pointer to the filesystem.
+/// @param inode the inode we free.
+/// @param inode_index its index.
+/// @return 0 on success, otherwise it is a failure.
+int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index)
+{
+    // Retrieve the group index.
+    uint32_t group_index  = ext2_inode_index_to_group_index(fs, inode_index);
+    // Get the index of the inode inside the group.
+    uint32_t group_offset = ext2_inode_index_to_group_offset(fs, inode_index);
+    // Get the block bitmap index.
+    uint32_t inode_bitmap = fs->block_groups[group_index].inode_bitmap;
+
+    // Log the allocation of the inode.
+    pr_debug(
+        "ext2_free_inode(group: %4u, inode_index: %4u, group_offset: %4u)\n", group_index, inode_index, group_offset);
+
+    // Give back every block the inode owns, data and index alike.
+    ext2_free_inode_blocks(fs, inode);
 
     // Allocate the cache.
     uint8_t *cache = ext2_alloc_cache(fs);

--- a/kernel/src/fs/ext2/ext2_blockmap.c
+++ b/kernel/src/fs/ext2/ext2_blockmap.c
@@ -707,3 +707,46 @@ int ext2_clean_inode_content(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_
     ext2_dealloc_cache(cache);
     return ret;
 }
+
+/// @brief Discards the whole content of a regular file.
+/// @param fs a pointer to the filesystem.
+/// @param inode the inode to truncate.
+/// @param inode_index the inode index.
+/// @return 0 on success, a negative errno on failure.
+/// @details This is what `O_TRUNC` has to do: the file is left with length 0
+///          and its blocks go back to the filesystem. Overwriting the content
+///          with zeroes and keeping the length was not enough — `stat` kept
+///          reporting the old size, reading returned that many zero bytes
+///          instead of end-of-file, and the space was never released (#320).
+int ext2_truncate_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index)
+{
+    pr_debug("ext2_truncate_inode(inode_index: %u, size: %u)\n", inode_index, inode->size);
+    // Only the content of a regular file can be discarded this way. A
+    // directory holds the entries its parent and children depend on, and
+    // there is no size to speak of for the other types.
+    if ((inode->mode & S_IFREG) != S_IFREG) {
+        pr_err("Trying to truncate inode %u, which is not a regular file.\n", inode_index);
+        return -EINVAL;
+    }
+    // Nothing to give back, and nothing to write: an inode that is already
+    // empty must not have its timestamps touched by a truncation that does
+    // not change it.
+    if (inode->size == 0) {
+        return 0;
+    }
+    // Release the blocks before the size stops naming them: the loop that
+    // frees the data derives its bound from `size`, so clearing the size
+    // first would leak every block of the file.
+    ext2_free_inode_blocks(fs, inode);
+    inode->size  = 0;
+    inode->ctime = sys_time(NULL);
+    inode->mtime = inode->ctime;
+    // The inode on the device still describes the old file until this
+    // succeeds, and the blocks are already back in the bitmap, so a failure
+    // here leaves the two disagreeing and has to be reported.
+    if (ext2_write_inode(fs, inode, inode_index) == -1) {
+        pr_err("Failed to write inode %u after truncating it.\n", inode_index);
+        return -EIO;
+    }
+    return 0;
+}

--- a/kernel/src/fs/ext2/ext2_file.c
+++ b/kernel/src/fs/ext2/ext2_file.c
@@ -258,15 +258,18 @@ vfs_file_t *ext2_open(const char *path, int flags, mode_t mode)
         return NULL;
     }
 
-    // Check if the file is a regular file, and the user wants to write and truncate.
-    if (bitmask_exact(inode.mode, S_IFREG) &&
-        (bitmask_exact(flags, O_RDWR | O_TRUNC) || bitmask_exact(flags, O_RDONLY | O_TRUNC))) {
-        // Clean the content of the newly created file.
-        if (ext2_clean_inode_content(fs, &inode, search.direntry.inode) < 0) {
+    // Any truncating open of a regular file has to leave it empty. There is
+    // one flag to test: the condition used to read as "read-write or
+    // read-only truncating opens", and meant "any open with O_TRUNC", because
+    // `bitmask_exact(V, M)` is `((V) & (M)) == (M)` and `O_RDONLY` is 0. The
+    // behaviour that fell out of it was the right one, but by accident (#320).
+    if (bitmask_exact(inode.mode, S_IFREG) && bitmask_check(flags, O_TRUNC)) {
+        if (ext2_truncate_inode(fs, &inode, search.direntry.inode) < 0) {
             pr_err(
-                "ext2_open(path: '%s', flags: %d, mode: %d): Failed to clean "
-                "the content of the newly created inode.\n",
+                "ext2_open(path: '%s', flags: %d, mode: %d): Failed to "
+                "truncate the file.\n",
                 path, flags, mode);
+            errno = EIO;
             return NULL;
         }
     }

--- a/kernel/src/fs/ext2/ext2_internal.h
+++ b/kernel/src/fs/ext2/ext2_internal.h
@@ -509,6 +509,7 @@ int ext2_allocate_inode(ext2_filesystem_t *fs, unsigned preferred_group);
 uint32_t ext2_allocate_block(ext2_filesystem_t *fs);
 void ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index);
 int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index);
+void ext2_free_inode_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode);
 
 // Defined in ext2_blockmap.c.
 uint32_t ext2_get_real_block_index(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t block_index);
@@ -518,6 +519,7 @@ ssize_t ext2_write_inode_block(ext2_filesystem_t *fs, ext2_inode_t *inode, uint3
 ssize_t ext2_read_inode_data(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index, off_t offset, size_t nbyte, char *buffer);
 ssize_t ext2_write_inode_data(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index, off_t offset, size_t nbyte, char *buffer);
 int ext2_clean_inode_content(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index);
+int ext2_truncate_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index);
 
 // Defined in ext2_dir.c.
 int ext2_direntry_iterator_valid(ext2_direntry_iterator_t *it);

--- a/userspace/tests/t_trunc_content.c
+++ b/userspace/tests/t_trunc_content.c
@@ -1,8 +1,10 @@
 /// @file t_trunc_content.c
-/// @brief Regression test for #315: truncating a file larger than one block
-/// must not write anything but zeroes, and must not make the file grow.
-/// @details ext2_clean_inode_content walked the file one block at a time with
-/// a one-block buffer, but computed the length of each write as
+/// @brief Regression test for #315 and #320: a truncating open must leave the
+/// file empty, and must give its blocks back.
+/// @details Two defects met on this path.
+///
+/// #315: ext2_clean_inode_content walked the file one block at a time with a
+/// one-block buffer, but computed the length of each write as
 /// `max(min(offset + cache_size, inode->size), 0)`, which is the offset of the
 /// end of the window rather than its length. The first iteration was right by
 /// accident, since its offset is 0; from the second on it asked
@@ -10,14 +12,21 @@
 /// copied whatever followed the one-block slab object into the file, and the
 /// last iteration wrote past the end of the file and grew it.
 ///
-/// The file therefore has to be larger than one block for the defect to show:
-/// t_write_read already truncates a file, but a 6-byte one, so its single
-/// iteration never leaves the range where the arithmetic happens to work.
+/// #320: nothing set the size to zero. The content was overwritten with
+/// zeroes and the length stayed whatever it was, so `stat` kept reporting the
+/// old size, reading returned that many zero bytes instead of end-of-file,
+/// and the blocks stayed allocated and attributed to the file.
 ///
-/// Both consequences are checked. The growth is the deterministic one and does
-/// not depend on what the kernel heap happens to hold; the non-zero bytes are
-/// the reason the defect matters, because they are kernel memory that a
-/// program can read back.
+/// The file therefore has to be larger than one block for either defect to
+/// show: t_write_read already truncates a file, but a 6-byte one, so its
+/// single iteration never leaves the range where the #315 arithmetic happens
+/// to work, and one block is too little to see space come back.
+///
+/// The file is created empty before the measurement starts, so that the
+/// directory entry already exists and a block the directory needs to grow
+/// cannot be counted against the file. Four blocks keeps it inside the twelve
+/// direct pointers of the inode, so no index block is involved either and the
+/// expected counts are exact.
 /// @copyright (c) 2014-2026 This file is distributed under the MIT License.
 /// See LICENSE.md for details.
 
@@ -28,6 +37,7 @@
 #include <strerror.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
 #include <syslog.h>
 #include <unistd.h>
 
@@ -41,17 +51,34 @@
 /// runs four times and the last one lands past the end of the file.
 #define FILE_SIZE ((3 * BLOCK_SIZE) + 100)
 
+/// How many blocks FILE_SIZE occupies: three whole ones and the remainder.
+#define FILE_BLOCKS 4
+
 /// Byte written everywhere, so that anything left over is visible.
 #define FILLER 0xAB
 
 /// Buffer used for writing and for reading back, one block at a time.
 static char buffer[BLOCK_SIZE];
 
-/// @brief Creates the file and fills it with FILLER.
+/// @brief Creates the file, empty, so the directory entry exists before the
+///        measurement starts.
 /// @return 0 on success, -1 on failure.
-static int __create_and_fill(void)
+static int __create_empty(void)
 {
     int fd = open(PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_trunc_content] open for creating: %s", strerror(errno));
+        return -1;
+    }
+    close(fd);
+    return 0;
+}
+
+/// @brief Fills the file with FILLER.
+/// @return 0 on success, -1 on failure.
+static int __fill(void)
+{
+    int fd = open(PATH, O_WRONLY, 0);
     if (fd < 0) {
         syslog(LOG_ERR, "[t_trunc_content] open for filling: %s", strerror(errno));
         return -1;
@@ -85,31 +112,46 @@ static int __size_of(unsigned *size)
     return 0;
 }
 
-/// @brief Counts the bytes of the file that are not zero.
-/// @param nonzero where the count is stored.
+/// @brief Reads the number of free blocks of the filesystem.
+/// @param blocks where the count is stored.
+/// @return 0 on success, -1 on failure.
+static int __free_blocks(unsigned long *blocks)
+{
+    statfs_t buf;
+    if (statfs("/home/user", &buf) < 0) {
+        syslog(LOG_ERR, "[t_trunc_content] statfs: %s", strerror(errno));
+        return -1;
+    }
+    *blocks = (unsigned long)buf.f_bfree;
+    return 0;
+}
+
+/// @brief Reads the whole file, counting what it holds.
+/// @param total where the number of bytes read before end-of-file is stored.
+/// @param nonzero where the count of bytes that are not zero is stored.
 /// @param first where the offset of the first non-zero byte is stored.
 /// @return 0 on success, -1 on failure.
-static int __count_nonzero(unsigned *nonzero, unsigned *first)
+static int __read_all(unsigned *total, unsigned *nonzero, unsigned *first)
 {
     int fd = open(PATH, O_RDONLY, 0);
     if (fd < 0) {
         syslog(LOG_ERR, "[t_trunc_content] open for reading: %s", strerror(errno));
         return -1;
     }
-    *nonzero      = 0;
-    *first        = 0;
-    unsigned seen = 0;
+    *total   = 0;
+    *nonzero = 0;
+    *first   = 0;
     ssize_t bytes;
     while ((bytes = read(fd, buffer, sizeof(buffer))) > 0) {
         for (ssize_t i = 0; i < bytes; ++i) {
             if (buffer[i] != 0) {
                 if (*nonzero == 0) {
-                    *first = seen + (unsigned)i;
+                    *first = *total + (unsigned)i;
                 }
                 ++(*nonzero);
             }
         }
-        seen += (unsigned)bytes;
+        *total += (unsigned)bytes;
     }
     close(fd);
     if (bytes < 0) {
@@ -121,21 +163,36 @@ static int __count_nonzero(unsigned *nonzero, unsigned *first)
 
 int main(void)
 {
-    unsigned before  = 0;
-    unsigned after   = 0;
-    unsigned nonzero = 0;
-    unsigned first   = 0;
-    int failures     = 0;
+    unsigned long free_empty  = 0;
+    unsigned long free_filled = 0;
+    unsigned long free_after  = 0;
+    unsigned size             = 0;
+    unsigned total            = 0;
+    unsigned nonzero          = 0;
+    unsigned first            = 0;
+    int failures              = 0;
 
-    if (__create_and_fill() < 0) {
-        return EXIT_FAILURE;
-    }
-    if (__size_of(&before) < 0) {
+    if ((__create_empty() < 0) || (__free_blocks(&free_empty) < 0) || (__fill() < 0) ||
+        (__free_blocks(&free_filled) < 0)) {
         unlink(PATH);
         return EXIT_FAILURE;
     }
-    if (before != FILE_SIZE) {
-        syslog(LOG_ERR, "[t_trunc_content] the file is %u bytes, expected %u", before, (unsigned)FILE_SIZE);
+
+    // The starting state has to be the one the test assumes, otherwise every
+    // check below can pass without meaning anything.
+    if (__size_of(&size) < 0) {
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+    if (size != FILE_SIZE) {
+        syslog(LOG_ERR, "[t_trunc_content] the filled file is %u bytes, expected %u", size, (unsigned)FILE_SIZE);
+        unlink(PATH);
+        return EXIT_FAILURE;
+    }
+    if ((free_empty - free_filled) != FILE_BLOCKS) {
+        syslog(
+            LOG_ERR, "[t_trunc_content] filling the file took %lu blocks, expected %u", free_empty - free_filled,
+            (unsigned)FILE_BLOCKS);
         unlink(PATH);
         return EXIT_FAILURE;
     }
@@ -150,30 +207,48 @@ int main(void)
     }
     close(fd);
 
-    // Truncating a file cannot make it longer. #320 tracks the fact that it
-    // does not shorten it either, which is why this is not an equality.
-    if (__size_of(&after) < 0) {
+    // A truncating open leaves the file with no content at all.
+    if (__size_of(&size) < 0) {
         ++failures;
-    } else if (after > before) {
-        syslog(LOG_ERR, "[t_trunc_content] truncating grew the file from %u bytes to %u", before, after);
+    } else if (size != 0) {
+        syslog(LOG_ERR, "[t_trunc_content] the truncated file is %u bytes, expected 0", size);
         ++failures;
     }
 
-    // Whatever length is left, none of it may be anything but zero: a non-zero
-    // byte here came from kernel memory past the one-block buffer.
-    if (__count_nonzero(&nonzero, &first) < 0) {
+    // Reading it therefore reports end-of-file straight away, and nothing it
+    // returns may be anything but zero: a non-zero byte here came from kernel
+    // memory past the one-block buffer.
+    if (__read_all(&total, &nonzero, &first) < 0) {
         ++failures;
-    } else if (nonzero != 0) {
+    } else {
+        if (total != 0) {
+            syslog(LOG_ERR, "[t_trunc_content] reading the truncated file returned %u bytes, expected 0", total);
+            ++failures;
+        }
+        if (nonzero != 0) {
+            syslog(
+                LOG_ERR, "[t_trunc_content] %u bytes of the truncated file are not zero, the first at offset %u",
+                nonzero, first);
+            ++failures;
+        }
+    }
+
+    // And the space it held goes back to the filesystem.
+    if (__free_blocks(&free_after) < 0) {
+        ++failures;
+    } else if (free_after != free_empty) {
         syslog(
-            LOG_ERR, "[t_trunc_content] %u bytes of the truncated file are not zero, the first at offset %u", nonzero,
-            first);
+            LOG_ERR, "[t_trunc_content] truncating gave back %lu of the %u blocks the file held",
+            free_after - free_filled, (unsigned)FILE_BLOCKS);
         ++failures;
     }
 
     unlink(PATH);
 
     if (failures == 0) {
-        syslog(LOG_INFO, "[t_trunc_content] truncating %u bytes left only zeroes and did not grow the file", before);
+        syslog(
+            LOG_INFO, "[t_trunc_content] truncating %u bytes left an empty file and returned %u blocks",
+            (unsigned)FILE_SIZE, (unsigned)FILE_BLOCKS);
         return EXIT_SUCCESS;
     }
     syslog(LOG_ERR, "[t_trunc_content] %d FAILURES", failures);


### PR DESCRIPTION
Fixes #320

## The defect

`ext2_open` handled `O_TRUNC` by calling `ext2_clean_inode_content`, which overwrites the bytes with zeroes and never touches `inode->size`. Nothing anywhere set the size to zero, so all three consequences the issue lists were visible to a program.

## Reproduction

`t_trunc_content` already existed for #315 and already noted what it was leaving for this issue: *"Truncating a file cannot make it longer. #320 tracks the fact that it does not shorten it either, which is why this is not an equality."* Tightening that inequality is the reproduction, and this is the run on the unfixed tree, before any kernel change in this branch:

```
not ok 22 - t_trunc_content: Exit: 1
[t_trunc_content] the truncated file is 12388 bytes, expected 0
[t_trunc_content] reading the truncated file returned 12388 bytes, expected 0
[t_trunc_content] truncating gave back 0 of the 4 blocks the file held
[t_trunc_content] 3 FAILURES
```

One failure per consequence in the issue, and it was the only failing test in the suite. **That run is the negative control** — the test was written before the fix, so staging a revert afterwards would add nothing.

The test now checks:

- the size equals 0;
- reading reports end-of-file straight away, and nothing it returns is non-zero (the #315 check, kept);
- the free block count returns to what it was before the file was filled.

Ahead of those there is a gate asserting that filling the file took **exactly four blocks**, so the block-release check cannot pass by a write that allocated nothing. The file is created empty before the first measurement, so a block the directory needs to grow cannot be counted against it, and four blocks stays inside the twelve direct pointers, so no index block is involved and the counts are exact.

## The fix

`ext2_truncate_inode` in `ext2_blockmap.c`, which is where the split put truncation:

- releases every block the inode owns, then sets the size to 0, stamps ctime and mtime, and writes the inode back;
- **frees the blocks before clearing the size**, because the loop that frees the data derives its bound from `size` — clearing it first would leak the entire file;
- clears `blocks_count` along with the pointers, because `ext2_write_inode_data` computes how much it still has to allocate from `blocks_count / blocks_per_block_count` and would otherwise skip re-allocating the blocks it just gave back;
- returns early on an inode that is already empty, so a truncation that changes nothing does not move the timestamps;
- returns `-EINVAL` for a non-regular file and `-EIO` if the inode cannot be written, and `ext2_open` now sets `errno` on that path, per the convention #324 established.

The block release already existed inside `ext2_free_inode`, so it is lifted out as `ext2_free_inode_blocks` and both callers share it. Deletion and truncation therefore release space through the same code, index blocks included — the ones #302 added.

## The condition that said one thing and did another

```c
bitmask_exact(flags, O_RDWR | O_TRUNC) || bitmask_exact(flags, O_RDONLY | O_TRUNC)
```

`bitmask_exact(V, M)` is `((V) & (M)) == (M)` and `O_RDONLY` is `0`, so the second half reduces to "has the `O_TRUNC` bit" and subsumes the first entirely. It read as "read-write or read-only truncating opens" and meant "any open with `O_TRUNC`". The behaviour that fell out was the right one — every `O_TRUNC` should truncate, `O_WRONLY` included — but by accident. It is now `bitmask_check(flags, O_TRUNC)`, which is what it always did.

## Also in the diff

The doc comment above `__ext2_free_index_blocks` in `ext2_alloc.c` belonged to `ext2_free_inode` and was stranded there by the split, so Doxygen was attributing one function's documentation to another. Since the refactor moves both functions, it is back where it belongs. Flagging it because it is not part of the fix.

## Verification

- Full suite on the finished tree: **64 tests, 0 failures, 0 panics**.
- Same with `-DENABLE_SCHEDULER_FEEDBACK=ON`: **64 tests, 0 failures, 0 panics**. That option is off by default and turns on the kernel's own truncating open (`scheduler_feedback.c:136` uses `O_WRONLY | O_TRUNC | O_CREAT` on every call), so it is the one configuration where the kernel is itself a user of this path. It was not exercised by any earlier run.
- `-DENABLE_EXT2_TRACE=ON` builds clean.

## One consequence worth stating

With `O_TRUNC` no longer going through `ext2_clean_inode_content`, its only remaining caller is `ext2_creat`, which calls it right after `ext2_create_inode` — and `ext2_create_inode` sets `inode->size = 0`, so the loop body cannot run. The zero-fill code, and the `min()` clamp that #315/#321 put in it, are no longer reachable with anything to do. I have not removed them here: deleting the subject of a fixed bug is a separate decision from this one, and it is filed on its own so it can be judged on its own.