### PR TITLE
fix(mem): report a user-mode fault once instead of once per delivery

### DIFF
--- a/kernel/src/mem/page_fault.c
+++ b/kernel/src/mem/page_fault.c
@@ -159,11 +159,51 @@ static int __page_handle_cow(page_table_entry_t *entry)
 ///          and scheduler_run delivers it through the stored frame (running
 ///          the handler or the default terminating action) before this
 ///          task runs again.
-static int __send_sigsegv_to_current(pt_regs_t *f)
+/// @brief The user-mode fault that was last reported.
+/// @details A SIGSEGV handler that returns without fixing the mapping leaves
+///          the faulting instruction to re-execute, which faults again, which
+///          enters the handler again, for ever. That loop is what Linux does
+///          too and is the program's own doing, but one error line per
+///          delivery is not: measured over 60 seconds of one such process, it
+///          was 341722 of the 341824 lines the kernel printed, so a program
+///          misusing its own handler starved everything else instead of only
+///          itself (#296). Remembering the last fault keeps one report per
+///          distinct fault and one note when it starts repeating.
+static struct {
+    int seen;         ///< Whether anything has been reported yet.
+    pid_t pid;        ///< The process that faulted.
+    uint32_t eip;     ///< The instruction that faulted.
+    uint32_t address; ///< The address it faulted on.
+    int noted;        ///< Whether the repeat has already been noted.
+} __last_user_fault;
+
+static int __send_sigsegv_to_current(pt_regs_t *f, uint32_t faulting_addr)
 {
     task_struct *task = scheduler_get_current_process();
     if (task) {
-        pr_err("User-mode fault: delivering SIGSEGV to pid %d.\n", task->pid);
+        // The same process faulting at the same instruction on the same
+        // address is the loop described above, and there is nothing to add
+        // after the first line.
+        int repeat = __last_user_fault.seen && (__last_user_fault.pid == task->pid) &&
+                     (__last_user_fault.eip == f->eip) && (__last_user_fault.address == faulting_addr);
+        if (!repeat) {
+            __last_user_fault.seen    = 1;
+            __last_user_fault.pid     = task->pid;
+            __last_user_fault.eip     = f->eip;
+            __last_user_fault.address = faulting_addr;
+            __last_user_fault.noted   = 0;
+            // The instruction and the address are what a report of this has
+            // to carry: without them the line says only that something in
+            // the process went wrong.
+            pr_err(
+                "User-mode fault: delivering SIGSEGV to pid %d (eip: 0x%08x, address: 0x%08x).\n", task->pid, f->eip,
+                faulting_addr);
+        } else if (!__last_user_fault.noted) {
+            __last_user_fault.noted = 1;
+            pr_err(
+                "pid %d keeps faulting at 0x%08x: further SIGSEGV deliveries for it are not reported.\n", task->pid,
+                faulting_addr);
+        }
         // Notifies current process.
         sys_kill(task->pid, SIGSEGV);
         // Now, we know the process needs to be removed from the list of
@@ -279,7 +319,7 @@ void page_fault_handler(pt_regs_t *f)
 
         // If the fault was caused by a user process, send a SIGSEGV signal.
         if (err_user) {
-            if (__send_sigsegv_to_current(f) == 0) {
+            if (__send_sigsegv_to_current(f, faulting_addr) == 0) {
                 return;
             }
             pr_crit("No task found for current process, unable to send SIGSEGV.\n");
@@ -322,7 +362,7 @@ void page_fault_handler(pt_regs_t *f)
         // it is a protection violation to signal, not something the kernel
         // demand paging should service (#237).
         if (err_user) {
-            if (__send_sigsegv_to_current(f) == 0) {
+            if (__send_sigsegv_to_current(f, faulting_addr) == 0) {
                 return;
             }
         }
@@ -358,7 +398,7 @@ void page_fault_handler(pt_regs_t *f)
                 // Any user-mode fault we cannot resolve (the CoW handling
                 // failed) kills the process, not the kernel (#237).
                 if (err_user) {
-                    if (__send_sigsegv_to_current(f) == 0) {
+                    if (__send_sigsegv_to_current(f, faulting_addr) == 0) {
                         return;
                     }
                 } else {
@@ -378,7 +418,7 @@ void page_fault_handler(pt_regs_t *f)
             // process dies with SIGSEGV; only kernel-mode faults panic
             // (#237).
             if (err_user) {
-                if (__send_sigsegv_to_current(f) == 0) {
+                if (__send_sigsegv_to_current(f, faulting_addr) == 0) {
                     return;
                 }
             }

--- a/userspace/tests/t_userfault.c
+++ b/userspace/tests/t_userfault.c
@@ -42,6 +42,28 @@ static void segv_handler(int sig)
     exit(HANDLER_EXIT);
 }
 
+/// How many times the returning handler has been entered.
+static volatile int handler_entries = 0;
+
+/// @brief SIGSEGV handler that returns the first time and exits the second.
+/// @details A handler that returns without fixing the mapping leaves the
+///          faulting instruction to re-execute, so the fault and the delivery
+///          repeat. That is what Linux does too, and it is the program's
+///          business, not the kernel's — but the kernel used to print an
+///          error line for every delivery, which was 341722 of the 341824
+///          lines it emitted in 60 seconds of one such process and starved
+///          everything else (#296). Bounding that output must not change what
+///          the process sees, which is what this checks: the handler has to
+///          be entered a second time, and the process has to be able to leave
+///          the loop under its own power.
+static void segv_returning_handler(int sig)
+{
+    (void)sig;
+    if (++handler_entries >= 2) {
+        exit(HANDLER_EXIT);
+    }
+}
+
 /// @brief Runs the faulting operation in a child and checks the outcome.
 /// @param label description of the case.
 /// @param fault the faulting operation (executed by the child).
@@ -112,6 +134,42 @@ static void fault_kernel_write(void)
     *KERNEL_REGION = 1;
 }
 
+/// @brief Checks that a handler which returns is entered again.
+/// @return 0 when the child left the loop through its handler, -1 otherwise.
+static int check_repeating_case(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        syslog(LOG_ERR, "[t_userfault] fork: %s", strerror(errno));
+        return -1;
+    }
+    if (pid == 0) {
+        if (signal(SIGSEGV, segv_returning_handler) == SIG_ERR) {
+            syslog(LOG_ERR, "[t_userfault] signal: %s", strerror(errno));
+            exit(90);
+        }
+        fault_null_read();
+        // The handler returned and the instruction did not fault again, so
+        // the process resumed past a dereference of NULL.
+        exit(92);
+    }
+    int status;
+    if (waitpid(pid, &status, 0) < 0) {
+        syslog(LOG_ERR, "[t_userfault] waitpid: %s", strerror(errno));
+        return -1;
+    }
+    if (WIFEXITED(status) && (WEXITSTATUS(status) == HANDLER_EXIT)) {
+        return 0;
+    }
+    if (WIFEXITED(status) && (WEXITSTATUS(status) == 92)) {
+        syslog(LOG_ERR, "[t_userfault] a returning SIGSEGV handler was entered only once");
+        return -1;
+    }
+    syslog(
+        LOG_ERR, "[t_userfault] repeating fault: expected handler exit %d, got raw status 0x%x", HANDLER_EXIT, status);
+    return -1;
+}
+
 int main(void)
 {
     int failures = 0;
@@ -135,6 +193,12 @@ int main(void)
         ++failures;
     }
     if (check_case("kernel read, handled", fault_kernel_read, 1) < 0) {
+        ++failures;
+    }
+    // A handler that returns has to be entered again, because the faulting
+    // instruction runs again. The kernel reports the fault once instead of
+    // once per delivery, and that must not stop the deliveries themselves.
+    if (check_repeating_case() < 0) {
         ++failures;
     }
 


### PR DESCRIPTION
Fixes #296

## Scope

#296 was narrowed by [a correction on the issue](https://github.com/mentos-team/MentOS/issues/296#issuecomment): the fault loop itself is not the defect. A handler that returns without fixing the mapping leaves the faulting instruction to re-execute, so it faults again and the handler runs again — which is what Linux does, and is the program's own business. **This PR does not stop the loop and is not meant to.** A process whose SIGSEGV handler returns still spins until something kills it.

What is a defect is that the kernel printed an error line for every delivery.

## Measurement

A throwaway probe — a child that installs a returning SIGSEGV handler and dereferences NULL — run under a 60-second cap, on `develop` before any change:

```
$ wc -l build/serial.log
341824 build/serial.log

$ grep -oE 'kernel/src/[a-z/_]+\.c:[0-9]+' build/serial.log | sort | uniq -c | sort -rn | head -3
 341722 kernel/src/mem/page_fault.c:166
      3 kernel/src/mem/alloc/zone_allocator.c:67
      3 kernel/src/mem/alloc/zone_allocator.c:66
```

One source line, 99.97% of everything the kernel emitted. That is why a program misusing its own handler starved every other process instead of only itself. The line came in with #295, when these faults stopped panicking, so the flood arrived with that fix.

Worth noting what the measurement also rules out: no other log site repeats. The `ERR(0): Page directory entry not present` and copy-on-write `pr_crit` lines print once or not at all, so line 166 was the whole problem.

## The fix

`__send_sigsegv_to_current` remembers the last fault it reported — pid, faulting instruction, faulting address — and prints one report per distinct fault plus one note when that fault begins repeating.

Same probe, same kernel, only this function differing:

```
$ wc -l build/serial.log
104 build/serial.log

User-mode fault: delivering SIGSEGV to pid 3 (eip: 0xacb20057, address: 0x00000000).
pid 3 keeps faulting at 0x00000000: further SIGSEGV deliveries for it are not reported.
```

341824 lines to 104, of which two concern the fault. `page_fault.c` no longer appears among the repeating sites at all. That pair of runs is the negative control: the probe and the kernel are identical apart from the fix.

Suppression is keyed on all three of pid, eip and address, not on pid alone, so a process that goes on to fault somewhere else is reported again rather than swallowed. The full-suite run demonstrates it: **seven distinct faults, seven reports**, and the single note belongs to the one child that loops.

```
User-mode fault: delivering SIGSEGV to pid 34 (eip: 0xa6e20276, address: 0x00000000).
User-mode fault: delivering SIGSEGV to pid 35 (eip: 0xa6e20290, address: 0x00000000).
User-mode fault: delivering SIGSEGV to pid 36 (eip: 0xa6e202a3, address: 0xc0000000).
User-mode fault: delivering SIGSEGV to pid 37 (eip: 0xa6e202b3, address: 0xc0000000).
User-mode fault: delivering SIGSEGV to pid 38 (eip: 0xa6e20276, address: 0x00000000).
User-mode fault: delivering SIGSEGV to pid 39 (eip: 0xa6e202a3, address: 0xc0000000).
User-mode fault: delivering SIGSEGV to pid 40 (eip: 0xa6e20276, address: 0x00000000).
pid 40 keeps faulting at 0x00000000: further SIGSEGV deliveries for it are not reported.
```

## The report now says where

The line used to carry only the pid. Finding out anything more meant instrumenting the kernel by hand — which is precisely what had to be done on #296 to establish that the repeats were the original instruction re-executing rather than a fault inside the signal machinery, and my first reading of that issue was wrong for want of it. The instruction pointer and the faulting address are in the report.

## Test

`t_userfault` gains the case it was missing: a handler that returns on the first delivery and exits on the second. It has to be entered twice, so the child leaves the loop under its own power and the suite does not hang.

Being plain about what that test does and does not do: it is **not** a regression test for the flood, because a user-space program cannot observe the kernel log. The flood evidence is the before/after measurement above. The test guards the other half — that bounding the output did not change what the process sees, so a future change to this logic cannot quietly stop delivering the signal. The probe itself is not merged: it livelocks by design and the runner exits 124 on it.

## Verification

- Full suite: **65 tests, 0 failures, 0 panics**.
- The whole suite's serial log is 492 lines, with 10 fault lines in it.