### PR TITLE
fix(libc): getcwd reports failure with NULL, as POSIX and its callers expect

### DIFF
--- a/lib/inc/system/syscall_types.h
+++ b/lib/inc/system/syscall_types.h
@@ -395,6 +395,27 @@
         return (type)(value);                                                                                          \
     } while (0)
 
+/// @brief Handle a pointer returned from a system call that reports failure
+///        with a null pointer.
+/// @param type Specifies the pointer type of the returned value.
+/// @param value The variable where the result of the system call is stored.
+/// @details POSIX splits the pointer-returning calls in two, and only one of
+///          them fits `__syscall_return`. `getcwd` and its kind report failure
+///          with a null pointer, and `__syscall_return` gives them
+///          `(type)-1`, which no `== NULL` test can ever see: the error
+///          handling written against the documented contract was dead code
+///          (#231). `shmat` and `mmap` are the other kind — POSIX gives them
+///          `(void *)-1` and MAP_FAILED respectively — so they keep using
+///          `__syscall_return` and must not be moved here.
+#define __syscall_return_pointer(type, value)                                                                          \
+    do {                                                                                                               \
+        if ((unsigned int)(value) >= (unsigned int)(-125)) {                                                           \
+            errno = -(value);                                                                                          \
+            return (type)0;                                                                                            \
+        }                                                                                                              \
+        return (type)(value);                                                                                          \
+    } while (0)
+
 // Few things about what follows:
 //
 // 1. The symbol "=", is a a constraint modifier, and it means that the operand

--- a/lib/src/unistd/getcwd.c
+++ b/lib/src/unistd/getcwd.c
@@ -12,5 +12,8 @@ char *getcwd(char *buf, size_t size)
 {
     long __res;
     __inline_syscall_2(__res, getcwd, buf, size);
-    __syscall_return(char *, __res);
+    // POSIX: NULL on failure, with errno set. `__syscall_return` would give
+    // `(char *)-1` here, which every `== NULL` caller in the tree missed
+    // (#231).
+    __syscall_return_pointer(char *, __res);
 }

--- a/userspace/tests/t_getcwd.c
+++ b/userspace/tests/t_getcwd.c
@@ -32,8 +32,15 @@ static int check_success(const char *what, char *buf, size_t size, char *ret, co
 
 static int check_failure(const char *what, char *ret, int expected_errno)
 {
-    if ((ret != (char *)-1) && (ret != NULL)) {
-        syslog(LOG_ERR, "[t_getcwd] %s: expected failure, got success pointer\n", what);
+    // POSIX: NULL, and only NULL. This used to accept `(char *)-1` as well,
+    // because the wrapper could not return NULL and the test had to take what
+    // it was given (#231).
+    if (ret != NULL) {
+        if (ret == (char *)-1) {
+            syslog(LOG_ERR, "[t_getcwd] %s: failure reported as (char *)-1 instead of NULL\n", what);
+        } else {
+            syslog(LOG_ERR, "[t_getcwd] %s: expected failure, got success pointer\n", what);
+        }
         return -1;
     }
     if (errno != expected_errno) {
@@ -61,7 +68,7 @@ int main(int argc, char *argv[])
     // 1. A sufficiently large buffer must succeed and be NUL-terminated.
     memset(buf, SENTINEL, sizeof(buf));
     errno = 0;
-    ret = getcwd(buf, sizeof(buf));
+    ret   = getcwd(buf, sizeof(buf));
     if (check_success("large buffer", buf, sizeof(buf), ret, directory) < 0) {
         failed = 1;
     }
@@ -70,7 +77,7 @@ int main(int argc, char *argv[])
     // 2. A buffer of exactly len + 1 bytes (terminator included) must succeed.
     memset(buf, SENTINEL, sizeof(buf));
     errno = 0;
-    ret = getcwd(buf, len + 1);
+    ret   = getcwd(buf, len + 1);
     if (check_success("exact-size buffer", buf, len + 1, ret, directory) < 0) {
         failed = 1;
     }
@@ -78,7 +85,7 @@ int main(int argc, char *argv[])
     // 3. A buffer one byte too small must fail with ERANGE.
     memset(buf, SENTINEL, sizeof(buf));
     errno = 0;
-    ret = getcwd(buf, len);
+    ret   = getcwd(buf, len);
     if (check_failure("one-byte-too-small buffer", ret, ERANGE) < 0) {
         failed = 1;
     }
@@ -86,7 +93,7 @@ int main(int argc, char *argv[])
     // 3b. A clearly undersized buffer must fail with ERANGE as well.
     memset(buf, SENTINEL, sizeof(buf));
     errno = 0;
-    ret = getcwd(buf, 2);
+    ret   = getcwd(buf, 2);
     if (check_failure("undersized buffer", ret, ERANGE) < 0) {
         failed = 1;
     }
@@ -94,7 +101,7 @@ int main(int argc, char *argv[])
     // 4. size == 0 must fail with EINVAL (POSIX.1-2017).
     memset(buf, SENTINEL, sizeof(buf));
     errno = 0;
-    ret = getcwd(buf, 0);
+    ret   = getcwd(buf, 0);
     if (check_failure("zero size", ret, EINVAL) < 0) {
         failed = 1;
     }


### PR DESCRIPTION
Fixes #231

## The defect

Every wrapper built on `__syscall_return` turns a kernel `-errno` into the integer -1 and casts it to the declared type, so a failing `getcwd` returned `(char *)-1`. Every caller in the tree tests for NULL:

```
userspace/bin/shell.c:185       if (getcwd(CWD, PATH_MAX) == NULL) {
userspace/bin/shell.c:508       if (getcwd(cwd, sizeof(cwd)) == NULL) {
userspace/bin/shell.c:726       if (getcwd(cwd, PATH_MAX) == NULL) {
userspace/tests/t_chdir.c:22    if (getcwd(cwd, sizeof(cwd)) != NULL) {
```

Not one of those branches could ever be taken, and the comment on the line after `shell.c:726` documented the contract the code did not have. They are all correct as written and become live with this change, so none of them needed editing.

## Narrower than the issue proposed, and deliberately so

#231 offered two options: a pointer-aware return macro used across the board, or keeping `(char *)-1` and fixing the callers. Neither is quite right, because POSIX splits the pointer-returning calls in two:

| wrapper | POSIX failure value | current behaviour |
| --- | --- | --- |
| `getcwd` | NULL | `(char *)-1` — **wrong** |
| `shmat` | `(void *)-1` | `(void *)-1` — already correct |
| `mmap` | `MAP_FAILED`, i.e. `(void *)-1` | already correct (and inside `#if 0`) |

So only one of the three wrappers was non-conforming. `__syscall_return_pointer` is added for that kind and used only by `getcwd`; `shmat` and `mmap` keep `__syscall_return`, and the new macro's doc comment says why they must not be moved to it. `t_shm` checks for `(char *)-1` today and keeps passing — the issue flagged that as a migration hazard, and it turns out there is nothing to migrate.

## Negative control

`t_getcwd` already had to accept both sentinels, which is how #231 was found:

```c
    if ((ret != (char *)-1) && (ret != NULL)) {
```

It now requires NULL and says which of the two it actually got. With only the wrapper line reverted:

```
not ok 26 - t_getcwd: Exit: 1
[t_getcwd] one-byte-too-small buffer: failure reported as (char *)-1 instead of NULL
[t_getcwd] undersized buffer: failure reported as (char *)-1 instead of NULL
[t_getcwd] zero size: failure reported as (char *)-1 instead of NULL
```

All three failure cases, one line each.

## Two transient failures I need to report

Two runs of this branch failed in tests unrelated to it and did not reproduce:

```
not ok 61 - t_spwd: Signal: 11
not ok  4 - t_chdir: Exit: 127
```

I chased this rather than re-running until green: **3 runs of `develop` — 0 failures. 8 runs of this branch — those 2, both in runs 3 and 4, then 6 consecutive green.** The second failure was a re-run of the *same image* that had just failed differently, so the image is not the variable.

Neither mode is reachable from this change. Exit 127 comes from `runtests.c:204`, where `execvp` returned and the test binary never started; and `t_spwd` does not call `getcwd`. I am **not** claiming three green runs of `develop` prove this is pre-existing — that sample is too small — only that the mechanism does not connect and that the build in this branch is green six times running.

Filed as **#336**, because a harness that intermittently fails an unrelated test can make a negative control look like it reproduced something it did not, which is the method this whole milestone is verified with. Same category as #289 item 5. It suggests one concrete first step: log `errno` before that `exit(127)`.

## Also filed

**#335** — four callers (`ls.c`, `rm.c`, `pwd.c`, `libgen.c`) ignore `getcwd`'s return entirely and use the buffer regardless. Not a regression, and not reachable today since all four pass `PATH_MAX`, but this change is what makes writing the check worthwhile: the POSIX idiom now works.

## Verification

- Full suite: **67 tests, 0 failures, 0 panics**, six consecutive runs.
- Negative control as quoted, with only the `getcwd` wrapper line reverted.