### PR TITLE
refactor(ext2): remove the zero-fill helper that no caller can use

### DIFF
--- a/docs/maintainer/ext2.md
+++ b/docs/maintainer/ext2.md
@@ -87,7 +87,9 @@ for a new issue on recurrence → #192.
 - `ext2_get_filesystem(path)` → `ext2_resolve_path(fs->root, path, &search)`.
 - O_CREAT → `ext2_creat`; O_DIRECTORY/O_EXCL validation; inode read;
   `vfs_valid_open_permissions` (root/pid-0 bypass; owner/group/other bits);
-  O_TRUNC on regular files → `ext2_clean_inode_content`.
+  O_TRUNC on regular files → `ext2_truncate_inode` (frees the blocks and sets
+  the size to 0; the old `ext2_clean_inode_content` zero-filled and left the
+  length alone, #320/#327).
 - **`ext2_find_vfs_file_with_inode`**: reuse cached `vfs_file_t` for the same
   inode (shared `count`, `f_pos`); only allocate + `ext2_init_vfs_file` +
   insert into `fs->opened_files` when not cached.

--- a/kernel/src/fs/ext2/ext2_blockmap.c
+++ b/kernel/src/fs/ext2/ext2_blockmap.c
@@ -659,55 +659,6 @@ ssize_t ext2_write_inode_data(
     return written;
 }
 
-/// @brief Cleans the inode content.
-/// @param fs a pointer to the filesystem.
-/// @param inode the inode.
-/// @param inode_index the inode index.
-/// @return 0 on success, 1 on failure.
-int ext2_clean_inode_content(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index)
-{
-    pr_debug("ext2_clean_inode_content(%p, %p, %u)\n", fs, inode, inode_index);
-    // Check the type of operation.
-    if ((inode->mode & S_IFREG) != S_IFREG) {
-        pr_alert("Trying to clean the content of a non-regular file.\n");
-        return 1;
-    }
-    // Allocate the cache.
-    uint8_t *cache = ext2_alloc_cache(fs);
-    if (cache == NULL) {
-        pr_err("Failed to allocate the cache to clean inode %u\n", inode_index);
-        return -1;
-    }
-    // Get the cache size.
-    size_t cache_size = fs->block_size;
-    //
-    int ret           = 0;
-    for (ssize_t offset = 0, to_write; offset < inode->size;) {
-        pr_debug(
-            "ext2_clean_inode_content(%p, %p, %u): offset = %6u of size = %u\n", fs, inode, inode_index, offset,
-            inode->size);
-        // How many bytes are left to clean. The cache holds a single block, so
-        // that is the most one call can store: asking for more made the driver
-        // copy whatever followed the cache into the file, and the last request
-        // reached past the end of the file and extended it (#315).
-        size_t remaining = (size_t)(inode->size - (uint32_t)offset);
-        to_write         = (ssize_t)min(cache_size, remaining);
-        pr_debug("ext2_clean_inode_content(%p, %p, %u): to_write = %6u\n", fs, inode, inode_index, to_write);
-        // Override the content.
-        ssize_t written = ext2_write_inode_data(fs, inode, inode_index, offset, to_write, (char *)cache);
-        pr_debug("ext2_clean_inode_content(%p, %p, %u): written = %6u\n", fs, inode, inode_index, written);
-        if (written < 0) {
-            pr_err("Failed to clean content of inode %d\n", inode_index);
-            ret = -1;
-            break;
-        }
-        offset += written;
-    }
-    // Free the cache.
-    ext2_dealloc_cache(cache);
-    return ret;
-}
-
 /// @brief Discards the whole content of a regular file.
 /// @param fs a pointer to the filesystem.
 /// @param inode the inode to truncate.

--- a/kernel/src/fs/ext2/ext2_file.c
+++ b/kernel/src/fs/ext2/ext2_file.c
@@ -122,13 +122,6 @@ vfs_file_t *ext2_creat(const char *path, mode_t mode)
         goto rollback;
     }
 
-    // Clean the content of the newly created file.
-    if (ext2_clean_inode_content(fs, &inode, inode_index) < 0) {
-        pr_err("Failed to clean the content of the newly created inode.\n");
-        failure = -EIO;
-        goto rollback;
-    }
-
     // Initialize the file.
     if (ext2_allocate_direntry(fs, parent->ino, inode_index, file_name, ext2_file_type_regular_file) == -1) {
         pr_err("Failed to allocate a new direntry for the inode.\n");

--- a/kernel/src/fs/ext2/ext2_internal.h
+++ b/kernel/src/fs/ext2/ext2_internal.h
@@ -518,7 +518,6 @@ ssize_t ext2_read_inode_block(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32
 ssize_t ext2_write_inode_block(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index, uint32_t block_index, uint8_t *buffer);
 ssize_t ext2_read_inode_data(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index, off_t offset, size_t nbyte, char *buffer);
 ssize_t ext2_write_inode_data(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index, off_t offset, size_t nbyte, char *buffer);
-int ext2_clean_inode_content(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index);
 int ext2_truncate_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index);
 
 // Defined in ext2_dir.c.


### PR DESCRIPTION
Fixes #327

## Why it is dead

After #326, `ext2_clean_inode_content` has one caller: `ext2_creat`, immediately after `ext2_create_inode`. That function sets the size explicitly —

```c
    // Set the size of the file in bytes.
    inode->size         = 0;
```

— and the helper's only loop is `for (ssize_t offset = 0, to_write; offset < inode->size;)`, so the body cannot run. Zeroing the content of a brand-new inode was already a no-op before #326; the truncating open was the one caller that reached the loop.

## Why remove rather than keep

The issue left the decision open and said I leaned towards removal. Two things decide it.

It is the last user of the "overwrite with zeroes and leave the length alone" idea that #320 established is not what truncation means, so leaving it in the header invites the next reader to reach for it.

And because it is unreachable, no test covers it — including the `min(cache_size, remaining)` clamp that #321 added for the #315 kernel heap disclosure. That is the awkward part of the current state: unreachable enough that nothing tests it, present enough that a new caller could revive the loop with nothing standing behind it.

The alternative, keeping it against a future `ftruncate(2)`, does not hold up. There is no `truncate` or `ftruncate` syscall in the tree, and a real one truncating to a non-zero length wants block-level work of the kind `ext2_truncate_inode` does, not a zero-fill — so it would not reuse this code anyway.

The #315 bug itself stays documented where it belongs: in `t_trunc_content`'s header comment, which explains both defects on that path.

## Verification

A removal needs no new test. `-Wall -Werror` and the link step prove it is complete — a leftover call would not compile, and a leftover definition would trip `-Wunused-function` once it lost its last caller — and the suite proves nothing depended on the call being made: **66 tests, 0 failures, 0 panics**.

`docs/maintainer/ext2.md` described the open path in terms of the old helper and now names `ext2_truncate_inode`.