### PR TITLE
fix(vfs): stop a mount point from claiming the paths just outside it

### DIFF
--- a/kernel/inc/fs/namei.h
+++ b/kernel/inc/fs/namei.h
@@ -14,8 +14,6 @@
 #define REMOVE_TRAILING_SLASH 1 << 0
 /// Flag to follow symbolic links during path resolution.
 #define FOLLOW_LINKS          1 << 1
-/// Flag to create the last component of the path if it doesn't exist.
-#define CREAT_LAST_COMPONENT  1 << 2
 
 /// @brief Resolve the given path by following all symbolic links.
 ///

--- a/kernel/src/fs/vfs.c
+++ b/kernel/src/fs/vfs.c
@@ -276,11 +276,24 @@ super_block_t *vfs_get_superblock(const char *path)
     list_for_each_decl (it, &vfs_super_blocks) {
         sb  = list_entry(it, super_block_t, mounts);
         len = strlen(sb->path);
-        if (!strncmp(path, sb->path, len)) {
-            if (len > last_sb_len) {
-                last_sb_len = len;
-                last_sb     = sb;
-            }
+        if (strncmp(path, sb->path, len) != 0) {
+            continue;
+        }
+        // The prefix has to end where a path component ends. Comparing only
+        // the first `len` characters made a mount at `/dev/hda` claim
+        // `/dev/hda2` as well: the two share eight characters and nothing
+        // looked at the ninth (#289). Harmless with a single disk, but it is
+        // mount confusion waiting for a second one.
+        //
+        // Two prefixes need no such check: one that is the separator itself,
+        // which is the root and is a prefix of everything, and one that
+        // already ends with a separator.
+        if ((len > 1) && (sb->path[len - 1] != '/') && (path[len] != '\0') && (path[len] != '/')) {
+            continue;
+        }
+        if (len > last_sb_len) {
+            last_sb_len = len;
+            last_sb     = sb;
         }
     }
     return last_sb;
@@ -331,11 +344,12 @@ vfs_file_t *vfs_open(const char *path, int flags, mode_t mode)
     pr_debug("vfs_open(path: %s, flags: %d, mode: %d)\n", path, flags, mode);
     assert(path && "Provided null path.");
     // Resolve all symbolic links in the path before opening the file.
+    // Resolution never requires the last component to exist, which is why
+    // O_CREAT works, so there was nothing for a CREAT_LAST_COMPONENT flag to
+    // ask for: it was set here, set unconditionally in vfs_mkdir, and read
+    // nowhere. A flag nobody reads describes behaviour that does not exist
+    // and invites the next reader to rely on it (#289).
     int resolve_flags = FOLLOW_LINKS | REMOVE_TRAILING_SLASH;
-    // Allow the last component to be non existing when attempting to create it.
-    if (bitmask_check(flags, O_CREAT)) {
-        resolve_flags |= CREAT_LAST_COMPONENT;
-    }
     // Allocate a variable for the path.
     char absolute_path[PATH_MAX];
     // If the first character is not the '/' then get the absolute path.
@@ -666,7 +680,7 @@ int vfs_mkdir(const char *path, mode_t mode)
     // Allocate a variable for the path.
     char absolute_path[PATH_MAX];
     // If the first character is not the '/' then get the absolute path.
-    int resolve_flags = REMOVE_TRAILING_SLASH | FOLLOW_LINKS | CREAT_LAST_COMPONENT;
+    int resolve_flags = REMOVE_TRAILING_SLASH | FOLLOW_LINKS;
     int ret           = resolve_path(path, absolute_path, PATH_MAX, resolve_flags);
     if (ret < 0) {
         pr_err("vfs_mkdir(%s): Cannot get the absolute path.\n", path);

--- a/scripts/run-qemu-test
+++ b/scripts/run-qemu-test
@@ -15,6 +15,7 @@ VGA_ARGS="${3:--vga std}"
 # test, which is the case for every backend that needs no promotion.
 REQUIRE_BACKEND="${4:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # PIDs of the log-streaming subshells. Each was started as a background job
 # under a temporary `set -m` window, so each subshell is also its own process
@@ -42,6 +43,57 @@ trap cleanup EXIT
 trap 'trap - INT; cleanup; exit 130' INT
 trap 'trap - TERM; cleanup; exit 143' TERM
 trap 'trap - HUP; cleanup; exit 129' HUP
+
+# Refuse to boot an image that predates what it is supposed to contain.
+#
+# Invoking this wrapper by hand boots whatever ${BUILD_DIR}/cdrom_test.iso and
+# ${BUILD_DIR}/rootfs.img happen to be there. Three times now that has
+# produced a verification that proved nothing: during the #283 negative control
+# a stale ISO carrying the already-fixed kernel kept booting while the sources
+# were reverted, and the control passed. The same trap recurred while setting
+# up the #245 campaign. A negative control that silently passes is worse than
+# no negative control, because it is believed (#289).
+#
+# The ISO carries the kernel through mentos/bootloader.bin, which embeds
+# kernel.bin; rootfs.img is built from the filesystem/ staging tree, where the
+# userspace binaries and the tests are installed. Those are the two inputs
+# that make an image stale.
+#
+# Set ALLOW_STALE_IMAGES=1 to boot an old image on purpose.
+check_freshness() {
+    local artifact="$1"
+    shift
+    local newer
+    if [ ! -f "${artifact}" ]; then
+        echo "Missing ${artifact}." >&2
+        return 1
+    fi
+    # -quit stops at the first offender: naming one is enough to explain why.
+    newer="$(find "$@" -newer "${artifact}" -print -quit 2>/dev/null)"
+    if [ -n "${newer}" ]; then
+        echo "${artifact} is older than ${newer}." >&2
+        return 1
+    fi
+    return 0
+}
+
+if [ "${ALLOW_STALE_IMAGES:-0}" != "1" ]; then
+    STALE=0
+    check_freshness "${BUILD_DIR}/cdrom_test.iso" "${BUILD_DIR}/mentos/bootloader.bin" || STALE=1
+    check_freshness "${BUILD_DIR}/rootfs.img" "${REPO_DIR}/filesystem" || STALE=1
+    if [ "${STALE}" -ne 0 ]; then
+        echo "" >&2
+        echo "This run would boot an image that does not contain the current build," >&2
+        echo "so whatever it reports would say nothing about the working tree." >&2
+        echo "" >&2
+        echo "Rebuild first:" >&2
+        echo "  make -C ${BUILD_DIR} -j\$(nproc)" >&2
+        echo "  make -C ${BUILD_DIR} cdrom_test.iso filesystem" >&2
+        echo "" >&2
+        echo "Set ALLOW_STALE_IMAGES=1 to boot the existing image anyway." >&2
+        exit 1
+    fi
+fi
 
 echo "===================================================="
 echo "Starting QEMU test run (timeout: ${TIMEOUT}s)..."

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -59,6 +59,7 @@ static char *all_tests[] = {
     "t_list",
     "t_mem",
     "t_mkdir",
+    "t_mount_boundary",
     "t_name_max",
     // Skipped on purpose: filling the image to make the allocation fail takes
     // about two minutes of guest time, too much for every CI run. Run it by

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TEST_LIST
     t_shm.c
     t_semget.c
     t_mkdir.c
+    t_mount_boundary.c
     t_name_max.c
     t_alarm.c
     t_exit.c

--- a/userspace/tests/t_mount_boundary.c
+++ b/userspace/tests/t_mount_boundary.c
@@ -1,0 +1,162 @@
+/// @file t_mount_boundary.c
+/// @brief Regression test for #289 item 4: a mount point must only claim the
+/// paths inside it.
+/// @details `vfs_get_superblock` picks the mount whose path is the longest
+/// prefix of the path being looked up, and compared only those characters:
+///
+///     len = strlen(sb->path);
+///     if (!strncmp(path, sb->path, len)) { ... }
+///
+/// Nothing checked that the prefix ended where a path component ends, so a
+/// mount at `/dev/null` also claimed `/dev/nullx`, and one at `/proc` claimed
+/// `/procx`. The issue recorded this as harmless with today's mounts. It is
+/// not: there are four of them — `/`, `/proc`, `/dev/null` and `/dev/hda` —
+/// and `open("/dev/nullx", O_RDONLY)` used to *succeed*, so any name starting
+/// with those nine characters was the null device.
+///
+/// Every check comes with the control that the mount it borders on still
+/// works, because the cheapest way to pass this test would be to stop
+/// matching mount points at all.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// A path that extends the `/dev/null` mount point without being inside it.
+#define BEYOND_NULL "/dev/nullx"
+
+/// A path that extends the `/proc` mount point without being inside it.
+#define BEYOND_PROC "/procx"
+
+/// @brief Checks that a path bordering a mount point is not claimed by it.
+/// @return 0 on success, -1 on failure.
+static int __check_beyond_null(void)
+{
+    errno  = 0;
+    int fd = open(BEYOND_NULL, O_RDONLY, 0);
+    if (fd >= 0) {
+        close(fd);
+        syslog(LOG_ERR, "[t_mount_boundary] opening " BEYOND_NULL " succeeded: it is the null device");
+        return -1;
+    }
+    if (errno != ENOENT) {
+        int reported = errno;
+        syslog(LOG_ERR, "[t_mount_boundary] opening " BEYOND_NULL " reported errno %d: %s", reported, strerror(reported));
+        syslog(LOG_ERR, "[t_mount_boundary] the expected errno was %d: %s", ENOENT, strerror(ENOENT));
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Control: the null device itself still works.
+/// @return 0 on success, -1 on failure.
+static int __check_null_device(void)
+{
+    int fd = open("/dev/null", O_WRONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_mount_boundary] opening /dev/null failed: %s", strerror(errno));
+        return -1;
+    }
+    ssize_t written = write(fd, "discarded", 9);
+    close(fd);
+    if (written != 9) {
+        syslog(LOG_ERR, "[t_mount_boundary] writing to /dev/null returned %zd, expected 9", written);
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Checks that a path bordering /proc lands on the root filesystem.
+/// @details Being routed to procfs did not merely give the wrong error, it
+///          gave a *different* one for every operation: creating the file
+///          reported ENOSYS because procfs has no creat, while `stat` on it
+///          reported EPERM. On the root filesystem it is an ordinary file.
+/// @return 0 on success, -1 on failure.
+static int __check_beyond_proc(void)
+{
+    errno  = 0;
+    int fd = creat(BEYOND_PROC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_mount_boundary] creating " BEYOND_PROC " failed: %s", strerror(errno));
+        return -1;
+    }
+    const char *content = "root";
+    ssize_t written     = write(fd, content, strlen(content));
+    close(fd);
+    if (written != (ssize_t)strlen(content)) {
+        syslog(LOG_ERR, "[t_mount_boundary] writing to " BEYOND_PROC " returned %zd", written);
+        unlink(BEYOND_PROC);
+        return -1;
+    }
+    int failures = 0;
+    stat_t st;
+    if (stat(BEYOND_PROC, &st) < 0) {
+        syslog(LOG_ERR, "[t_mount_boundary] stat of " BEYOND_PROC ": %s", strerror(errno));
+        ++failures;
+    } else if ((unsigned)st.st_size != strlen(content)) {
+        syslog(LOG_ERR, "[t_mount_boundary] " BEYOND_PROC " is %u bytes, expected %u", (unsigned)st.st_size, (unsigned)strlen(content));
+        ++failures;
+    }
+    if (unlink(BEYOND_PROC) < 0) {
+        syslog(LOG_ERR, "[t_mount_boundary] unlink of " BEYOND_PROC ": %s", strerror(errno));
+        ++failures;
+    }
+    return (failures == 0) ? 0 : -1;
+}
+
+/// @brief Control: /proc itself still works.
+/// @return 0 on success, -1 on failure.
+static int __check_procfs(void)
+{
+    int fd = open("/proc/mounts", O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_mount_boundary] opening /proc/mounts failed: %s", strerror(errno));
+        return -1;
+    }
+    char buffer[256] = {0};
+    ssize_t bytes    = read(fd, buffer, sizeof(buffer) - 1);
+    close(fd);
+    if (bytes <= 0) {
+        syslog(LOG_ERR, "[t_mount_boundary] reading /proc/mounts returned %zd", bytes);
+        return -1;
+    }
+    // The root mount has to be in there, otherwise the read said nothing.
+    if (strstr(buffer, " / ") == NULL) {
+        syslog(LOG_ERR, "[t_mount_boundary] /proc/mounts does not list the root mount");
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    if (__check_beyond_null() < 0) {
+        ++failures;
+    }
+    if (__check_null_device() < 0) {
+        ++failures;
+    }
+    if (__check_beyond_proc() < 0) {
+        ++failures;
+    }
+    if (__check_procfs() < 0) {
+        ++failures;
+    }
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_mount_boundary] mount points claim only the paths inside them");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_mount_boundary] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #289

Items 2, 4 and 5. Item 3 needs no change and the evidence for that is below. [Details and two corrections are on the issue.](https://github.com/mentos-team/MentOS/issues/289)

## Item 4 — the mount prefix had no component boundary

`vfs_get_superblock` picks the mount whose path is the longest prefix of the path being looked up, and compared only those characters:

```c
len = strlen(sb->path);
if (!strncmp(path, sb->path, len)) { ... }
```

The issue recorded this as harmless with today's mounts. It is not. There are four mounts, not the three the issue lists — `/proc`, `/dev/null`, `/` and `/dev/hda`, the last of which I only found by reading `/proc/mounts` in the guest — and `/dev/null` being a mount point is enough to misroute today.

**Negative control**, the new test with only this hunk reverted:

```
not ok 36 - t_mount_boundary: Exit: 1
[t_mount_boundary] opening /dev/nullx succeeded: it is the null device
vfs_creat(/procx): Function not supported in current filesystem.
[t_mount_boundary] creating /procx failed: Function not implemented
[t_mount_boundary] 2 FAILURES
```

`open("/dev/nullx", O_RDONLY)` succeeded — any name beginning with those nine characters was the null device. A path bordering `/proc` got whatever error procfs happened to produce for the operation, ENOSYS for creating and EPERM for `stat`, instead of being an ordinary file on the root filesystem.

The prefix now has to end where a path component ends. Two mount paths need no such check and are excluded: one that is the separator itself, which is the root and is a prefix of everything, and one that already ends with a separator.

## Item 2 — `CREAT_LAST_COMPONENT` removed rather than implemented

It was set by `vfs_open` under `O_CREAT`, set unconditionally by `vfs_mkdir`, and read nowhere. Path resolution never required the last component to exist in the first place — which is why `O_CREAT` works at all — so there was nothing for the flag to ask for. Implementing it would have been a no-op, so the definition goes too: a flag nobody reads describes behaviour that does not exist and invites the next reader to rely on it.

## Item 5 — `run-qemu-test` refuses a stale image

The ISO is checked against `mentos/bootloader.bin`, which embeds the kernel; `rootfs.img` against the `filesystem/` staging tree. On a stale image the script names the offender and how to rebuild:

```
$ touch build/mentos/bootloader.bin && ./scripts/run-qemu-test build 60
build/cdrom_test.iso is older than build/mentos/bootloader.bin.

This run would boot an image that does not contain the current build,
so whatever it reports would say nothing about the working tree.

Rebuild first:
  make -C build -j$(nproc)
  make -C build cdrom_test.iso filesystem

Set ALLOW_STALE_IMAGES=1 to boot the existing image anyway.
$ echo $?
1
```

Both checks were exercised independently, and `ALLOW_STALE_IMAGES=1` was checked to let a run through.

**CI is unaffected**, and this was verified rather than assumed: the `qemu-test` target depends on `cdrom_test.iso`, which depends on `bootloader.bin` and `filesystem`, and `filesystem` depends on `programs tests`, so the binaries are installed before `mke2fs` runs and both artefacts are newer than their inputs by the time the wrapper starts. The normal local flow was run end to end with the guard active and produced no false positive.

Why it is worth more than its size: invoking the wrapper by hand boots whatever is in the build directory, and that has now produced a verification proving nothing three times. During the #283 negative control a stale ISO carrying the already-fixed kernel kept booting while the sources were reverted, and the control passed. A negative control that silently passes is worse than no negative control, because it is believed. It happened to me a fourth time while measuring item 4 for this very PR.

## Item 3 needs nothing

The `ata_soft_reset` message is now a `pr_debug` and already ends with a newline. Parsing every `pr_*` call in `kernel/src/drivers/ata.c` and checking the format string each one is actually handed — not just the first line of the call — finds no call in the file missing one.

## Test

`t_mount_boundary` pins item 4. Each boundary check is paired with the control that the mount it borders on still works — `/dev/null` accepts a write, `/proc/mounts` lists the root mount — because the cheapest way to pass this test would be to stop matching mount points altogether. Both controls pass with and without the fix; only the two boundary checks fail without it.

## Verification

- Full suite: **66 tests, 0 failures, 0 panics**.
- Negative control as quoted, with only the `vfs_get_superblock` hunk reverted.