### PR TITLE
fix(ext2): bound the directory-entry name copies at the 255-character boundary

### DIFF
--- a/kernel/src/fs/ext2/ext2_dir.c
+++ b/kernel/src/fs/ext2/ext2_dir.c
@@ -124,13 +124,23 @@ static inline void ext2_initialize_direntry(
     uint32_t rec_len,
     uint8_t file_type)
 {
-    // Initialize the new directory entry.
+    // Initialize the new directory entry. The length is stored in a uint8_t,
+    // so a name of 256 characters or more would be recorded modulo 256 and
+    // the entry would describe a name nobody wrote: 300 characters would go
+    // on the disk as 44. The VFS rejects an over-long path component before
+    // this is reached, so the clamp is there to keep the invariant local
+    // rather than to catch a caller that exists (#285).
+    size_t name_len = strlen(name);
+    if (name_len > (EXT2_NAME_LEN - 1)) {
+        pr_warning("Directory entry name of %u characters truncated to %u.\n", (unsigned)name_len, EXT2_NAME_LEN - 1);
+        name_len = EXT2_NAME_LEN - 1;
+    }
     direntry->inode     = inode_index;
     direntry->rec_len   = rec_len;
-    direntry->name_len  = strlen(name);
+    direntry->name_len  = (uint8_t)name_len;
     direntry->file_type = file_type;
-    memset(direntry->name, 0, direntry->name_len + 1);
-    strncpy(direntry->name, name, direntry->name_len);
+    memset(direntry->name, 0, name_len + 1);
+    memcpy(direntry->name, name, name_len);
 }
 
 /// @brief Initializes a new directory entry block for the specified inode.
@@ -628,14 +638,29 @@ int ext2_find_direntry(ext2_filesystem_t *fs, ino_t ino, const char *name, ext2_
     // Copy the direntry.
     search->direntry.inode     = it.direntry->inode;
     search->direntry.rec_len   = it.direntry->rec_len;
-    search->direntry.name_len  = it.direntry->name_len;
     search->direntry.file_type = it.direntry->file_type;
-    strncpy(search->direntry.name, it.direntry->name, it.direntry->name_len);
-    search->direntry.name[it.direntry->name_len] = 0;
+    // The on-disk name_len is a uint8_t, so 255 is a legal value, while the
+    // destination is a NUL-terminated char[EXT2_NAME_LEN] with EXT2_NAME_LEN
+    // equal to 255. A name of exactly that length filled the array and put
+    // its terminator one byte past it, which happened to be the trailing
+    // padding of the search structure: the name was readable only because of
+    // a write that was out of bounds of the array (#285). Keep the terminator
+    // inside, and report the length that was actually stored, so that a
+    // caller comparing name_len against the string it can see agrees with it.
+    uint8_t copy_len           = it.direntry->name_len;
+    if (copy_len > (EXT2_NAME_LEN - 1)) {
+        pr_warning(
+            "Directory entry name of %u characters truncated to %u (inode %u).\n", it.direntry->name_len,
+            EXT2_NAME_LEN - 1, it.direntry->inode);
+        copy_len = EXT2_NAME_LEN - 1;
+    }
+    memcpy(search->direntry.name, it.direntry->name, copy_len);
+    search->direntry.name[copy_len] = 0;
+    search->direntry.name_len       = copy_len;
     // Copy the index of the block containing the direntry.
-    search->block_index                          = it.block_index;
+    search->block_index             = it.block_index;
     // Copy the offset of the direntry inside the block.
-    search->block_offset                         = it.block_offset;
+    search->block_offset            = it.block_offset;
     // Free the cache.
     ext2_dealloc_cache(cache);
     return 0;

--- a/kernel/src/fs/ext2/ext2_file.c
+++ b/kernel/src/fs/ext2/ext2_file.c
@@ -512,10 +512,21 @@ ssize_t ext2_getdents(vfs_file_t *file, dirent_t *dirp, off_t doff, size_t count
             continue;
         }
         // Write on current directory entry data.
-        dirp->d_ino  = it.direntry->inode;
-        dirp->d_type = ext2_file_type_to_vfs_file_type(it.direntry->file_type);
+        dirp->d_ino      = it.direntry->inode;
+        dirp->d_type     = ext2_file_type_to_vfs_file_type(it.direntry->file_type);
+        // d_name is a NUL-terminated char[NAME_MAX], and the on-disk
+        // name_len is a uint8_t that may legally hold 255: copying that many
+        // bytes filled the field and left no terminator, so the program
+        // reading the entry ran into the next record (#285).
+        uint8_t copy_len = it.direntry->name_len;
+        if (copy_len > (NAME_MAX - 1)) {
+            pr_warning(
+                "Directory entry name of %u characters truncated to %u (inode %u).\n", it.direntry->name_len,
+                NAME_MAX - 1, it.direntry->inode);
+            copy_len = NAME_MAX - 1;
+        }
         memset(dirp->d_name, 0, NAME_MAX);
-        strncpy(dirp->d_name, it.direntry->name, it.direntry->name_len);
+        memcpy(dirp->d_name, it.direntry->name, copy_len);
         dirp->d_off    = it.direntry->rec_len;
         dirp->d_reclen = it.direntry->rec_len;
         // Increment the amount written.

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -59,6 +59,7 @@ static char *all_tests[] = {
     "t_list",
     "t_mem",
     "t_mkdir",
+    "t_name_max",
     // Skipped on purpose: filling the image to make the allocation fail takes
     // about two minutes of guest time, too much for every CI run. Run it by
     // hand when touching the ext2 allocation paths (#264).

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TEST_LIST
     t_shm.c
     t_semget.c
     t_mkdir.c
+    t_name_max.c
     t_alarm.c
     t_exit.c
     t_environ.c

--- a/userspace/tests/t_name_max.c
+++ b/userspace/tests/t_name_max.c
@@ -1,0 +1,259 @@
+/// @file t_name_max.c
+/// @brief Regression test for #285: names at the 255-character boundary.
+/// @details Every name field in the kernel is a NUL-terminated `char[255]`:
+/// `vfs_file_t::name`, `dirent_t::d_name` and the `name` of the direntry the
+/// ext2 search fills in are all `NAME_MAX` bytes, and `EXT2_NAME_LEN` is 255
+/// as well. A name of exactly 255 characters therefore has no room for its
+/// terminator anywhere in the kernel, while the on-disk `uint8_t name_len`
+/// makes 255 a perfectly legal value to store.
+///
+/// The longest name the kernel can represent is `NAME_MAX - 1`, so that is
+/// the contract this checks: 254 characters work end to end, and anything
+/// longer is refused with ENAMETOOLONG rather than created as a name the
+/// kernel cannot then handle.
+///
+/// A name that is accepted has to survive the whole round trip, not just the
+/// creation: it is written to, read back, found by `stat`, listed by
+/// `getdents` at its full length, and removed. Listing it is the check that
+/// matters most, because the copy into `d_name` is the one place where a
+/// name of the maximum length fills the field exactly.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The directory the names are created in.
+#define DIR "/home/user"
+
+/// The longest name the kernel can hold, terminator included.
+#define LONGEST 254
+
+/// Buffer for the paths under test.
+static char path[512];
+
+/// Buffer for reading directory entries.
+static char entries[sizeof(dirent_t) * 32];
+
+/// @brief Builds DIR/<len characters>.
+/// @param len how many characters the name has.
+static void __build_path(unsigned len)
+{
+    unsigned pos = 0;
+    memcpy(path, DIR "/", sizeof(DIR));
+    pos = sizeof(DIR);
+    for (unsigned i = 0; i < len; ++i) {
+        path[pos++] = 'n';
+    }
+    path[pos] = 0;
+}
+
+/// @brief Looks for the name in the listing of DIR.
+/// @param name the name to look for.
+/// @param found_len where the length of the entry that was found is stored.
+/// @return 1 when the name is listed, 0 when it is not, -1 on failure.
+static int __listed(const char *name, unsigned *found_len)
+{
+    int fd = open(DIR, O_RDONLY | O_DIRECTORY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_name_max] open of " DIR ": %s", strerror(errno));
+        return -1;
+    }
+    *found_len = 0;
+    ssize_t bytes;
+    while ((bytes = getdents(fd, (dirent_t *)entries, sizeof(entries))) > 0) {
+        for (ssize_t off = 0; off < bytes; off += sizeof(dirent_t)) {
+            dirent_t *entry = (dirent_t *)(entries + off);
+            if (strcmp(entry->d_name, name) == 0) {
+                *found_len = (unsigned)strlen(entry->d_name);
+                close(fd);
+                return 1;
+            }
+        }
+    }
+    close(fd);
+    if (bytes < 0) {
+        syslog(LOG_ERR, "[t_name_max] getdents: %s", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Checks that a name of the given length works end to end.
+/// @param len how many characters the name has.
+/// @return 0 on success, -1 on failure.
+static int __check_accepted(unsigned len)
+{
+    __build_path(len);
+    const char *name = path + sizeof(DIR);
+
+    errno  = 0;
+    int fd = creat(path, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_name_max] creating a name of %u characters failed: %s", len, strerror(errno));
+        return -1;
+    }
+    const char *content = "name";
+    ssize_t written     = write(fd, content, strlen(content));
+    close(fd);
+    if (written != (ssize_t)strlen(content)) {
+        syslog(LOG_ERR, "[t_name_max] writing to the %u-character name returned %zd", len, written);
+        unlink(path);
+        return -1;
+    }
+
+    int failures = 0;
+
+    // The name has to be found again by the very lookup that stores it in a
+    // buffer of exactly NAME_MAX bytes.
+    stat_t st;
+    if (stat(path, &st) < 0) {
+        syslog(LOG_ERR, "[t_name_max] stat of the %u-character name: %s", len, strerror(errno));
+        ++failures;
+    } else if ((unsigned)st.st_size != strlen(content)) {
+        syslog(LOG_ERR, "[t_name_max] the %u-character name is %u bytes, expected %u", len, (unsigned)st.st_size, (unsigned)strlen(content));
+        ++failures;
+    }
+
+    // And it has to be listed at its full length: a copy that fills d_name
+    // without terminating it reads as a longer name, or as a different one.
+    unsigned found_len = 0;
+    int listed         = __listed(name, &found_len);
+    if (listed < 0) {
+        ++failures;
+    } else if (listed == 0) {
+        syslog(LOG_ERR, "[t_name_max] the %u-character name is not in the listing of " DIR, len);
+        ++failures;
+    } else if (found_len != len) {
+        syslog(LOG_ERR, "[t_name_max] the %u-character name is listed with %u characters", len, found_len);
+        ++failures;
+    }
+
+    // Reading it back proves the direntry points where it should.
+    char buffer[16] = {0};
+    fd              = open(path, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_name_max] reopening the %u-character name: %s", len, strerror(errno));
+        ++failures;
+    } else {
+        ssize_t bytes = read(fd, buffer, sizeof(buffer) - 1);
+        close(fd);
+        if ((bytes != (ssize_t)strlen(content)) || (strcmp(buffer, content) != 0)) {
+            syslog(LOG_ERR, "[t_name_max] the %u-character name reads back `%s`, expected `%s`", len, buffer, content);
+            ++failures;
+        }
+    }
+
+    if (unlink(path) < 0) {
+        syslog(LOG_ERR, "[t_name_max] unlink of the %u-character name: %s", len, strerror(errno));
+        ++failures;
+    }
+    return (failures == 0) ? 0 : -1;
+}
+
+/// @brief Checks that a name of the given length is refused.
+/// @param len how many characters the name has.
+/// @return 0 on success, -1 on failure.
+static int __check_refused(unsigned len)
+{
+    __build_path(len);
+
+    errno  = 0;
+    int fd = creat(path, 0644);
+    if (fd >= 0) {
+        // A name the kernel cannot terminate must not reach the disk: every
+        // later lookup of it copies name_len bytes into a NAME_MAX buffer.
+        close(fd);
+        syslog(LOG_ERR, "[t_name_max] creating a name of %u characters succeeded, it had to be refused", len);
+        unlink(path);
+        return -1;
+    }
+    if (errno != ENAMETOOLONG) {
+        int reported = errno;
+        syslog(LOG_ERR, "[t_name_max] a name of %u characters reported errno %d: %s", len, reported, strerror(reported));
+        syslog(LOG_ERR, "[t_name_max] the expected errno was %d: %s", ENAMETOOLONG, strerror(ENAMETOOLONG));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Checks that mkdir applies the same bound as creat.
+/// @param len how many characters the name has.
+/// @param accepted whether the length has to be accepted.
+/// @return 0 on success, -1 on failure.
+static int __check_mkdir(unsigned len, int accepted)
+{
+    __build_path(len);
+
+    errno   = 0;
+    int ret = mkdir(path, 0755);
+    if (accepted) {
+        if (ret < 0) {
+            syslog(LOG_ERR, "[t_name_max] mkdir of a %u-character name failed: %s", len, strerror(errno));
+            return -1;
+        }
+        if (rmdir(path) < 0) {
+            syslog(LOG_ERR, "[t_name_max] rmdir of the %u-character name: %s", len, strerror(errno));
+            return -1;
+        }
+        return 0;
+    }
+    if (ret >= 0) {
+        syslog(LOG_ERR, "[t_name_max] mkdir of a %u-character name succeeded, it had to be refused", len);
+        rmdir(path);
+        return -1;
+    }
+    if (errno != ENAMETOOLONG) {
+        int reported = errno;
+        syslog(LOG_ERR, "[t_name_max] mkdir of a %u-character name reported errno %d: %s", len, reported, strerror(reported));
+        syslog(LOG_ERR, "[t_name_max] the expected errno was %d: %s", ENAMETOOLONG, strerror(ENAMETOOLONG));
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    // Well inside the bound, so a failure here is not about the boundary.
+    if (__check_accepted(LONGEST - 1) < 0) {
+        ++failures;
+    }
+    // Exactly the longest name the kernel can hold.
+    if (__check_accepted(LONGEST) < 0) {
+        ++failures;
+    }
+    // One past it: 255 fits the on-disk name_len but leaves no room for a
+    // terminator in any of the kernel's NAME_MAX buffers.
+    if (__check_refused(LONGEST + 1) < 0) {
+        ++failures;
+    }
+    // And beyond, where the on-disk name_len itself would wrap.
+    if (__check_refused(LONGEST + 2) < 0) {
+        ++failures;
+    }
+
+    // Directories carry the same names through the same copies.
+    if (__check_mkdir(LONGEST, 1) < 0) {
+        ++failures;
+    }
+    if (__check_mkdir(LONGEST + 1, 0) < 0) {
+        ++failures;
+    }
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_name_max] names up to %u characters work, longer ones are refused", (unsigned)LONGEST);
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_name_max] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #285

**Read [my correction on the issue](https://github.com/mentos-team/MentOS/issues/285#issuecomment-) first if the severity matters to you**: the report claimed a kernel stack corruption reachable from user space, and neither half of that is true any more. The user-space route was closed by the #284 work, and the one write that is out of bounds of its array stays inside its own object. What is left is a filesystem driver trusting on-disk lengths it should bound, the same class as #304 and #314.

## The boundary

The on-disk `name_len` is a `uint8_t`, so 255 is a legal stored value. Every field the kernel copies it into is a NUL-terminated `char[255]` — `EXT2_NAME_LEN` and `NAME_MAX` are both 255. A name of exactly that length has nowhere to put its terminator, and three copies assumed it always fits.

### `ext2_getdents` — the one site reachable from on-disk data alone

```c
memset(dirp->d_name, 0, NAME_MAX);
strncpy(dirp->d_name, it.direntry->name, it.direntry->name_len);
```

255 bytes into a 255-byte field terminates nothing. Listing a directory walks its blocks directly instead of resolving a path, so no length check stands in front of this one.

### `ext2_find_direntry` — out of bounds of the array, inside the object

```c
strncpy(search->direntry.name, it.direntry->name, it.direntry->name_len);
search->direntry.name[it.direntry->name_len] = 0;
```

Measured by compiling the struct as declared, rather than by arithmetic:

```
sizeof(ext2_direntry_search_t) = 276
offsetof(.direntry.name)       = 20
byte written by name[255]      = 275
last byte of the object        = 275
=> the write lands INSIDE (in padding) the object
```

`direntry` is the last member, so the terminator goes into the structure's own trailing padding. Nothing outside it is touched. The real defect is subtler than the reported one: the array is left with no terminator inside it, and the name is legible **only because of** the write that is out of bounds of it. Removing the UB without bounding the copy would leave an unterminated string.

### `ext2_initialize_direntry` — the length itself

```c
direntry->name_len = strlen(name);
```

`strlen` into a `uint8_t`, so a 300-character name would have been recorded as 44 and the entry would describe a name nobody wrote.

### The fourth site was already fixed

`ext2_init_vfs_file`, the second site in the issue, is now `ext2_set_vfs_file_properties`, and its copy already keeps room for the terminator. That was the one that mattered most, because `vfs_file_t::name` has live fields after it rather than padding.

## The fix

All three clamp to `EXT2_NAME_LEN - 1`, terminate inside the array, and warn. `ext2_find_direntry` also writes back the length it actually stored, so a caller comparing `name_len` against the string it can see agrees with it.

## Verification, and what it does and does not show

`t_name_max` is new, and it **passes on unfixed `develop`**. I am saying that plainly rather than dressing it up: it is a boundary guard, not a reproduction. Nothing tested the 254/255 boundary before, so the fact that it holds today was accidental. It checks that 253 and 254 characters work end to end — created, written, `stat`ed, **listed by `getdents` at their full length**, read back, unlinked — and that 255 and 256 are refused with `ENAMETOOLONG`, for `creat` and `mkdir` alike.

To show the clamps actually do something I widened the token buffer in `namei.c` temporarily, which reopens the path the VFS closed, and ran a throwaway probe that creates a 255-character name and lists the directory. Same probe, same kernel, only the two ext2 hunks differing:

**Without the clamps**

```
[probe255] creat of a 255-character name returned 4, errno 0
[probe255] listed entry starting with 'n' has strlen 255
```

**With the clamps**

```
[probe255] creat of a 255-character name returned 4, errno 0
[probe255] listed entry starting with 'n' has strlen 254
[EXT2  ] Directory entry name of 255 characters truncated to 254.
```

`strlen` returning 255 on a 255-byte field is the defect stated exactly: the array is full, and what the program reads next is whatever follows it.

That probe also settles the reachability of the other two sites, and not in my favour: I could not drive them even with the VFS check widened, because `ext2_resolve_path` applies the same bound independently (`ext2_namei.c:111`, "Path component too long in `%s`"). Two layers reject an over-long component before either copy is reached. Those two clamps are consistency guards on data this driver could be handed by an image it did not write, and I have no path to them to offer.

The probe, the `namei.c` change and the widened buffer are **not in this branch** — `namei.c` is byte-identical to `develop`, and the two tests that guard it (`t_path_bounds`, `t_name_max`) both failed while it was patched, which is itself a check that they are doing their job.

## Suite

- Full suite on the finished tree: **65 tests, 0 failures, 0 panics**.
- No clamp warning fires in a normal run, which is what a guard should do.