### PR TITLE
fix(stdint): make int64_t and uint64_t actually 64 bits wide

### DIFF
--- a/kernel/src/drivers/ata.c
+++ b/kernel/src/drivers/ata.c
@@ -131,6 +131,13 @@ typedef struct ata_identity {
     uint16_t unused7[152];
 } ata_identity_t;
 
+// IDENTIFY returns 256 words, and the read below derives its word count from
+// this structure, so a structure of the wrong size reads the wrong number of
+// words. It was 508 bytes while `uint64_t` was 32 bits wide, which made the
+// driver take 254 of the 256 words the drive had to give and leave two of them
+// in its buffer (#270).
+typedef char ata_identity_size_check[(sizeof(ata_identity_t) == 512) ? 1 : -1];
+
 /// @brief Physical Region Descriptor Table (PRDT) entry.
 /// @details
 /// The physical memory region to be transferred is described by a Physical
@@ -517,7 +524,9 @@ static inline void ata_dump_device(ata_device_t *dev)
     pr_debug("        overwrite_ext_command_supported       : %u\n", dev->identity.overwrite_ext_command_supported);
     pr_debug("        block_erase_ext_command_supported     : %u\n", dev->identity.block_erase_ext_command_supported);
     pr_debug("        sectors_28                            : %u\n", dev->identity.sectors_28);
-    pr_debug("        sectors_48                            : %u\n", dev->identity.sectors_48);
+    // 48-bit, and this printf has no 64-bit conversion. The dump shows the
+    // low half; ata_max_offset is where the whole value is used (#270).
+    pr_debug("        sectors_48 (low 32)                   : %u\n", (uint32_t)dev->identity.sectors_48);
     pr_debug("    }\n");
     pr_debug("    bmr {\n");
     pr_debug("        command : %6u, status : %6u, prdt : %6u\n", dev->bmr.command, dev->bmr.status, dev->bmr.prdt);
@@ -579,16 +588,14 @@ static inline int __cond_status_missing_bits(uint8_t status, uint8_t mask)
 /// @return 0 on success (condition satisfied), 1 on timeout.
 /// @details Polls the device status register while applying the condition function.
 /// Uses volatile timeout to prevent compiler optimization of the critical wait loop.
-static inline int ata_status_wait(ata_device_t *dev, uint8_t mask, 
-                                  int (*evaluate_condition)(uint8_t, uint8_t),
-                                  long timeout)
+static inline int ata_status_wait(ata_device_t *dev, uint8_t mask, int (*evaluate_condition)(uint8_t, uint8_t), long timeout)
 {
     uint8_t status;
     // Use volatile local copy to prevent compiler optimization of timeout loop.
     // The return value depends on proper timeout decrement, making volatile
     // semantics critical for correctness.
     volatile long volatile_timeout = timeout;
-    
+
     do {
         // Read current device status.
         status = inportb(dev->io_reg.status);
@@ -598,7 +605,7 @@ static inline int ata_status_wait(ata_device_t *dev, uint8_t mask,
             return 0;
         }
     } while (--volatile_timeout > 0);
-    
+
     // Timeout occurred - operation failed or device not responding.
     return 1;
 }

--- a/kernel/src/hardware/timer.c
+++ b/kernel/src/hardware/timer.c
@@ -4,10 +4,10 @@
 /// See LICENSE.md for details.
 
 // Setup the logging for this file (do this before any other include).
-#include "sys/kernel_levels.h"          // Include kernel log levels.
-#define __DEBUG_HEADER__ "[TIMER ]"     ///< Change header.
+#include "sys/kernel_levels.h"           // Include kernel log levels.
+#define __DEBUG_HEADER__ "[TIMER ]"      ///< Change header.
 #define __DEBUG_LEVEL__  LOGLEVEL_NOTICE ///< Set log level.
-#include "io/debug.h"                   // Include debugging functions.
+#include "io/debug.h"                    // Include debugging functions.
 
 #include "assert.h"
 #include "descriptor_tables/isr.h"
@@ -560,16 +560,18 @@ void run_timer_softirq(void)
 /// @param data The data.
 static inline void debug_timeout(unsigned long data)
 {
+    // The seconds come back as a uint64_t and the logging printf has no
+    // 64-bit conversion, so narrow it here (#270).
     pr_debug(
         "The timer has been successfully deactivated: %d, ticks: %d, seconds: "
-        "%d\n",
-        data, timer_ticks, timer_get_seconds());
+        "%u\n",
+        data, timer_ticks, (uint32_t)timer_get_seconds());
 }
 
 /// @brief Cancels a sleep timer for a task being woken up by signals.
 /// This handles the race where a signal interrupts a sleeping task:
 /// the signal handler calls this to stop the sleep timer from firing.
-/// 
+///
 /// With boundary-based context switching, we don't need to trigger
 /// immediate scheduling - the signal handler will return to the next
 /// interrupt/exception boundary where scheduler_run() picks the next task.
@@ -691,7 +693,7 @@ int sys_nanosleep(const struct timespec *req, struct timespec *rem)
     // Prevent a race between entering sleep state and arming the wake timer.
     // If a timer interrupt preempts in that window, the task can become
     // TASK_UNINTERRUPTIBLE without a wake source and block the system.
-    uint8_t irqs = irq_disable();
+    uint8_t irqs                   = irq_disable();
     // Create a dinamic timer to wake up the process after some time
     struct timer_list *sleep_timer = __timer_list_alloc();
     // First, we save the remaining time. Then, we remove the current process

--- a/kernel/src/io/proc_system.c
+++ b/kernel/src/io/proc_system.c
@@ -160,7 +160,12 @@ int procs_module_init(void)
 /// @param buffer the buffer.
 /// @param bufsize the buffer size.
 /// @return the amount we wrote.
-static ssize_t procs_do_uptime(char *buffer, size_t bufsize) { return sprintf(buffer, "%d", timer_get_seconds()); }
+// The uptime is a uint64_t and this printf has no 64-bit conversion, so it
+// is narrowed here rather than read half-width by a %d (#270).
+static ssize_t procs_do_uptime(char *buffer, size_t bufsize)
+{
+    return sprintf(buffer, "%u", (uint32_t)timer_get_seconds());
+}
 
 /// @brief Write the version inside the buffer.
 /// @param buffer the buffer.
@@ -194,10 +199,10 @@ static int procs_do_mounts_cb(super_block_t *sb, void *ctx)
         return 1;
     }
 
-    const char *source = (sb->source[0] != '\0') ? sb->source : sb->name;
+    const char *source     = (sb->source[0] != '\0') ? sb->source : sb->name;
     const char *mountpoint = sb->path;
-    const char *fstype = (sb->type && sb->type->name) ? sb->type->name : "unknown";
-    const char *options = "rw";
+    const char *fstype     = (sb->type && sb->type->name) ? sb->type->name : "unknown";
+    const char *options    = "rw";
 
     int written = snprintf(
         mounts_ctx->buf + mounts_ctx->pos,
@@ -213,7 +218,7 @@ static int procs_do_mounts_cb(super_block_t *sb, void *ctx)
 
     if ((size_t)written >= mounts_ctx->bufsize - mounts_ctx->pos) {
         // Buffer filled, stop writing.
-        mounts_ctx->pos = mounts_ctx->bufsize - 1;
+        mounts_ctx->pos                  = mounts_ctx->bufsize - 1;
         mounts_ctx->buf[mounts_ctx->pos] = '\0';
         return 1;
     }

--- a/kernel/src/process/scheduler_feedback.c
+++ b/kernel/src/process/scheduler_feedback.c
@@ -94,7 +94,10 @@ static inline void __scheduler_feedback_log(void)
     int written = 0;
 #endif
 #ifdef WRITE_ON_FILE
-    written = sprintf(buffer, "TIME : %ds\n", timer_get_seconds());
+    // timer_get_seconds returns a uint64_t, and this printf has no 64-bit
+    // conversion, so the value is narrowed here rather than left to be read
+    // half-width by a %d that cannot say so (#270).
+    written = sprintf(buffer, "TIME : %us\n", (uint32_t)timer_get_seconds());
     vfs_write(feedback, buffer, offset, written);
     offset += written;
 #endif

--- a/lib/inc/stdint.h
+++ b/lib/inc/stdint.h
@@ -6,10 +6,10 @@
 #pragma once
 
 /// @brief Define the signed 64-bit integer.
-typedef int int64_t;
+typedef long long int64_t;
 
 /// @brief Define the unsigned 64-bit integer.
-typedef unsigned int uint64_t;
+typedef unsigned long long uint64_t;
 
 /// @brief Define the signed 32-bit integer.
 typedef int int32_t;
@@ -62,5 +62,36 @@ typedef unsigned uintptr_t;
 /// @brief Maximum value of an unsigned 32-bit integer.
 #define UINT32_MAX (+4294967295U)
 
+/// @brief Minimum value of a signed 64-bit integer.
+/// @details Written as `-MAX - 1` because `-9223372036854775808` is parsed as
+///          the negation of a constant too large for a signed 64-bit type.
+#define INT64_MIN (-9223372036854775807LL - 1)
+
+/// @brief Maximum value of a signed 64-bit integer.
+#define INT64_MAX (+9223372036854775807LL)
+
+/// @brief Maximum value of an unsigned 64-bit integer.
+#define UINT64_MAX (+18446744073709551615ULL)
+
 /// @brief Maximum value representable by size_t.
 #define SIZE_MAX (+4294967295U)
+
+// The width of every one of these types is a promise the rest of the tree
+// relies on, and breaking it is silent: a cast to a type that turns out to be
+// narrower than advertised is perfectly legal, so the compiler cannot warn
+// about it. `uint64_t` and `int64_t` were `unsigned int` and `int` for years,
+// which left the ELF bounds checks in elf.c unable to detect the overflow they
+// were added to catch, truncated ext2 byte offsets past 4 GiB, cut the ATA
+// 48-bit sector count to 32 bits, and made `ata_identity_t` 508 bytes instead
+// of the 512 the hardware sends (#270). These make the next such change fail
+// the build instead.
+typedef char int8_width_check[(sizeof(int8_t) == 1) ? 1 : -1];
+typedef char uint8_width_check[(sizeof(uint8_t) == 1) ? 1 : -1];
+typedef char int16_width_check[(sizeof(int16_t) == 2) ? 1 : -1];
+typedef char uint16_width_check[(sizeof(uint16_t) == 2) ? 1 : -1];
+typedef char int32_width_check[(sizeof(int32_t) == 4) ? 1 : -1];
+typedef char uint32_width_check[(sizeof(uint32_t) == 4) ? 1 : -1];
+typedef char int64_width_check[(sizeof(int64_t) == 8) ? 1 : -1];
+typedef char uint64_width_check[(sizeof(uint64_t) == 8) ? 1 : -1];
+typedef char intptr_width_check[(sizeof(intptr_t) == sizeof(void *)) ? 1 : -1];
+typedef char uintptr_width_check[(sizeof(uintptr_t) == sizeof(void *)) ? 1 : -1];

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -59,6 +59,7 @@ static char *all_tests[] = {
     "t_list",
     "t_mem",
     "t_mkdir",
+    "t_stdint",
     "t_mount_boundary",
     "t_name_max",
     // Skipped on purpose: filling the image to make the allocation fail takes

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TEST_LIST
     t_shm.c
     t_semget.c
     t_mkdir.c
+    t_stdint.c
     t_mount_boundary.c
     t_name_max.c
     t_alarm.c

--- a/userspace/tests/t_stdint.c
+++ b/userspace/tests/t_stdint.c
@@ -1,0 +1,110 @@
+/// @file t_stdint.c
+/// @brief Regression test for #270: the integer types are the widths they
+/// are named for, and the 64-bit ones have the range the kernel relies on.
+/// @details `lib/inc/stdint.h` defined the 64-bit types as 32-bit:
+///
+///     typedef int int64_t;
+///     typedef unsigned int uint64_t;
+///
+/// Nothing could warn about it. A cast to a type that turns out to be
+/// narrower than advertised is perfectly legal, so code that cast to
+/// `uint64_t` specifically to gain range gained nothing and compiled clean.
+/// What it cost:
+///
+///   - the ELF bounds checks in elf.c cast to `uint64_t` so that the sum
+///     `offset + filesz` could not wrap, and the sum wrapped anyway;
+///   - ext2 byte offsets `(uint64_t)block_index * block_size` truncated past
+///     4 GiB;
+///   - the ATA 48-bit sector count did not fit in the field meant to hold it,
+///     and `ata_identity_t` came out 508 bytes instead of the 512 the drive
+///     sends, so IDENTIFY read 254 of its 256 words.
+///
+/// The widths themselves are pinned at compile time, in `stdint.h` and next to
+/// the ATA structure, so a future change to a typedef fails the build rather
+/// than being caught here. What this test adds is the part a compile-time
+/// check cannot express: that the arithmetic actually carries beyond 32 bits
+/// at run time, on the same shape of expression the ELF checks are built from.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <syslog.h>
+
+/// @brief Checks that a type has the expected size.
+/// @param name the name of the type, for the log.
+/// @param actual its measured size.
+/// @param expected the size it has to have.
+/// @return 0 when they match, -1 otherwise.
+static int __check_size(const char *name, unsigned actual, unsigned expected)
+{
+    if (actual != expected) {
+        syslog(LOG_ERR, "[t_stdint] sizeof(%s) is %u, expected %u", name, actual, expected);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    // The 64-bit types are the point of the issue.
+    failures += (__check_size("uint64_t", (unsigned)sizeof(uint64_t), 8) < 0);
+    failures += (__check_size("int64_t", (unsigned)sizeof(int64_t), 8) < 0);
+
+    // The narrower types are the control: widening everything would pass the
+    // two checks above and break the on-disk and hardware layouts that the
+    // whole kernel is built on.
+    failures += (__check_size("uint8_t", (unsigned)sizeof(uint8_t), 1) < 0);
+    failures += (__check_size("int8_t", (unsigned)sizeof(int8_t), 1) < 0);
+    failures += (__check_size("uint16_t", (unsigned)sizeof(uint16_t), 2) < 0);
+    failures += (__check_size("int16_t", (unsigned)sizeof(int16_t), 2) < 0);
+    failures += (__check_size("uint32_t", (unsigned)sizeof(uint32_t), 4) < 0);
+    failures += (__check_size("int32_t", (unsigned)sizeof(int32_t), 4) < 0);
+
+    // The shape of the ELF check: a 32-bit value promoted so the sum cannot
+    // wrap. `0xFFFFFFFF + 1` has to be 0x100000000, not 0.
+    uint32_t near_max = UINT32_MAX;
+    uint64_t widened  = (uint64_t)near_max + 1;
+    if (widened != 0x100000000ULL) {
+        syslog(LOG_ERR, "[t_stdint] (uint64_t)UINT32_MAX + 1 did not carry past 32 bits");
+        ++failures;
+    }
+
+    // And the shape of the ext2 offset: a block index past 2^20 multiplied by
+    // a 4 KiB block size, which used to truncate.
+    uint32_t block_index = 2u * 1024u * 1024u;
+    uint64_t offset      = (uint64_t)block_index * 4096u;
+    if (offset != 8589934592ULL) {
+        syslog(LOG_ERR, "[t_stdint] a block offset past 4 GiB did not fit a uint64_t");
+        ++failures;
+    }
+
+    // The limits have to describe the types they are named for. UINT64_MAX
+    // did not exist at all before this change.
+    if ((UINT64_MAX + 1ULL) != 0ULL) {
+        syslog(LOG_ERR, "[t_stdint] UINT64_MAX is not the largest unsigned 64-bit value");
+        ++failures;
+    }
+    if ((INT64_MAX > 0) && ((INT64_MAX + INT64_MIN) != -1)) {
+        syslog(LOG_ERR, "[t_stdint] INT64_MIN and INT64_MAX are not a matched pair");
+        ++failures;
+    }
+
+    // Signed 64-bit arithmetic has to reach past 32 bits too, in both
+    // directions: ext2 compares an offset against an inode size as ssize_t.
+    int64_t negative = -(int64_t)block_index * 4096;
+    if (negative != -8589934592LL) {
+        syslog(LOG_ERR, "[t_stdint] signed 64-bit arithmetic truncated");
+        ++failures;
+    }
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_stdint] the integer types are the widths they are named for");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_stdint] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #270

## The defect

`lib/inc/stdint.h` defined the 64-bit types as 32-bit, so `sizeof(uint64_t) == 4`. Nothing could warn about it: a cast to a type that turns out to be narrower than advertised is perfectly legal, so code that cast to `uint64_t` specifically to gain range gained nothing and compiled clean. The ELF bounds checks in `elf.c` cast to `uint64_t` so that `offset + filesz` could not wrap, and it wrapped anyway.

They are now `long long` and `unsigned long long`. `INT64_MIN`, `INT64_MAX` and `UINT64_MAX` did not exist in the header and now do.

## The consequence the issue did not know about

`ata_identity_t` describes the 512-byte IDENTIFY response, and the read derives its word count from the structure:

```c
inportsw(dev->io_reg.data, (uint16_t *)&dev->identity,
         (sizeof(ata_identity_t) / sizeof(uint16_t)));
```

Measured from the debug info of the compiled object rather than by arithmetic:

```
BEFORE (uint64_t = unsigned int)   sizeof = 508   offsetof(sectors_48) = 200
AFTER  (uint64_t = unsigned long long)  sizeof = 512   offsetof(sectors_48) = 200
```

The drive sends 256 words; the driver was asking for `508/2 = 254` and leaving two in the drive's buffer. Nothing was *misread* — `sectors_48` sits at offset 200 either way, which is where word 100 belongs, and the truncated tail is the `unused7` padding — but the transfer was short. The size is now asserted against 512 next to the structure.

## Negative control

Reverting only the two typedefs, with everything else in this branch in place:

```
lib/inc/stdint.h:94:14: error: size of array 'int64_width_check' is negative
lib/inc/stdint.h:95:14: error: size of array 'uint64_width_check' is negative
kernel/src/drivers/ata.c:139:14: error: size of array 'ata_identity_size_check' is negative
```

The widths of every type in the header are pinned with the `typedef char <name>_check[(cond) ? 1 : -1];` idiom the tree already uses for struct layouts (`virtq_desc_size_check`, `gpu_hdr_size_check`, `vga_text_cell_layout_check`), so a future change to a typedef fails the build rather than being discovered years later.

## The toolchain consequence does not arise

The issue warned that the i386 ABI needs `__udivdi3`/`__divdi3` for 64-bit division, and that this was the reason to change the types deliberately. It turns out nothing in the tree performs 64-bit division or a variable 64-bit shift:

```
$ nm -u build/kernel/libkernel.a | grep -E '__(u)?(div|mod)di3|__ashldi3|__lshrdi3|__ashrdi3|__muldi3'
(nothing)
```

A **clean** build of the whole tree — `rm -rf build`, reconfigure, build — succeeds with `-nostdlib`, which is itself the proof that no helper is unresolved.

## What widening broke, and none of it was diagnosed

Four call sites passed one of these values to a 32-bit conversion, and they were correct while `uint64_t` was `int`:

- `kernel/src/process/scheduler_feedback.c` — `"TIME : %ds\n", timer_get_seconds()`
- `kernel/src/io/proc_system.c` — `/proc/uptime`, `"%d", timer_get_seconds()`
- `kernel/src/hardware/timer.c` — `"seconds: %d\n", ..., timer_get_seconds()`
- `kernel/src/drivers/ata.c` — `"sectors_48 : %u\n", dev->identity.sectors_48`

**The build produced no diagnostic for any of them**, on `-Wall -Werror`, because the logging helpers carry no `__attribute__((format(printf, ...)))`. I found them by grepping the callers of the three `uint64_t`-returning functions by hand. Each is now narrowed explicitly with a comment saying why, because the kernel's `vsprintf` has no length modifiers at all and there is no way to print a 64-bit value.

Filed rather than fixed here:

- **#332** — `vsprintf` has no `h`/`l`/`ll` handling, so `%lld` prints literally and consumes no argument. There is a live instance at `sync.c:68` whose trailing `0x%x` reads the low half of `offset` instead of `flags`. Pre-existing and independent of this change, since `long long` was always 8 bytes.
- **#333** — `ata_max_offset` returns a 48-bit value that all three callers put in something 32 bits wide. Not a regression: the truncation used to happen earlier, inside `sectors_48`. What changed is that it is now written down in the code instead of hidden in a typedef.
- Evidence added to **#216** (format attribute on the logging helpers), which is exactly the class of mistake that went undiagnosed here.

## Test

`t_stdint` covers what a compile-time check cannot: that the arithmetic carries past 32 bits at run time, on the shapes the kernel actually depends on — `(uint64_t)UINT32_MAX + 1` from the `elf.c` bounds checks, and `(uint64_t)block_index * 4096` past 2^20 from the ext2 offsets — plus the signed direction and the new limits.

It also asserts that `uint8_t`, `int8_t`, `uint16_t`, `int16_t`, `uint32_t` and `int32_t` still have *their* widths. That is the control: widening everything would pass the 64-bit assertions and destroy every on-disk and hardware layout in the kernel.

## Verification

- Full suite: **67 tests, 0 failures, 0 panics**.
- `-DENABLE_SCHEDULER_FEEDBACK=ON`: **67 tests, 0 failures, 0 panics**. It is the only configuration that compiles one of the four narrowed call sites.
- `-DENABLE_EXT2_TRACE=ON` builds clean.
- Clean from-scratch build with width assertions in place, as above.

## What this does not do

`elf.c`'s bounds checks now compute in 64 bits and reject the overflow they were written to catch, but I have not added a crafted-ELF test for them. Reaching that check requires `e_phoff` near `UINT32_MAX`, and with the wrap gone `execve` fails at the bounds check instead of failing slightly later when the read at that offset returns nothing — so the observable outcome from user space is the same either way, and a test asserting it would not distinguish the fix. The arithmetic itself is what changed, and `t_stdint` tests that directly.