### PR TITLE
feat(test): make block transfers fail on demand, so the storage error paths can be tested

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -14,6 +14,7 @@ option(ENABLE_FILE_TRACE "Enables vfs_file allocation tracing." OFF)
 option(ENABLE_KERNEL_TESTS "Enable kernel-side unit and integration tests" OFF)
 option(ENABLE_PERF "Enables the perf counter facility (klib/perf.h)." OFF)
 option(ENABLE_SCHEDULER_FEEDBACK "Enables scheduling feedback on terminal." OFF)
+option(ENABLE_ATA_FAULT_INJECTION "Enables deliberate failure of block transfers, for testing." OFF)
 
 # =============================================================================
 # Set the list of valid video backends.
@@ -156,6 +157,10 @@ endif()
 # Enables scheduling feedback on terminal.
 if(ENABLE_SCHEDULER_FEEDBACK)
     target_compile_definitions(kernel PUBLIC ENABLE_SCHEDULER_FEEDBACK)
+endif()
+
+if(ENABLE_ATA_FAULT_INJECTION)
+    target_compile_definitions(kernel PUBLIC ENABLE_ATA_FAULT_INJECTION)
 endif()
 
 # =============================================================================

--- a/kernel/inc/io/fault_injection.h
+++ b/kernel/inc/io/fault_injection.h
@@ -1,0 +1,54 @@
+/// @file fault_injection.h
+/// @brief Deliberate failure of block-device transfers, for testing.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+///
+/// @details The storage error paths cannot be tested without this. A sector
+/// read fails on real hardware about once in a few hundred boots (#291), which
+/// is often enough to matter and far too rare to write a test against, so every
+/// fix to those paths has had to ship verified only by inspection and by the
+/// success path continuing to work. That is the gap this closes: with the
+/// failure arriving on demand, the code above the block layer can be exercised
+/// exactly as a failing device would exercise it (#338).
+///
+/// Compiled in only under -DENABLE_ATA_FAULT_INJECTION=ON. When the option is
+/// off the calls are macros that evaluate to 0, so the default build carries
+/// neither the branch nor the state.
+///
+/// Armed through /proc/faultinj:
+///
+///     echo "read 1"  > /proc/faultinj   # fail the next sector read
+///     echo "write 2" > /proc/faultinj   # fail the next two sector writes
+///     echo "off"     > /proc/faultinj   # disarm
+///     cat /proc/faultinj                # what is armed, and what has fired
+
+#pragma once
+
+#ifdef ENABLE_ATA_FAULT_INJECTION
+
+/// @brief Reports whether the next sector read should be failed.
+/// @return the negative errno to fail with, or 0 to let the read proceed.
+/// @details Consumes one of the armed failures when it returns non-zero.
+int ata_fault_inject_read(void);
+
+/// @brief Reports whether the next sector write should be failed.
+/// @return the negative errno to fail with, or 0 to let the write proceed.
+/// @details Consumes one of the armed failures when it returns non-zero.
+int ata_fault_inject_write(void);
+
+/// @brief Arms or disarms the injection.
+/// @param reads how many subsequent reads to fail.
+/// @param writes how many subsequent writes to fail.
+void ata_fault_inject_arm(unsigned reads, unsigned writes);
+
+/// @brief Registers `/proc/faultinj`.
+/// @return 0 on success, 1 on failure.
+int procfaultinj_module_init(void);
+
+#else
+
+/// The option is off: no state, no branch, no cost.
+#define ata_fault_inject_read()  0
+#define ata_fault_inject_write() 0
+
+#endif

--- a/kernel/inc/io/proc_modules.h
+++ b/kernel/inc/io/proc_modules.h
@@ -22,3 +22,9 @@ int procfb_module_init(void);
 /// @brief Initializes the IPC information system.
 /// @return 0 on success, 1 on failure.
 int procipc_module_init(void);
+
+#ifdef ENABLE_ATA_FAULT_INJECTION
+/// @brief Initializes the `/proc/faultinj` entry.
+/// @return 0 on success, 1 on failure.
+int procfaultinj_module_init(void);
+#endif

--- a/kernel/src/drivers/ata.c
+++ b/kernel/src/drivers/ata.c
@@ -13,6 +13,7 @@
 
 #include "drivers/ata/ata.h"
 #include "drivers/ata/ata_types.h"
+#include "io/fault_injection.h"
 
 #include "descriptor_tables/isr.h"
 #include "devices/pci.h"
@@ -1191,6 +1192,14 @@ static bool_t ata_device_init(ata_device_t *dev)
 /// @return 0 on success, negative errno on failure.
 static int ata_device_read_sector_pio(ata_device_t *dev, uint32_t lba_sector, uint8_t *buffer)
 {
+    // Injected failures return before the transfer, which is where every real
+    // error path here leaves off too: the caller's buffer is left untouched,
+    // so the code above sees exactly what a failing device shows it (#338).
+    int injected = ata_fault_inject_read();
+    if (injected != 0) {
+        return injected;
+    }
+
     int rc = 0;
 
     if (ata_status_wait_not(dev, ata_status_bsy, 100000)) {
@@ -1335,6 +1344,12 @@ ata_device_write_sector(ata_device_t *dev, uint32_t lba_sector, uint8_t *buffer)
     if ((dev->type != ata_dev_type_pata) && (dev->type != ata_dev_type_sata)) {
         pr_crit("[%s] Unsupported device type for read operation.\n", ata_get_device_settings_str(dev));
         return -EPERM;
+    }
+
+    // As for the read: fail before anything reaches the device (#338).
+    int injected = ata_fault_inject_write();
+    if (injected != 0) {
+        return injected;
     }
 
     // Acquire the lock for thread safety.

--- a/kernel/src/io/proc_faultinj.c
+++ b/kernel/src/io/proc_faultinj.c
@@ -1,0 +1,185 @@
+/// @file proc_faultinj.c
+/// @brief `/proc/faultinj`: deliberate failure of block-device transfers.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+// Setup the logging for this file (do this before any other include).
+#include "sys/kernel_levels.h"           // Include kernel log levels.
+#define __DEBUG_HEADER__ "[FAULTI]"      ///< Change header.
+#define __DEBUG_LEVEL__  LOGLEVEL_NOTICE ///< Set log level.
+#include "io/debug.h"                    // Include debugging functions.
+
+#include "io/fault_injection.h"
+
+#ifdef ENABLE_ATA_FAULT_INJECTION
+
+#include "fs/procfs.h"
+#include "stdio.h"
+#include "string.h"
+#include "errno.h"
+
+/// @brief How many transfers are still to be failed, and how many have been.
+/// @details A single-processor, non-preemptible kernel reaches the block layer
+///          one request at a time, so plain counters need no locking here. If
+///          that stops being true this state has to be revisited along with
+///          everything else that assumes it.
+static struct {
+    unsigned reads_armed;     ///< Reads still to be failed.
+    unsigned writes_armed;    ///< Writes still to be failed.
+    unsigned reads_injected;  ///< Reads failed since the last arming.
+    unsigned writes_injected; ///< Writes failed since the last arming.
+} __faultinj;
+
+int ata_fault_inject_read(void)
+{
+    if (__faultinj.reads_armed == 0) {
+        return 0;
+    }
+    --__faultinj.reads_armed;
+    ++__faultinj.reads_injected;
+    // -EIO rather than -EBUSY: a caller that retries transient statuses must
+    // still see a hard failure propagate, and -EIO is the one the retry does
+    // not swallow.
+    pr_notice("Injecting a read failure (%u left armed).\n", __faultinj.reads_armed);
+    return -EIO;
+}
+
+int ata_fault_inject_write(void)
+{
+    if (__faultinj.writes_armed == 0) {
+        return 0;
+    }
+    --__faultinj.writes_armed;
+    ++__faultinj.writes_injected;
+    pr_notice("Injecting a write failure (%u left armed).\n", __faultinj.writes_armed);
+    return -EIO;
+}
+
+void ata_fault_inject_arm(unsigned reads, unsigned writes)
+{
+    __faultinj.reads_armed     = reads;
+    __faultinj.writes_armed    = writes;
+    __faultinj.reads_injected  = 0;
+    __faultinj.writes_injected = 0;
+    pr_notice("Armed for %u read and %u write failures.\n", reads, writes);
+}
+
+/// @brief Reports what is armed and what has fired.
+/// @param file the file to read from.
+/// @param buf the buffer where the data is placed.
+/// @param offset the offset to read from.
+/// @param nbyte the size of the buffer.
+/// @return the number of bytes placed in the buffer.
+static ssize_t procfaultinj_read(vfs_file_t *file, char *buf, off_t offset, size_t nbyte)
+{
+    char content[128];
+    int written = sprintf(
+        content, "reads_armed %u\nwrites_armed %u\nreads_injected %u\nwrites_injected %u\n", __faultinj.reads_armed,
+        __faultinj.writes_armed, __faultinj.reads_injected, __faultinj.writes_injected);
+    if (written < 0) {
+        return -EIO;
+    }
+    // A read past the end is end of file, not an error.
+    if (offset >= written) {
+        return 0;
+    }
+    size_t available = (size_t)(written - offset);
+    size_t to_copy   = (nbyte < available) ? nbyte : available;
+    memcpy(buf, content + offset, to_copy);
+    return (ssize_t)to_copy;
+}
+
+/// @brief Arms the injection from a written command.
+/// @param file the file to write to.
+/// @param buf the buffer holding the command.
+/// @param offset ignored: a write is a command, not a position in a file.
+/// @param nbyte the length of the command.
+/// @return the number of bytes consumed, or a negative errno.
+/// @details Accepts `read <n>`, `write <n>` and `off`. Anything else is
+///          rejected with -EINVAL rather than partially applied, so a
+///          mistyped command cannot leave the injection in a state the test
+///          did not ask for.
+static ssize_t procfaultinj_write(vfs_file_t *file, const void *buf, off_t offset, size_t nbyte)
+{
+    char command[64];
+    if (nbyte == 0) {
+        return 0;
+    }
+    if (nbyte >= sizeof(command)) {
+        return -EINVAL;
+    }
+    memcpy(command, buf, nbyte);
+    command[nbyte] = 0;
+    // Drop a trailing newline, so `echo` works without `-n`.
+    if ((nbyte > 0) && (command[nbyte - 1] == '\n')) {
+        command[nbyte - 1] = 0;
+    }
+
+    if (strcmp(command, "off") == 0) {
+        ata_fault_inject_arm(0, 0);
+        return (ssize_t)nbyte;
+    }
+    // The count is whatever follows the keyword and a single space.
+    unsigned count = 0;
+    const char *rest;
+    if (strncmp(command, "read ", 5) == 0) {
+        rest = command + 5;
+    } else if (strncmp(command, "write ", 6) == 0) {
+        rest = command + 6;
+    } else {
+        pr_err("Unrecognized command `%s`.\n", command);
+        return -EINVAL;
+    }
+    // Parse by hand: the count has to be digits and nothing else, so that a
+    // typo is refused instead of silently becoming zero.
+    if (*rest == 0) {
+        return -EINVAL;
+    }
+    for (const char *c = rest; *c != 0; ++c) {
+        if ((*c < '0') || (*c > '9')) {
+            pr_err("Not a count: `%s`.\n", rest);
+            return -EINVAL;
+        }
+        count = (count * 10U) + (unsigned)(*c - '0');
+    }
+    if (command[0] == 'r') {
+        ata_fault_inject_arm(count, __faultinj.writes_armed);
+    } else {
+        ata_fault_inject_arm(__faultinj.reads_armed, count);
+    }
+    return (ssize_t)nbyte;
+}
+
+/// Filesystem file operations for the entry.
+static vfs_file_operations_t procfaultinj_fs_operations = {
+    .open_f     = NULL,
+    .unlink_f   = NULL,
+    .close_f    = NULL,
+    .read_f     = procfaultinj_read,
+    .write_f    = procfaultinj_write,
+    .lseek_f    = NULL,
+    .stat_f     = NULL,
+    .ioctl_f    = NULL,
+    .getdents_f = NULL,
+    .readlink_f = NULL,
+};
+
+int procfaultinj_module_init(void)
+{
+    proc_dir_entry_t *entry = proc_create_entry("faultinj", NULL);
+    if (entry == NULL) {
+        pr_err("Cannot create `/proc/faultinj`.\n");
+        return 1;
+    }
+    entry->fs_operations = &procfaultinj_fs_operations;
+    // Writable, and only by root: arming this makes the filesystem return
+    // errors on demand, which is a way to lose data if it is left armed.
+    if (proc_entry_set_mask(entry, 0600) < 0) {
+        pr_err("Cannot set mask of `/proc/faultinj`.\n");
+        return 1;
+    }
+    pr_notice("Fault injection is available at `/proc/faultinj`.\n");
+    return 0;
+}
+
+#endif // ENABLE_ATA_FAULT_INJECTION

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -374,6 +374,15 @@ int kmain(boot_info_t *boot_informations)
         print_fail();
         kernel_panic("Failed to initialize the IPC information system.");
     }
+
+#ifdef ENABLE_ATA_FAULT_INJECTION
+    // Only present when the option is on: it exists to make the block layer
+    // fail on demand, which is a testing facility and not something a normal
+    // build should offer (#338).
+    if (procfaultinj_module_init()) {
+        pr_err("Failed to initialize the fault injection entry.\n");
+    }
+#endif
     print_ok();
 
     //==========================================================================

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -97,6 +97,7 @@ static char *all_tests[] = {
     "t_time",
     "t_wifsignaled",
     "t_write_read",
+    "t_faultinj",
 };
 
 static char **tests = &all_tests[0];

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TEST_LIST
     t_shm.c
     t_semget.c
     t_mkdir.c
+    t_faultinj.c
     t_syslog_format.c
     t_rmdir_dotfiles.c
     t_stdint.c

--- a/userspace/tests/t_faultinj.c
+++ b/userspace/tests/t_faultinj.c
@@ -1,0 +1,244 @@
+/// @file t_faultinj.c
+/// @brief Checks the block-transfer fault injection of #338.
+/// @details The storage error paths had no test that reached them: a sector
+/// read fails on real hardware about once in a few hundred boots (#291), which
+/// is far too rare to write a test against. `/proc/faultinj` makes the failure
+/// arrive on demand, so the code above the block layer can be exercised the way
+/// a failing device exercises it.
+///
+/// This test checks the facility itself, and in doing so pins both halves of
+/// #291's retry, which was previously only demonstrable with a temporary patch:
+/// the injection sits inside `ata_device_read_sector_pio`, which the retry loop
+/// calls up to ATA_TRANSFER_ATTEMPTS times, so arming *one* failure is
+/// recovered and the operation succeeds, while arming three outlasts the retry
+/// and propagates. The issues the facility exists to serve (#342, #343, #344)
+/// get their own tests on top of it.
+///
+/// The facility is compiled in only under -DENABLE_ATA_FAULT_INJECTION=ON, so
+/// `/proc/faultinj` is absent from a default build. That is not a failure: the
+/// test reports it and passes, which is what lets it stay registered in the
+/// suite permanently instead of being commented in and out.
+///
+/// A word of warning for anyone turning the option on: an injected failure
+/// lands on whatever transfer comes next, including one belonging to the
+/// filesystem's own bookkeeping, so a run with this armed can leave the image
+/// inconsistent. The emulator opens the disk with `snapshot=on`, so nothing
+/// survives the run, and the option is off by default.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The control file.
+#define CONTROL "/proc/faultinj"
+
+/// A file of our own to operate on, so an injected failure lands on something
+/// this test owns rather than on an unrelated part of the filesystem.
+#define VICTIM "/home/user/t_faultinj.bin"
+
+/// @brief Sends a command to the control file.
+/// @param command the command to send.
+/// @return 0 when it was accepted, -1 otherwise.
+static int __arm(const char *command)
+{
+    int fd = open(CONTROL, O_WRONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_faultinj] open of " CONTROL " for writing: %s", strerror(errno));
+        return -1;
+    }
+    ssize_t written = write(fd, command, strlen(command));
+    close(fd);
+    if (written != (ssize_t)strlen(command)) {
+        syslog(LOG_ERR, "[t_faultinj] `%s` returned %zd", command, written);
+        return -1;
+    }
+    return 0;
+}
+
+/// @brief Reads a counter out of the control file.
+/// @param name the counter to read.
+/// @param value where the value is stored.
+/// @return 0 on success, -1 on failure.
+static int __counter(const char *name, unsigned *value)
+{
+    int fd = open(CONTROL, O_RDONLY, 0);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_faultinj] open of " CONTROL " for reading: %s", strerror(errno));
+        return -1;
+    }
+    char buffer[192] = {0};
+    ssize_t bytes    = read(fd, buffer, sizeof(buffer) - 1);
+    close(fd);
+    if (bytes <= 0) {
+        syslog(LOG_ERR, "[t_faultinj] reading " CONTROL " returned %zd", bytes);
+        return -1;
+    }
+    char *at = strstr(buffer, name);
+    if (at == NULL) {
+        syslog(LOG_ERR, "[t_faultinj] " CONTROL " does not report `%s`", name);
+        return -1;
+    }
+    at += strlen(name);
+    while (*at == ' ') {
+        ++at;
+    }
+    *value = 0;
+    for (; (*at >= '0') && (*at <= '9'); ++at) {
+        *value = (*value * 10U) + (unsigned)(*at - '0');
+    }
+    return 0;
+}
+
+/// @brief Rejects a command that is not one of the three accepted forms.
+/// @param command the command to send.
+/// @return 0 when it was refused, -1 when it was accepted.
+static int __check_rejected(const char *command)
+{
+    int fd = open(CONTROL, O_WRONLY, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    errno           = 0;
+    ssize_t written = write(fd, command, strlen(command));
+    close(fd);
+    if (written >= 0) {
+        syslog(LOG_ERR, "[t_faultinj] the malformed command `%s` was accepted", command);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    // Absent means the option is off, which is the default and not a failure.
+    // Checked by opening it, because this libc has no access(2).
+    int probe = open(CONTROL, O_RDONLY, 0);
+    if (probe < 0) {
+        syslog(LOG_INFO, "[t_faultinj] " CONTROL " is absent: built without ENABLE_ATA_FAULT_INJECTION, nothing to do");
+        return EXIT_SUCCESS;
+    }
+    close(probe);
+
+    int failures = 0;
+
+    // Something to operate on, created before anything is armed.
+    int fd = creat(VICTIM, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "[t_faultinj] creating " VICTIM ": %s", strerror(errno));
+        return EXIT_FAILURE;
+    }
+    if (write(fd, "fault", 5) != 5) {
+        syslog(LOG_ERR, "[t_faultinj] writing " VICTIM ": %s", strerror(errno));
+        close(fd);
+        unlink(VICTIM);
+        return EXIT_FAILURE;
+    }
+    close(fd);
+
+    // A malformed command must be refused outright rather than partly applied.
+    if (__check_rejected("nonsense") < 0) {
+        ++failures;
+    }
+    if (__check_rejected("read ") < 0) {
+        ++failures;
+    }
+    if (__check_rejected("read seven") < 0) {
+        ++failures;
+    }
+
+    // One armed failure is *recovered*, not propagated: ata_device_read_sector
+    // retries a failed transfer up to ATA_TRANSFER_ATTEMPTS times (#291), and
+    // the injection sits inside the function the retry loop calls. So arming
+    // one failure exercises the retry, and the operation has to succeed.
+    if (__arm("read 1") < 0) {
+        ++failures;
+    } else {
+        int victim = open(VICTIM, O_RDONLY, 0);
+        if (victim < 0) {
+            syslog(LOG_ERR, "[t_faultinj] one injected failure was not recovered by the retry: %s", strerror(errno));
+            ++failures;
+        } else {
+            close(victim);
+        }
+        unsigned injected = 0;
+        if (__counter("reads_injected", &injected) < 0) {
+            ++failures;
+        } else if (injected != 1) {
+            syslog(LOG_ERR, "[t_faultinj] reads_injected is %u after arming one, expected 1", injected);
+            ++failures;
+        }
+    }
+
+    // Enough failures must eventually reach a read the operation cannot do
+    // without. Three is ATA_TRANSFER_ATTEMPTS, so three exhausts the retry for
+    // one sector and propagates out of ata_read — but not necessarily out of
+    // the syscall, because path resolution absorbs an I/O error on the way:
+    // `__is_a_link` in namei.c reads "stat failed" as "not a link" and carries
+    // on. Three injected failures were observed doing exactly that, with
+    // `Failed to read the inode (2)` in the log and `open` still succeeding.
+    // Filed separately; here the count is simply raised past the reads that
+    // are tolerated, so the failure lands on one that is load-bearing.
+    if (__arm("read 30") < 0) {
+        ++failures;
+    } else {
+        errno       = 0;
+        int victim  = open(VICTIM, O_RDONLY, 0);
+        int op_fail = (victim < 0);
+        if (victim >= 0) {
+            char buffer[8];
+            op_fail = (read(victim, buffer, sizeof(buffer)) < 0);
+            close(victim);
+        }
+        if (!op_fail) {
+            syslog(LOG_ERR, "[t_faultinj] a persistently failing device did not make the operation fail");
+            ++failures;
+        }
+        // The facility has to say it fired, which is what distinguishes "the
+        // injection worked" from "the operation failed for its own reasons".
+        unsigned injected = 0;
+        if (__counter("reads_injected", &injected) < 0) {
+            ++failures;
+        } else if (injected < 3) {
+            syslog(LOG_ERR, "[t_faultinj] reads_injected is %u, expected at least 3", injected);
+            ++failures;
+        }
+    }
+
+    // Disarming has to restore normal operation: the point of the facility is
+    // that it is off unless asked for, and a test that could not read the file
+    // afterwards would not have shown that.
+    if (__arm("off") < 0) {
+        ++failures;
+    } else {
+        int victim = open(VICTIM, O_RDONLY, 0);
+        if (victim < 0) {
+            syslog(LOG_ERR, "[t_faultinj] " VICTIM " unreadable after disarming: %s", strerror(errno));
+            ++failures;
+        } else {
+            char buffer[8] = {0};
+            ssize_t bytes  = read(victim, buffer, sizeof(buffer) - 1);
+            close(victim);
+            if ((bytes != 5) || (strcmp(buffer, "fault") != 0)) {
+                syslog(LOG_ERR, "[t_faultinj] " VICTIM " reads back %zd bytes `%s` after disarming", bytes, buffer);
+                ++failures;
+            }
+        }
+    }
+
+    unlink(VICTIM);
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_faultinj] arming makes a transfer fail, disarming restores it");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_faultinj] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #338

## Why

The storage error paths had no test that reached them. A sector read fails on real hardware about once in a few hundred boots, which is often enough to matter and far too rare to write a test against. So every fix to those paths has shipped verified only by inspection plus the success path continuing to work: **#291** had to be demonstrated with a temporary patch I then deleted, and **#324** could not cover its `-EIO` cause at all.

## The facility

```
echo "read 1"  > /proc/faultinj   # fail the next sector read
echo "write 2" > /proc/faultinj   # fail the next two sector writes
echo "off"     > /proc/faultinj   # disarm
cat /proc/faultinj                # what is armed, and what has fired
```

The injection sits inside `ata_device_read_sector_pio` and the write counterpart, **before** the transfer — which is where every real error path in those functions leaves off too, so the caller's buffer is untouched and the code above sees exactly what a failing device shows it.

Malformed commands are refused with `-EINVAL` rather than partly applied, so a typo cannot leave the injection in a state the test did not ask for. The entry is mode 0600: leaving it armed is a way to lose data.

## The default build keeps nothing

Compiled in only under `-DENABLE_ATA_FAULT_INJECTION=ON`. With it off:

```
$ size build/kernel/CMakeFiles/kernel.dir/src/io/proc_faultinj.c.o
   text	   data	    bss	    dec	    hex	filename
      0	      0	      0	      0	      0
```

The only remaining symbol is a `-g3` macro-tracking marker, not code. I checked this rather than asserting it, because "off by default" is worth nothing if the branch is still in the hot path.

## Two things it found while being written

Both worth more than the facility itself.

**It pins both halves of #291's retry.** The injection is inside the function the retry loop calls, so arming *one* failure is recovered and the operation succeeds, while arming enough to outlast the retry propagates. Earlier today I could only show that with a temporary hack; the test now asserts both directions permanently.

**An I/O error during path resolution is silently absorbed.** Three injected failures produced this, with the `open` still succeeding:

```
[ATA   ] ata_read: failed to read sector 40 (-5)
[EXT2  ] Failed to read inode table block (inode 2, block 5).
[EXT2  ] Failed to read the inode (2).
```

Inode 2 is the root directory. `__is_a_link` in `namei.c` reads "stat failed" as "not a link" and carries on. Filed as **#353** rather than changed here, because whether resolution should fail on an I/O error is a decision, not an oversight — and the honest fix is to distinguish `-ENOENT` from a device error, which the code currently cannot.

That finding is also why the test arms a larger count than three: the small counts are absorbed, so the comment says so and the count is raised past the reads that are tolerated.

## The test

`t_faultinj` is registered permanently and reports the facility as absent when the option is off, so it never needs commenting in and out — unlike `t_nospace`. It runs late in the suite, because an injected failure lands on whatever transfer comes next, including the filesystem's own bookkeeping; the emulator's `snapshot=on` is what keeps that from surviving the run.

## Verification

| build | result |
| --- | --- |
| `-DENABLE_ATA_FAULT_INJECTION=OFF` (default) | **70 tests, 0 failures, 0 panics**, test reports the facility absent and passes |
| `-DENABLE_ATA_FAULT_INJECTION=ON` | **70 tests, 0 failures, 0 panics**, test exercises retry-recovered and propagated failures |

One process note: CMake **caches** options, so `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` after an `ON` configure leaves it on. I was briefly fooled by that and reported an OFF result that was really an ON build; both numbers above come from explicit `-DENABLE_ATA_FAULT_INJECTION=OFF`/`=ON` configures.

## Next

This unblocks #344, #342 and #343 — the ext2 read-modify-write family — which is where I am going next, and where the injection should be pointed first.