### PR TITLE
fix(ata): report a failed sector transfer, and retry the transient kind

### DIFF
--- a/kernel/src/drivers/ata.c
+++ b/kernel/src/drivers/ata.c
@@ -1254,39 +1254,87 @@ static int ata_device_read_sector_dma(ata_device_t *dev, uint32_t lba_sector, ui
     return -ENOSYS;
 }
 
+/// @brief How many times a sector transfer is attempted before it is reported
+///        as a failure.
+/// @details Three, because the observed failure is a transient status race
+///          that clears on the next attempt, and a sector that genuinely
+///          cannot be read will not become readable on the tenth try either.
+#define ATA_TRANSFER_ATTEMPTS 3
+
 /// @brief Reads an ATA sector with PIO (DMA disabled due to QEMU incompatibility).
 /// @param dev the device on which we perform the read.
 /// @param lba_sector the sector where we read.
 /// @param buffer the buffer we are writing.
-static void ata_device_read_sector(ata_device_t *dev, uint32_t lba_sector, uint8_t *buffer)
+/// @return 0 on success, a negative errno on failure.
+/// @details The result must be checked. This used to be a void function that
+///          logged the failure and returned, and `ata_device_read_sector_pio`
+///          jumps out before its `inportsw` on every error path, so the
+///          caller's buffer kept whatever it held before — for the two
+///          `support_buffer` paths in `ata_read` that is the previous sector,
+///          read as though it were this one. A transient `-EBUSY` was observed
+///          on a boot that then passed its whole suite (#291).
+static __attribute__((warn_unused_result)) int
+ata_device_read_sector(ata_device_t *dev, uint32_t lba_sector, uint8_t *buffer)
 {
     if ((dev->type != ata_dev_type_pata) && (dev->type != ata_dev_type_sata)) {
         pr_crit("[%s] Unsupported device type for read operation.\n", ata_get_device_settings_str(dev));
-        return;
+        return -EPERM;
     }
 
     spinlock_lock(&dev->lock);
 
     // Skip DMA entirely; QEMU's DMA IRQ emulation is unreliable.
     // PIO works perfectly, so use it directly.
-    int rc = ata_device_read_sector_pio(dev, lba_sector, buffer);
-    if (rc) {
-        pr_crit("ata_device_read_sector: PIO failed (sector %u, rc=%d)\n", lba_sector, rc);
+    //
+    // Retry a failed attempt before reporting it. What this bounds is a status
+    // race and not a bad sector: the device reports BSY, or clears DRQ, on a
+    // sector that reads perfectly when asked again. Once the error stopped
+    // being dropped it turned out to be frequent enough to break a suite run,
+    // on sectors 40 and 44 of the inode table in the same boot, which is how
+    // #291's "silently absorbed" reads were being absorbed. Reporting it
+    // immediately is correct but needlessly destructive; absorbing it, which
+    // is what this function used to do, handed ext2 the previous sector as an
+    // inode table.
+    int rc = 0;
+    for (unsigned attempt = 0; attempt < ATA_TRANSFER_ATTEMPTS; ++attempt) {
+        rc = ata_device_read_sector_pio(dev, lba_sector, buffer);
+        if (rc == 0) {
+            // Keep the transient visible: it is a real event on the bus, and
+            // a driver that recovers in silence cannot be told from one that
+            // never had the problem.
+            if (attempt > 0) {
+                pr_warning(
+                    "ata_device_read_sector: sector %u read on attempt %u of %u\n", lba_sector, attempt + 1,
+                    ATA_TRANSFER_ATTEMPTS);
+            }
+            break;
+        }
+        pr_crit(
+            "ata_device_read_sector: PIO failed (sector %u, rc=%d, attempt %u of %u)\n", lba_sector, rc, attempt + 1,
+            ATA_TRANSFER_ATTEMPTS);
     }
 
     spinlock_unlock(&dev->lock);
+
+    return rc;
 }
 
 /// @brief Writs an ATA sector.
 /// @param dev the device on which we perform the write.
 /// @param lba_sector the sector where we read.
 /// @param buffer the buffer where we store what we read.
-static void ata_device_write_sector(ata_device_t *dev, uint32_t lba_sector, uint8_t *buffer)
+/// @return 0 on success, a negative errno on failure.
+/// @details The result must be checked, for the same reason as the read: a
+///          write that never reached the device used to report nothing, so
+///          `ata_write` returned the byte count it had been asked for and the
+///          data was not on the disk (#291).
+static __attribute__((warn_unused_result)) int
+ata_device_write_sector(ata_device_t *dev, uint32_t lba_sector, uint8_t *buffer)
 {
     // Check if we are trying to perform the read on a valid device type.
     if ((dev->type != ata_dev_type_pata) && (dev->type != ata_dev_type_sata)) {
         pr_crit("[%s] Unsupported device type for read operation.\n", ata_get_device_settings_str(dev));
-        return;
+        return -EPERM;
     }
 
     // Acquire the lock for thread safety.
@@ -1308,7 +1356,7 @@ static void ata_device_write_sector(ata_device_t *dev, uint32_t lba_sector, uint
     if (ata_status_wait_not(dev, ata_status_bsy, 100000)) {
         ata_print_status_error(dev);
         spinlock_unlock(&dev->lock);
-        return;
+        return -EBUSY;
     }
 
     // Select the drive (set head and device).
@@ -1318,7 +1366,7 @@ static void ata_device_write_sector(ata_device_t *dev, uint32_t lba_sector, uint
     if (ata_status_wait_not(dev, ata_status_bsy, 100000)) {
         ata_print_status_error(dev);
         spinlock_unlock(&dev->lock);
-        return;
+        return -EBUSY;
     }
 
     // Set the features, sector count, and LBA for the write operation.
@@ -1332,7 +1380,7 @@ static void ata_device_write_sector(ata_device_t *dev, uint32_t lba_sector, uint
     if (ata_status_wait_not(dev, ata_status_bsy, 100000)) {
         ata_print_status_error(dev);
         spinlock_unlock(&dev->lock);
-        return;
+        return -EBUSY;
     }
 
     // Notify that we are starting the DMA writing operation.
@@ -1360,6 +1408,8 @@ static void ata_device_write_sector(ata_device_t *dev, uint32_t lba_sector, uint
 
     // Release the lock after the operation is complete.
     spinlock_unlock(&dev->lock);
+
+    return 0;
 }
 
 // == VFS CALLBACKS ===========================================================
@@ -1497,8 +1547,18 @@ static ssize_t ata_read(vfs_file_t *file, char *buffer, off_t offset, size_t siz
     uint32_t postfix_size = (offset + size) % ATA_SECTOR_SIZE;
     uint32_t x_offset     = 0;
 
+    // A sector that could not be read must not be copied out. The support
+    // buffer holds the previous sector and the caller's buffer holds whatever
+    // it held before, and neither is distinguishable from the data that was
+    // asked for, so the error has to end the read (#291).
+    int rc;
+
     if (start_offset) {
-        ata_device_read_sector(dev, start_block, (uint8_t *)support_buffer);
+        rc = ata_device_read_sector(dev, start_block, (uint8_t *)support_buffer);
+        if (rc < 0) {
+            pr_err("ata_read: failed to read sector %u (%d)\n", start_block, rc);
+            return rc;
+        }
         // Copy the prefix from the support buffer to the output buffer.
         memcpy(buffer, (void *)((uintptr_t)support_buffer + start_offset), prefix_size);
         x_offset += prefix_size;
@@ -1507,7 +1567,11 @@ static ssize_t ata_read(vfs_file_t *file, char *buffer, off_t offset, size_t siz
 
     // Read postfix if needed.
     if (postfix_size && (start_block <= end_block)) {
-        ata_device_read_sector(dev, end_block, (uint8_t *)support_buffer);
+        rc = ata_device_read_sector(dev, end_block, (uint8_t *)support_buffer);
+        if (rc < 0) {
+            pr_err("ata_read: failed to read sector %u (%d)\n", end_block, rc);
+            return rc;
+        }
         // Copy the postfix from the support buffer to the output buffer.
         memcpy((void *)((uintptr_t)buffer + size - postfix_size), support_buffer, postfix_size);
         --end_block;
@@ -1515,7 +1579,11 @@ static ssize_t ata_read(vfs_file_t *file, char *buffer, off_t offset, size_t siz
 
     // Read full sectors in between.
     for (; start_block <= end_block; ++start_block) {
-        ata_device_read_sector(dev, start_block, (uint8_t *)((uintptr_t)buffer + x_offset));
+        rc = ata_device_read_sector(dev, start_block, (uint8_t *)((uintptr_t)buffer + x_offset));
+        if (rc < 0) {
+            pr_err("ata_read: failed to read sector %u (%d)\n", start_block, rc);
+            return rc;
+        }
         x_offset += ATA_SECTOR_SIZE;
     }
 
@@ -1570,26 +1638,52 @@ static ssize_t ata_write(vfs_file_t *file, const void *buffer, off_t offset, siz
         size = max_offset - offset;
     }
 
+    // A partial sector has to be read before it can be modified, so a failed
+    // read here would write the previous sector's contents back over the one
+    // being edited. And a write that never reached the device used to leave
+    // `ata_write` reporting the full byte count (#291).
+    int rc;
+
     // Handle the prefix if needed.
     if (start_offset) {
-        ata_device_read_sector(dev, start_block, (uint8_t *)support_buffer);
+        rc = ata_device_read_sector(dev, start_block, (uint8_t *)support_buffer);
+        if (rc < 0) {
+            pr_err("ata_write: failed to read sector %u before modifying it (%d)\n", start_block, rc);
+            return rc;
+        }
         memcpy((void *)((uintptr_t)support_buffer + (start_offset)), buffer, prefix_size);
-        ata_device_write_sector(dev, start_block, (uint8_t *)support_buffer);
+        rc = ata_device_write_sector(dev, start_block, (uint8_t *)support_buffer);
+        if (rc < 0) {
+            pr_err("ata_write: failed to write sector %u (%d)\n", start_block, rc);
+            return rc;
+        }
         x_offset += prefix_size;
         ++start_block;
     }
 
     // Handle the postfix if needed.
     if (postfix_size && (start_block <= end_block)) {
-        ata_device_read_sector(dev, end_block, (uint8_t *)support_buffer);
+        rc = ata_device_read_sector(dev, end_block, (uint8_t *)support_buffer);
+        if (rc < 0) {
+            pr_err("ata_write: failed to read sector %u before modifying it (%d)\n", end_block, rc);
+            return rc;
+        }
         memcpy(support_buffer, (void *)((uintptr_t)buffer + size - postfix_size), postfix_size);
-        ata_device_write_sector(dev, end_block, (uint8_t *)support_buffer);
+        rc = ata_device_write_sector(dev, end_block, (uint8_t *)support_buffer);
+        if (rc < 0) {
+            pr_err("ata_write: failed to write sector %u (%d)\n", end_block, rc);
+            return rc;
+        }
         --end_block;
     }
 
     // Write full sectors in between.
     for (; start_block <= end_block; ++start_block) {
-        ata_device_write_sector(dev, start_block, (uint8_t *)((uintptr_t)buffer + x_offset));
+        rc = ata_device_write_sector(dev, start_block, (uint8_t *)((uintptr_t)buffer + x_offset));
+        if (rc < 0) {
+            pr_err("ata_write: failed to write sector %u (%d)\n", start_block, rc);
+            return rc;
+        }
         x_offset += ATA_SECTOR_SIZE;
     }
 


### PR DESCRIPTION
Fixes #291

## Making the error propagate found the bug live

`ata_device_read_sector` was `void`: on failure it logged and returned, and `ata_device_read_sector_pio` jumps out before its `inportsw` on every error path, so the caller's buffer kept whatever it already held. For the two `support_buffer` paths in `ata_read` that is the previous sector, handed back as though it were the one requested.

The issue reported this from a single log line seen during the #245 campaigns. Once the error stopped being dropped, it appeared on the third suite run of this branch:

```
[ATA   ] ata_device_read_sector: PIO failed (sector 44, rc=-16)
[ATA   ] ata_read: failed to read sector 44 (-16)
[EXT2  ] Failed to read inode table block (inode 2, block 5).
[EXT2  ] Failed to read the inode (2).
[t_dir_entries] 397 of the 400 files created can be found by name
```

A transient `-EBUSY` on a sector of the inode table, twice in that boot. **Before this change, that same event returned the previous sector as the root inode and the directory lookup carried on against it.** That is #291's "silently absorbed" read caught in the act, and it is the strongest evidence in this PR — not constructed, and not reproducible on demand.

It also very likely explains **#336**, the intermittent unrelated-test failures I filed earlier today. A test binary is an ELF read off the disk through this path; a stale sector in its headers or text gives either an `execvp` that fails (`Exit: 127`) or a process that starts and dies (`Signal: 11`), which is exactly the pair recorded there. Commented on that issue with the reasoning and with what I am *not* claiming.

## Reporting alone would have been wrong

The condition is a status race, not a bad sector: the same read succeeds when asked again. Propagating it immediately turns a recoverable event into a user-visible failure — which is precisely what the run above shows, three files lost out of four hundred.

So `ATA_TRANSFER_ATTEMPTS` is three, and a recovery is **logged** rather than passed over, because a driver that recovers in silence cannot be told from one that never had the problem. The issue proposed this ("optionally retry transient `-EBUSY`/`-ETIMEDOUT` once before failing"); the run above is why it is not optional.

## The write side

`ata_device_write_sector` had the same void signature, with the mirror consequence: a write that never reached the device reported nothing, so `ata_write` returned the byte count it had been asked for and the data was not on the disk. Its three status-wait bailouts now return `-EBUSY`.

It is **not** retried, deliberately: its failures were never observed, and retrying it means extracting its eighty-line body into a function first, which belongs with the `ata.c` split rather than with this.

## All eight call sites, enforced

`ata_read` has three and `ata_write` five, and each now checks and stops. In `ata_write` the read half matters as much as the write: a partial sector is read before being modified, so a failed read there would have written the previous sector's contents back over the one being edited.

Both functions are `warn_unused_result`, so this cannot quietly come back. Dropping the check at one call site:

```
ata.c:1551:9: error: ignoring return value of 'ata_device_read_sector'
declared with attribute 'warn_unused_result' [-Werror=unused-result]
```

## Verification

The natural transient appears about once in eight boots, so both new behaviours were exercised by temporarily injecting failures:

| injection | result |
| --- | --- |
| first attempt fails, 20 reads | **20 recovered on attempt 2, 0 propagated**, suite green at 67 tests, 0 panics |
| every attempt fails | **propagated** as `ata_read: failed to read sector 4 (-16)`, 0 recovered |

The second is the one that matters for the retry: it shows the loop does not mask a genuine failure. Neither injection is in this branch — `grep '__inject' kernel/src/drivers/ata.c` is empty — and **#338** proposes it as a permanent off-by-default knob, which the ext2 failure paths need for the same reason.

On the finished tree: **three consecutive runs, 67 tests, 0 failures, 0 panics**, and no ATA line logged in any of them, so nothing here fires spuriously. Five further runs before the retry was added were also green.

## Scope note

I framed the `ata.c` split as step one of this issue earlier. It is not required by it and would have buried the eight-call-site change in 1800 lines of code motion, so it is left out. The split is still worth doing before the next substantial change to this file, and the write-retry above is a concrete reason to do it.