### PR TITLE
fix(security): treat a syslog message as data, and remove the %n write primitive

### DIFF
--- a/kernel/src/klib/vsprintf.c
+++ b/kernel/src/klib/vsprintf.c
@@ -246,16 +246,6 @@ static void __format_pointer(char **buf, char *end, void *ptr, int width, int fl
     __format_unsigned(buf, end, addr, 16, width - 2, 0, 0);
 }
 
-/// @brief Handles `%n`, storing the number of characters printed so far.
-/// @param count_var Pointer to the integer where the character count is stored.
-/// @param count The number of characters written so far.
-static void __format_count(int *count_var, int count)
-{
-    if (count_var) {
-        *count_var = count;
-    }
-}
-
 int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
 {
     char dummy;
@@ -270,7 +260,6 @@ int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
     }
 
     // Tracks number of characters written.
-    int count = 0;
 
     while (*format) {
         if (*format == '%') {
@@ -420,10 +409,6 @@ int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
                 __format_float(&buf, end, va_arg(args, double), width, precision, flags);
                 break;
             }
-            case 'n': {
-                __format_count(va_arg(args, int *), count);
-                break;
-            }
             case '%': {
                 __emit_char(&buf, end, '%');
                 break;
@@ -439,7 +424,6 @@ int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
         }
 
         format++;
-        count++;
     }
     if (buffer)
         *buf = '\0';

--- a/kernel/src/system/printk.c
+++ b/kernel/src/system/printk.c
@@ -8,5 +8,10 @@
 
 void sys_syslog(const char *file, const char *fun, int line, short log_level, const char *format)
 {
-    dbg_printf(file, fun, line, "[SYSLOG]", log_level, format);
+    // The message comes from user space, so it is an argument and never the
+    // format. Passing it as the format let a caller supply conversion
+    // specifiers to the kernel's own printf, against a variadic list that
+    // does not exist — `%n` writes through a pointer read from the kernel
+    // stack past the real parameters, and `%s` dereferences one (#351).
+    dbg_printf(file, fun, line, "[SYSLOG]", log_level, "%s", format);
 }

--- a/lib/src/syslog.c
+++ b/lib/src/syslog.c
@@ -90,7 +90,9 @@ int __syslog(const char *file, const char *fun, int line, short log_level, const
 
     // If the syslog system call fails and LOG_CONS is set, write to console as a fallback.
     if ((len == -1) && (syslog_options & LOG_CONS)) {
-        fprintf(stderr, buf, len);
+        // The message is an argument, not a format: it holds whatever the
+        // caller wrote, expansions included (#351).
+        fprintf(stderr, "%s", buf);
     }
 
     __syscall_return(int, len);

--- a/lib/src/vsprintf.c
+++ b/lib/src/vsprintf.c
@@ -242,16 +242,6 @@ static void __format_pointer(char **buf, char *end, void *ptr, int width, int fl
     __format_unsigned(buf, end, addr, 16, width - 2, 0, 0);
 }
 
-/// @brief Handles `%n`, storing the number of characters printed so far.
-/// @param count_var Pointer to the integer where the character count is stored.
-/// @param count The number of characters written so far.
-static void __format_count(int *count_var, int count)
-{
-    if (count_var) {
-        *count_var = count;
-    }
-}
-
 int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
 {
     char dummy;
@@ -266,7 +256,6 @@ int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
     }
 
     // Tracks number of characters written.
-    int count = 0;
 
     while (*format) {
         if (*format == '%') {
@@ -416,10 +405,6 @@ int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
                 __format_float(&buf, end, va_arg(args, double), width, precision, flags);
                 break;
             }
-            case 'n': {
-                __format_count(va_arg(args, int *), count);
-                break;
-            }
             case '%': {
                 __emit_char(&buf, end, '%');
                 break;
@@ -435,7 +420,6 @@ int vsnprintf(char *buffer, size_t size, const char *format, va_list args)
         }
 
         format++;
-        count++;
     }
     if (buffer)
         *buf = '\0';

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -59,6 +59,7 @@ static char *all_tests[] = {
     "t_list",
     "t_mem",
     "t_mkdir",
+    "t_syslog_format",
     "t_rmdir_dotfiles",
     "t_stdint",
     "t_mount_boundary",

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TEST_LIST
     t_shm.c
     t_semget.c
     t_mkdir.c
+    t_syslog_format.c
     t_rmdir_dotfiles.c
     t_stdint.c
     t_mount_boundary.c

--- a/userspace/tests/t_syslog_format.c
+++ b/userspace/tests/t_syslog_format.c
@@ -1,0 +1,54 @@
+/// @file t_syslog_format.c
+/// @brief Regression test for #351: a message passed to syslog is data, never
+/// a format string.
+/// @details `sys_syslog` handed the user-supplied message straight to
+/// `dbg_printf` as its format argument, with no variadic arguments after it:
+///
+///     dbg_printf(file, fun, line, "[SYSLOG]", log_level, format);
+///
+/// So any conversion specifier in the message was executed by the kernel's own
+/// printf against an argument list that did not exist. `%s` dereferenced a
+/// pointer read from the kernel stack past the real parameters, and `%n` —
+/// which that printf implemented — *wrote* through one.
+///
+/// The test sends the specifiers that mattered and requires the process to
+/// come back and the system to keep running. It cannot inspect the kernel log
+/// from user space, so what it proves is bounded: that the specifiers reach
+/// the kernel and are survived. The write primitive itself is closed by
+/// removing `%n` from the kernel's printf, which is a compile-time fact rather
+/// than something a test can observe.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+int main(void)
+{
+    openlog("t_syslog_format", LOG_PID | LOG_CONS, LOG_USER);
+
+    // Each of these arrives at the kernel as message *text*. Before the fix
+    // the kernel read them as conversions: %n took a pointer off its own
+    // stack and wrote to it, %s dereferenced one, and %99999999d asked it to
+    // pad to a length no buffer has.
+    syslog(LOG_INFO, "[t_syslog_format] literal percent-n: %%n");
+    syslog(LOG_INFO, "[t_syslog_format] literal percent-s: %%s");
+    syslog(LOG_INFO, "[t_syslog_format] several: %%n %%s %%p %%x");
+    syslog(LOG_INFO, "[t_syslog_format] wide: %%99999999d");
+    syslog(LOG_INFO, "[t_syslog_format] trailing percent: %%");
+
+    // And the same by the route a program is most likely to hit it: the
+    // specifier arriving inside an argument rather than written in the format.
+    const char *from_argument = "%n%n%n%s%s%s";
+    syslog(LOG_INFO, "[t_syslog_format] from an argument: %s", from_argument);
+
+    // Reaching here means every one of those returned. The suite continuing
+    // past this test is what shows the kernel survived them.
+    syslog(LOG_INFO, "[t_syslog_format] the kernel treated every message as text");
+    closelog();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Fixes #351

## The defect

`sys_syslog` handed the user-supplied message to `dbg_printf` as its **format** argument, with no variadic arguments after it:

```c
    dbg_printf(file, fun, line, "[SYSLOG]", log_level, format);
```

Every conversion specifier a program put in its log message was therefore executed by the kernel's own printf against an argument list that did not exist. `__NR_syslog` is registered in `sys_call_table`, and the userspace wrapper formats the caller's message into a buffer and passes that buffer as this parameter, so the path is open to any unprivileged program.

## Negative control, and it found more than I had claimed

I filed the issue from the code, saying only that a write primitive existed and its controllability was unproven. Running the vulnerable state with a test that sends `%n`, `%s`, `%p`, `%x` and a wide field width:

**Kernel memory printed to the console** — `%s` dereferencing pointers off the kernel stack:

```
����Ã�,���������v����D$�D$�$�����D$��&��D$���D$d@��$
```

Those `D$` fragments are x86 operand encodings; that is kernel code and stack bytes.

**Kernel addresses disclosed** — from `%p`/`%x`, `0xc18…` being the kernel's mapped region:

```
0xc183e000 c183e2f0
```

**The whole system wedged** — exit 124 at the emulator timeout, with 35 of 69 tests completed and no further output:

```
ok 34 - t_mem
ok 35 - t_mkdir
                <- t_syslog_format, then nothing
```

So: kernel information disclosure and a local denial of service, both **observed**, from five lines of user code, neither of which needs `%n`. Whether the `%n` write can be *aimed* is still unresolved — I did not try to steer it — but the primitive was live.

With the fix: 69 tests, 0 failures, 0 panics, no kernel address anywhere in the serial log, and every specifier appearing as literal text.

## The fix, and the part I nearly got wrong

- `sys_syslog` passes the message as an argument, with `"%s"` as the format.
- **`%n` removed from both printf implementations.** The kernel's `vsnprintf` is `kernel/src/klib/vsprintf.c`, not `lib/src/vsprintf.c` — `dbg_printf` calls the klib one. My first attempt patched only the userspace copy, which would have left the kernel primitive completely intact; I caught it by checking which object actually defines `vsnprintf`. Nothing in the tree used `%n`, and a freestanding kernel printf has no legitimate use for a write primitive, so removing it closes the class rather than one call site.
- `lib/src/syslog.c`'s `LOG_CONS` fallback used the message as a format too. Same mistake, own process, one line.

## Test

`t_syslog_format` sends the specifiers that mattered, including one arriving *inside an argument* rather than written in the format, which is the route a program is most likely to hit this by accident. It requires the process to return and the suite to continue.

Being explicit about its limits: a userspace test cannot read the kernel log, so the disclosure is demonstrated by the control run above, not asserted by the test. And closing the write primitive is a compile-time fact rather than something any test can observe.

## How it was found

By adding `__attribute__((format(printf, 6, 7)))` to `dbg_printf` while starting #216. The first build said:

```
kernel/src/system/printk.c:11:5: error: format not a string literal and no format arguments [-Werror=format-security]
```

One declaration attribute, and a vulnerability that had been reachable for as long as the syscall existed. #216 is still open and is worth doing on its own merits — it surfaced 75 further format mismatches, six of which are `%s` with no argument at all on VFS error paths.

## Note on release

This shipped in v0.9.7 and every release before it. Worth a decision about whether v0.9.7.1 is warranted — see the issue.