### PR TITLE
fix(fhs): apply the directory modes the FHS table declares

### DIFF
--- a/kernel/src/fs/ext2/ext2_attr.c
+++ b/kernel/src/fs/ext2/ext2_attr.c
@@ -156,6 +156,14 @@ static int __ext2_setattr(ext2_inode_t *inode, struct iattr *attr)
 static int __ext2_check_setattr_permission(uid_t file_owner)
 {
     task_struct *task = scheduler_get_current_process();
+    // There is no current process during kernel initialization: fhs_initialize
+    // runs at kernel.c:319 and scheduler_initialize at :453. The kernel is not
+    // a user and has nothing to prove, and dereferencing the null task here
+    // would have faulted the moment anything in early boot tried to set an
+    // attribute — which is what fixing #263 needed it to do.
+    if (task == NULL) {
+        return 1;
+    }
     return task->uid == 0 || task->uid == file_owner;
 }
 

--- a/kernel/src/fs/fhs.c
+++ b/kernel/src/fs/fhs.c
@@ -11,6 +11,7 @@
 /// Reference: https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html
 
 #include "fs/fhs.h"
+#include "fs/attr.h"
 #include "fs/vfs.h"
 #include "io/debug.h"
 #include "sys/stat.h"
@@ -71,7 +72,21 @@ static int create_directory_if_not_exists(const char *path, mode_t mode)
     if (stat_result == 0) {
         // Path exists, check if it's a directory
         if (S_ISDIR(stat_buf.st_mode)) {
-            pr_debug("[FHS] Directory already exists: %s\n", path);
+            // Existing is not the same as correct. `/root` is in the staged
+            // rootfs at 0755 and the table asks for 0700, and this function
+            // used to stat it, see a directory and return: the table
+            // documented a contract the code never delivered (#263).
+            mode_t current = stat_buf.st_mode & 07777;
+            mode_t wanted  = mode & 07777;
+            if (current != wanted) {
+                if (sys_chmod(path, wanted) != 0) {
+                    pr_err("[FHS] Failed to set the mode of %s to 0%o (it is 0%o)\n", path, wanted, current);
+                    return -1;
+                }
+                pr_debug("[FHS] Corrected the mode of %s: 0%o -> 0%o\n", path, current, wanted);
+            } else {
+                pr_debug("[FHS] Directory already exists: %s\n", path);
+            }
             return 0;
         } else {
             // Path exists but is not a directory
@@ -80,13 +95,19 @@ static int create_directory_if_not_exists(const char *path, mode_t mode)
         }
     }
 
-    // Directory doesn't exist, create it using vfs_mkdir
-    if (vfs_mkdir(path, mode & 0777) != 0) {
+    // Directory doesn't exist, create it using vfs_mkdir. The mask is 07777
+    // and not 0777 because the low four bits of that nibble are the set-user,
+    // set-group and sticky bits, and 0777 dropped exactly the 01000 that the
+    // table asks for on /tmp and /var/tmp. ext2_mkdir keeps the whole low 12
+    // bits, so the sticky bit was being discarded here and nowhere else,
+    // which left both directories world-writable *without* it: any user could
+    // delete another user's files there (#263).
+    if (vfs_mkdir(path, mode & 07777) != 0) {
         pr_err("[FHS] Failed to create directory: %s\n", path);
         return -1;
     }
 
-    pr_debug("[FHS] Created directory: %s (mode: 0%o)\n", path, mode & 0777);
+    pr_debug("[FHS] Created directory: %s (mode: 0%o)\n", path, mode & 07777);
     return 0;
 }
 

--- a/userspace/tests/t_fhs.c
+++ b/userspace/tests/t_fhs.c
@@ -65,8 +65,13 @@ int main(int argc, char *argv[])
                     syslog(LOG_INFO, "[t_fhs] [PASS] %s (%s) - Mode: 0%o\n", test->path, test->description, actual_mode);
                     passed_tests++;
                 } else {
-                    syslog(LOG_INFO, "[t_fhs] [WARN] %s (%s) - Expected mode 0%o, got 0%o\n", test->path, test->description, expected_mode, actual_mode);
-                    passed_tests++; // Still count as pass since directory exists
+                    // A mode mismatch is a failure, not a warning. It used to
+                    // be counted as a pass "since the directory exists",
+                    // which let /tmp and /var/tmp sit world-writable without
+                    // their sticky bit, and /root at 0755 instead of 0700, on
+                    // every boot with the suite reporting `ok` (#263).
+                    syslog(LOG_ERR, "[t_fhs] [FAIL] %s (%s) - Expected mode 0%o, got 0%o\n", test->path, test->description, expected_mode, actual_mode);
+                    failed_tests++;
                 }
             } else {
                 syslog(LOG_INFO, "[t_fhs] [FAIL] %s - Exists but is not a directory\n", test->path);


### PR DESCRIPTION
Fixes #263

## The defect

`fhs_directories[]` asks for `/tmp` and `/var/tmp` at 01777 and `/root` at 0700. None of the three was ever applied, and the suite reported `ok` on every boot while printing the mismatch:

```
[t_fhs] [WARN] /tmp     - Expected mode 01777, got 0777
[t_fhs] [WARN] /root    - Expected mode 0700,  got 0755
[t_fhs] [WARN] /var/tmp - Expected mode 01777, got 0777
```

The security-relevant instance is the one the issue names: **world-writable `/tmp` and `/var/tmp` without their sticky bit**, so any user could delete another user's files there.

## Two mechanisms

**The creation mask.** `vfs_mkdir(path, mode & 0777)` drops exactly the 01000 the table asks for. `ext2_mkdir` keeps the whole low 12 bits (`mode = S_IFDIR | (0xFFF & mode)`), so the sticky bit was being discarded here and nowhere else. The mask is now 07777.

**Existing directories were never corrected.** `/root` is in the staged rootfs at 0755 — `mke2fs -d` bakes in the source tree's mode — and the function statted it, saw a directory, and returned. It now compares and chmods when they differ.

## One prerequisite, worth flagging

`__ext2_check_setattr_permission` read `scheduler_get_current_process()->uid` with no null check:

```c
    task_struct *task = scheduler_get_current_process();
    return task->uid == 0 || task->uid == file_owner;
```

`fhs_initialize` runs at `kernel.c:319`; `scheduler_initialize` runs at `:453`. So the first attribute set during early boot would have faulted on a null task — which is precisely what this fix needed to do. It now treats the absence of a current process as the kernel's own context, which is permitted: the kernel is not a user and has nothing to prove.

That path was unreachable before, since nothing set an attribute that early, so this is not a latent bug being fixed on the side — it is a trap that this change would have walked into. Calling it out because it is a permission check being loosened, and that deserves to be seen rather than buried.

## Negative control

`t_fhs` counted a mode mismatch as a pass "since the directory exists", which is why three wrong modes shipped on every boot under a green suite. It is a failure now, and with the kernel hunk reverted and the tightened test kept:

```
not ok 20 - t_fhs: Exit: 1
[t_fhs] [FAIL] /tmp     (Temporary files directory)  - Expected mode 01777, got 0777
[t_fhs] [FAIL] /root    (Root home directory)        - Expected mode 0700,  got 0755
[t_fhs] [FAIL] /var/tmp (Temporary variable data)    - Expected mode 01777, got 0777
```

One line per mechanism: the two sticky bits are the creation mask, `/root` is the uncorrected pre-existing directory.

## After the fix

```
[t_fhs] [PASS] /tmp (Temporary files directory) - Mode: 01777
[t_fhs] [PASS] /root (Root home directory) - Mode: 0700
[t_fhs] [PASS] /var/tmp (Temporary variable data) - Mode: 01777
```

## Verification

- Full suite: **67 tests, 0 failures, 0 panics**, two consecutive runs on the finished tree.
- This also removes the last case I know of where the suite printed a defect and reported `ok` anyway.