### PR TITLE
fix(ext2): never write a metadata block that could not be read

### DIFF
--- a/kernel/inc/io/fault_injection.h
+++ b/kernel/inc/io/fault_injection.h
@@ -17,19 +17,28 @@
 ///
 /// Armed through /proc/faultinj:
 ///
-///     echo "read 1"  > /proc/faultinj   # fail the next sector read
-///     echo "write 2" > /proc/faultinj   # fail the next two sector writes
-///     echo "off"     > /proc/faultinj   # disarm
-///     cat /proc/faultinj                # what is armed, and what has fired
+///     echo "read 1"          > /proc/faultinj  # fail the next sector read
+///     echo "read 3 sector 40" > /proc/faultinj  # fail reads of sector 40 only
+///     echo "read 3 sector 40 skip 1" > /proc/faultinj  # ... after letting one through
+///     echo "write 2"         > /proc/faultinj  # fail the next two writes
+///     echo "off"             > /proc/faultinj  # disarm
+///     cat /proc/faultinj                       # armed, fired, last sector read
 
 #pragma once
 
+#include "stdint.h"
+
 #ifdef ENABLE_ATA_FAULT_INJECTION
 
-/// @brief Reports whether the next sector read should be failed.
+/// @brief Reports whether a read of the given sector should be failed.
+/// @param lba_sector the sector about to be read.
 /// @return the negative errno to fail with, or 0 to let the read proceed.
-/// @details Consumes one of the armed failures when it returns non-zero.
-int ata_fault_inject_read(void);
+/// @details Consumes one of the armed failures when it returns non-zero, and
+///          records the sector so a test can discover which one carries the
+///          metadata it wants to fail. Arming a specific sector is the only
+///          way to reach a read-modify-write: a count alone is spent by
+///          whatever reads first, which is path resolution.
+int ata_fault_inject_read(uint32_t lba_sector);
 
 /// @brief Reports whether the next sector write should be failed.
 /// @return the negative errno to fail with, or 0 to let the write proceed.
@@ -39,7 +48,15 @@ int ata_fault_inject_write(void);
 /// @brief Arms or disarms the injection.
 /// @param reads how many subsequent reads to fail.
 /// @param writes how many subsequent writes to fail.
-void ata_fault_inject_arm(unsigned reads, unsigned writes);
+/// @param sector the sector to restrict read failures to, or 0 for any.
+/// @param skip how many matching reads to let through before failing any.
+/// @details `skip` is what makes a read-modify-write reachable. Every path
+///          that writes a metadata block reads something from the same block
+///          first, through a function that already checks its read, so an
+///          unskipped failure stops the operation before it gets to the
+///          write-back. Skipping the first match lets that earlier read
+///          succeed and fails the one that matters.
+void ata_fault_inject_arm(unsigned reads, unsigned writes, uint32_t sector, unsigned skip);
 
 /// @brief Registers `/proc/faultinj`.
 /// @return 0 on success, 1 on failure.
@@ -48,7 +65,7 @@ int procfaultinj_module_init(void);
 #else
 
 /// The option is off: no state, no branch, no cost.
-#define ata_fault_inject_read()  0
-#define ata_fault_inject_write() 0
+#define ata_fault_inject_read(sector) 0
+#define ata_fault_inject_write()      0
 
 #endif

--- a/kernel/src/drivers/ata.c
+++ b/kernel/src/drivers/ata.c
@@ -1195,7 +1195,7 @@ static int ata_device_read_sector_pio(ata_device_t *dev, uint32_t lba_sector, ui
     // Injected failures return before the transfer, which is where every real
     // error path here leaves off too: the caller's buffer is left untouched,
     // so the code above sees exactly what a failing device shows it (#338).
-    int injected = ata_fault_inject_read();
+    int injected = ata_fault_inject_read(lba_sector);
     if (injected != 0) {
         return injected;
     }

--- a/kernel/src/fs/ext2/ext2_alloc.c
+++ b/kernel/src/fs/ext2/ext2_alloc.c
@@ -241,7 +241,12 @@ uint32_t ext2_allocate_block(ext2_filesystem_t *fs)
 /// @brief Frees a block.
 /// @param fs the filesystem.
 /// @param block_index the index of the block we are freeing.
-void ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index)
+/// @return 0 on success, -1 when the block could not be released.
+/// @details A block that cannot be freed is a leak. A group whose bitmap is
+///          wrongly rewritten is corruption, and the allocator will hand out
+///          blocks that are in use. Leaking is by far the lesser harm, so
+///          nothing is written unless the bitmap was read first (#342).
+int ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index)
 {
     uint32_t group_index  = ext2_block_index_to_group_index(fs, block_index);
     uint32_t group_offset = ext2_block_index_to_group_offset(fs, block_index);
@@ -253,13 +258,25 @@ void ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index)
 
     // Allocate the cache.
     uint8_t *cache = ext2_alloc_cache(fs);
-    // Read the bitmap.
-    ext2_read_block(fs, block_bitmap, cache);
+    if (cache == NULL) {
+        pr_err("Failed to allocate the cache to free block %u.\n", block_index);
+        return -1;
+    }
+    // Read the bitmap. `ext2_alloc_cache` zeroes what it returns, so a failed
+    // read leaves an all-zero bitmap rather than a stale one: writing that
+    // back would mark every block in the group free.
+    if (ext2_read_block(fs, block_bitmap, cache) < 0) {
+        pr_err("Failed to read the block bitmap %u; block %u stays allocated.\n", block_bitmap, block_index);
+        ext2_dealloc_cache(cache);
+        return -1;
+    }
     // Set it as free.
     ext2_bitmap_clear(cache, group_offset);
-    // Write back the inode bitmap.
+    // Write back the block bitmap.
     if (ext2_write_block(fs, block_bitmap, cache) < 0) {
         pr_err("We failed to write back the block_bitmap.\n");
+        ext2_dealloc_cache(cache);
+        return -1;
     }
     // Free the cache.
     ext2_dealloc_cache(cache);
@@ -276,16 +293,18 @@ void ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index)
     if (ext2_write_superblock(fs) < 0) {
         pr_warning("Failed to write superblock.\n");
     }
+    return 0;
 }
 
 /// @brief Frees the blocks that hold the block pointers of an inode.
 /// @param fs the filesystem.
 /// @param inode the inode whose index blocks are freed.
+/// @return 0 when every block was released, -1 when any was kept.
 /// @details The data blocks of a file are reached through these, so they must
 ///          be freed after the data blocks, and they belong to the file just
 ///          as much: leaving them behind lost a block per indirection level on
 ///          every deletion (#302).
-static void __ext2_free_index_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
+static int __ext2_free_index_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
 {
     uint32_t pointers = fs->pointers_per_block;
     uint8_t *outer    = ext2_alloc_cache(fs);
@@ -294,60 +313,99 @@ static void __ext2_free_index_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
         pr_err("Failed to allocate the cache to free the index blocks.\n");
         ext2_dealloc_cache(outer);
         ext2_dealloc_cache(inner);
-        return;
+        return -1;
     }
+    // An index block is the only record of which blocks it points at, so
+    // freeing one whose contents could not be read loses that record for good:
+    // the blocks under it stay marked used with nothing naming them, and no
+    // later pass can find them. Every level below therefore keeps the index
+    // block when its read fails, and reports it. A leak that is still
+    // described on disk can be recovered by a checker; one whose description
+    // has been released cannot (#343).
+    int failure = 0;
+
     // The single-indirect block holds pointers only.
     if (inode->data.blocks.indir_block != 0) {
-        ext2_free_block(fs, inode->data.blocks.indir_block);
-        inode->data.blocks.indir_block = 0;
+        if (ext2_free_block(fs, inode->data.blocks.indir_block) < 0) {
+            failure = -1;
+        } else {
+            inode->data.blocks.indir_block = 0;
+        }
     }
     // The doubly-indirect block points at a level of index blocks.
     if (inode->data.blocks.doubly_indir_block != 0) {
-        if (ext2_read_block(fs, inode->data.blocks.doubly_indir_block, outer) != -1) {
+        if (ext2_read_block(fs, inode->data.blocks.doubly_indir_block, outer) == -1) {
+            pr_err(
+                "Cannot read the doubly-indirect block %u: keeping it, so what it points at stays findable.\n",
+                inode->data.blocks.doubly_indir_block);
+            failure = -1;
+        } else {
             for (uint32_t index = 0; index < pointers; ++index) {
                 uint32_t block = ((uint32_t *)outer)[index];
-                if (block != 0) {
-                    ext2_free_block(fs, block);
+                if ((block != 0) && (ext2_free_block(fs, block) < 0)) {
+                    failure = -1;
                 }
             }
+            if (ext2_free_block(fs, inode->data.blocks.doubly_indir_block) < 0) {
+                failure = -1;
+            } else {
+                inode->data.blocks.doubly_indir_block = 0;
+            }
         }
-        ext2_free_block(fs, inode->data.blocks.doubly_indir_block);
-        inode->data.blocks.doubly_indir_block = 0;
     }
     // The trebly-indirect block points at two levels of index blocks.
     if (inode->data.blocks.trebly_indir_block != 0) {
-        if (ext2_read_block(fs, inode->data.blocks.trebly_indir_block, outer) != -1) {
+        if (ext2_read_block(fs, inode->data.blocks.trebly_indir_block, outer) == -1) {
+            pr_err(
+                "Cannot read the trebly-indirect block %u: keeping it, so what it points at stays findable.\n",
+                inode->data.blocks.trebly_indir_block);
+            failure = -1;
+        } else {
             for (uint32_t index = 0; index < pointers; ++index) {
                 uint32_t middle = ((uint32_t *)outer)[index];
                 if (middle == 0) {
                     continue;
                 }
-                if (ext2_read_block(fs, middle, inner) != -1) {
-                    for (uint32_t inner_index = 0; inner_index < pointers; ++inner_index) {
-                        uint32_t block = ((uint32_t *)inner)[inner_index];
-                        if (block != 0) {
-                            ext2_free_block(fs, block);
-                        }
+                if (ext2_read_block(fs, middle, inner) == -1) {
+                    pr_err("Cannot read the index block %u: keeping it, so what it points at stays findable.\n", middle);
+                    failure = -1;
+                    continue;
+                }
+                for (uint32_t inner_index = 0; inner_index < pointers; ++inner_index) {
+                    uint32_t block = ((uint32_t *)inner)[inner_index];
+                    if ((block != 0) && (ext2_free_block(fs, block) < 0)) {
+                        failure = -1;
                     }
                 }
-                ext2_free_block(fs, middle);
+                if (ext2_free_block(fs, middle) < 0) {
+                    failure = -1;
+                }
+            }
+            // Only release the top of the tree once every level under it is
+            // accounted for, for the same reason.
+            if (failure == 0) {
+                if (ext2_free_block(fs, inode->data.blocks.trebly_indir_block) < 0) {
+                    failure = -1;
+                } else {
+                    inode->data.blocks.trebly_indir_block = 0;
+                }
             }
         }
-        ext2_free_block(fs, inode->data.blocks.trebly_indir_block);
-        inode->data.blocks.trebly_indir_block = 0;
     }
     ext2_dealloc_cache(outer);
     ext2_dealloc_cache(inner);
+    return failure;
 }
 
 /// @brief Frees every block that belongs to an inode, data and index alike.
 /// @param fs a pointer to the filesystem.
 /// @param inode the inode whose blocks are released.
+/// @return 0 when every block was released, -1 when any was kept.
 /// @details The block pointers and the sector count are cleared, so the inode
 ///          is left describing a file with no blocks at all. `size` is the
 ///          caller's: releasing the blocks of a file and declaring it empty
 ///          are two different things, and only truncation does both.
-void ext2_free_inode_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
+int ext2_free_inode_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
 {
     // How many blocks the size says the file holds. Sparse files legally
     // contain holes, so a null pointer inside that range is skipped rather
@@ -356,26 +414,37 @@ void ext2_free_inode_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode)
 
     // Free the data blocks first: they are reached through the index blocks,
     // which the next step releases.
+    int failure = 0;
     for (uint32_t block_index = 0; block_index < block_number; ++block_index) {
         // Get the real index.
         uint32_t real_index = ext2_get_real_block_index(fs, inode, block_index);
         if (real_index == 0) {
             continue;
         }
-        ext2_free_block(fs, real_index);
+        if (ext2_free_block(fs, real_index) < 0) {
+            failure = -1;
+        }
     }
 
     // Free the blocks that held the pointers to those data blocks (#302).
-    __ext2_free_index_blocks(fs, inode);
+    if (__ext2_free_index_blocks(fs, inode) < 0) {
+        failure = -1;
+    }
 
     // Nothing points anywhere any more, and the inode owns no sector. The
     // write path derives the blocks it still has to allocate from
     // `blocks_count`, so leaving it set would make it skip allocating the
     // blocks it just gave back.
-    for (uint32_t index = 0; index < EXT2_DIRECT_BLOCKS; ++index) {
-        inode->data.blocks.dir_blocks[index] = 0;
+    // Only claim the inode owns nothing when it really owns nothing. Clearing
+    // the pointers after a block was kept would lose the record of it, which
+    // is the mistake #343 is about one level down.
+    if (failure == 0) {
+        for (uint32_t index = 0; index < EXT2_DIRECT_BLOCKS; ++index) {
+            inode->data.blocks.dir_blocks[index] = 0;
+        }
+        inode->blocks_count = 0;
     }
-    inode->blocks_count = 0;
+    return failure;
 }
 
 /// @brief Frees the given inode.
@@ -396,18 +465,36 @@ int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_i
     pr_debug(
         "ext2_free_inode(group: %4u, inode_index: %4u, group_offset: %4u)\n", group_index, inode_index, group_offset);
 
-    // Give back every block the inode owns, data and index alike.
-    ext2_free_inode_blocks(fs, inode);
+    // Give back every block the inode owns, data and index alike. A block that
+    // stays behind is a leak, and the inode is being freed either way, so this
+    // is reported rather than aborted: stopping here would leave the inode
+    // marked in use as well as the blocks.
+    if (ext2_free_inode_blocks(fs, inode) < 0) {
+        pr_err("Failed to release every block of inode %u; they stay allocated.\n", inode_index);
+    }
 
     // Allocate the cache.
     uint8_t *cache = ext2_alloc_cache(fs);
-    // Read the bitmap.
-    ext2_read_block(fs, inode_bitmap, cache);
+    if (cache == NULL) {
+        pr_err("Failed to allocate the cache to free inode %u.\n", inode_index);
+        return -1;
+    }
+    // Read the bitmap. As in ext2_free_block: the cache comes back zeroed, so
+    // writing it after a failed read would mark every inode in the group free
+    // (#342). An inode that stays allocated is a leak; a group wrongly marked
+    // free lets the allocator reuse inodes that are in use.
+    if (ext2_read_block(fs, inode_bitmap, cache) < 0) {
+        pr_err("Failed to read the inode bitmap %u; inode %u stays allocated.\n", inode_bitmap, inode_index);
+        ext2_dealloc_cache(cache);
+        return -1;
+    }
     // Set it as free.
     ext2_bitmap_clear(cache, group_offset);
     // Write back the inode bitmap.
     if (ext2_write_block(fs, inode_bitmap, cache) < 0) {
         pr_err("We failed to write back the inode_bitmap.\n");
+        ext2_dealloc_cache(cache);
+        return -1;
     }
     // Free the cache.
     ext2_dealloc_cache(cache);

--- a/kernel/src/fs/ext2/ext2_blockmap.c
+++ b/kernel/src/fs/ext2/ext2_blockmap.c
@@ -40,8 +40,15 @@ static int __ext2_allocate_indexing_block_for_inode(ext2_filesystem_t *fs, uint3
 static int
 __ext2_read_and_allocate_indexing_block(ext2_filesystem_t *fs, uint32_t indexing_block, uint8_t *cache, uint32_t index)
 {
-    // Read the doubly-indirect block (which contains pointers to indirect blocks).
-    ext2_read_block(fs, indexing_block, cache);
+    // Read the doubly-indirect block (which contains pointers to indirect
+    // blocks). The result cannot be discarded here: the cache comes back
+    // zeroed, so a failed read makes every slot look empty, and the check
+    // below would then allocate a new block over a pointer that already
+    // existed — orphaning whatever it referenced (#344).
+    if (ext2_read_block(fs, indexing_block, cache) < 0) {
+        pr_err("Cannot read the indexing block %u; not allocating over it.\n", indexing_block);
+        return -1;
+    }
     // Check if we need to allocate a new block.
     if (!((uint32_t *)cache)[index]) {
         // Allocate a new block.
@@ -111,11 +118,23 @@ static int ext2_set_real_block_index(
                 goto early_exit;
             }
             // Read the indirect block (which contains pointers to the next set of blocks).
-            ext2_read_block(fs, inode->data.blocks.indir_block, cache);
+            // One pointer is patched into a block that holds up to
+            // pointers_per_block of them, so a failed read must not be
+            // written back: the cache comes back zeroed, and writing zeroes
+            // would lose every other pointer in the block (#344).
+            if (ext2_read_block(fs, inode->data.blocks.indir_block, cache) < 0) {
+                pr_err("Cannot read the indirect block %u to set an index in it.\n", inode->data.blocks.indir_block);
+                ret = -1;
+                goto early_exit;
+            }
             // Write the index inside the final block.
             ((uint32_t *)cache)[a] = real_index;
             // Write back the indirect block.
-            ext2_write_block(fs, inode->data.blocks.indir_block, cache);
+            if (ext2_write_block(fs, inode->data.blocks.indir_block, cache) < 0) {
+                pr_err("Cannot write back the indirect block %u.\n", inode->data.blocks.indir_block);
+                ret = -1;
+                goto early_exit;
+            }
 
         } else {
             // Are we setting a DOUBLY-INDIRECT block.
@@ -135,12 +154,21 @@ static int ext2_set_real_block_index(
                 }
                 // Save the index.
                 index_save = ((uint32_t *)cache)[c];
-                // Compute the index inside the indirect block.
-                ext2_read_block(fs, index_save, cache);
+                // Compute the index inside the indirect block. As above: a
+                // failed read here would be written back as zeroes (#344).
+                if (ext2_read_block(fs, index_save, cache) < 0) {
+                    pr_err("Cannot read the index block %u to set an index in it.\n", index_save);
+                    ret = -1;
+                    goto early_exit;
+                }
                 // Write the index inside the final block.
                 ((uint32_t *)cache)[d] = real_index;
                 // Write back the indirect block.
-                ext2_write_block(fs, index_save, cache);
+                if (ext2_write_block(fs, index_save, cache) < 0) {
+                    pr_err("Cannot write back the index block %u.\n", index_save);
+                    ret = -1;
+                    goto early_exit;
+                }
 
             } else {
                 d = c - p * p * p;
@@ -168,12 +196,21 @@ static int ext2_set_real_block_index(
                     }
                     // Save the index.
                     index_save = ((uint32_t *)cache)[f];
-                    // Read the indirect block (which contains pointers to the next set of blocks).
-                    ext2_read_block(fs, index_save, cache);
+                    // Read the indirect block (which contains pointers to the
+                    // next set of blocks). As above (#344).
+                    if (ext2_read_block(fs, index_save, cache) < 0) {
+                        pr_err("Cannot read the index block %u to set an index in it.\n", index_save);
+                        ret = -1;
+                        goto early_exit;
+                    }
                     // Write the index inside the final block.
                     ((uint32_t *)cache)[g] = real_index;
                     // Write back the indirect block.
-                    ext2_write_block(fs, index_save, cache);
+                    if (ext2_write_block(fs, index_save, cache) < 0) {
+                        pr_err("Cannot write back the index block %u.\n", index_save);
+                        ret = -1;
+                        goto early_exit;
+                    }
 
                 } else {
                     pr_err(
@@ -219,15 +256,24 @@ uint32_t ext2_get_real_block_index(ext2_filesystem_t *fs, ext2_inode_t *inode, u
     } else {
         // Allocate the cache.
         uint8_t *cache = ext2_alloc_cache(fs);
+        if (cache == NULL) {
+            pr_err("Failed to allocate the cache to map block %u of an inode.\n", block_index);
+            return 0;
+        }
         // Check if the index is among the INDIRECT blocks.
-        b              = a - p;
+        b = a - p;
         if (b < 0) {
             // Read the indirect block (which contains pointers to the next set of blocks).
             if (inode->data.blocks.indir_block == 0) {
                 pr_warning("ext2_get_real_block_index: indirect block not allocated (block_index=%u)\n", block_index);
                 real_index = 0;
             } else {
-                ext2_read_block(fs, inode->data.blocks.indir_block, cache);
+                // A failed read leaves the cache zeroed, which the caller cannot tell
+                // apart from a hole. Say so at least; the ambiguity itself needs this
+                // function to stop returning an index as its result.
+                if (ext2_read_block(fs, inode->data.blocks.indir_block, cache) < 0) {
+                    pr_err("Cannot read the index block while mapping block %u.\\n", block_index);
+                }
                 // Compute the index inside the final block.
                 real_index = ((uint32_t *)cache)[a];
                 pr_debug("ext2_get_real_block_index: indirect block %u (via block %u) -> real_index %u\n", block_index, inode->data.blocks.indir_block, real_index);
@@ -245,14 +291,24 @@ uint32_t ext2_get_real_block_index(ext2_filesystem_t *fs, ext2_inode_t *inode, u
                     pr_warning("ext2_get_real_block_index: doubly-indirect block not allocated (block_index=%u)\n", block_index);
                     real_index = 0;
                 } else {
-                    ext2_read_block(fs, inode->data.blocks.doubly_indir_block, cache);
+                    // A failed read leaves the cache zeroed, which the caller cannot tell
+                    // apart from a hole. Say so at least; the ambiguity itself needs this
+                    // function to stop returning an index as its result.
+                    if (ext2_read_block(fs, inode->data.blocks.doubly_indir_block, cache) < 0) {
+                        pr_err("Cannot read the index block while mapping block %u.\\n", block_index);
+                    }
                     // Compute the index inside the indirect block.
                     uint32_t indir_blk = ((uint32_t *)cache)[c];
                     if (indir_blk == 0) {
                         pr_warning("ext2_get_real_block_index: indirect block pointer is 0 in doubly-indirect (c=%u)\n", c);
                         real_index = 0;
                     } else {
-                        ext2_read_block(fs, indir_blk, cache);
+                        // A failed read leaves the cache zeroed, which the caller cannot tell
+                        // apart from a hole. Say so at least; the ambiguity itself needs this
+                        // function to stop returning an index as its result.
+                        if (ext2_read_block(fs, indir_blk, cache) < 0) {
+                            pr_err("Cannot read the index block while mapping block %u.\\n", block_index);
+                        }
                         // Compute the index inside the final block.
                         real_index = ((uint32_t *)cache)[d];
                         pr_debug("ext2_get_real_block_index: doubly-indirect block %u -> real_index %u\n", block_index, real_index);
@@ -271,21 +327,36 @@ uint32_t ext2_get_real_block_index(ext2_filesystem_t *fs, ext2_inode_t *inode, u
                         pr_warning("ext2_get_real_block_index: trebly-indirect block not allocated (block_index=%u)\n", block_index);
                         real_index = 0;
                     } else {
-                        ext2_read_block(fs, inode->data.blocks.trebly_indir_block, cache);
+                        // A failed read leaves the cache zeroed, which the caller cannot tell
+                        // apart from a hole. Say so at least; the ambiguity itself needs this
+                        // function to stop returning an index as its result.
+                        if (ext2_read_block(fs, inode->data.blocks.trebly_indir_block, cache) < 0) {
+                            pr_err("Cannot read the index block while mapping block %u.\\n", block_index);
+                        }
                         // Read the doubly-indirect block (which contains pointers to indirect blocks).
                         uint32_t dblind_blk = ((uint32_t *)cache)[e];
                         if (dblind_blk == 0) {
                             pr_warning("ext2_get_real_block_index: doubly-indirect pointer is 0 in trebly-indirect (e=%u)\n", e);
                             real_index = 0;
                         } else {
-                            ext2_read_block(fs, dblind_blk, cache);
+                            // A failed read leaves the cache zeroed, which the caller cannot tell
+                            // apart from a hole. Say so at least; the ambiguity itself needs this
+                            // function to stop returning an index as its result.
+                            if (ext2_read_block(fs, dblind_blk, cache) < 0) {
+                                pr_err("Cannot read the index block while mapping block %u.\\n", block_index);
+                            }
                             uint32_t indir_blk = ((uint32_t *)cache)[f];
                             if (indir_blk == 0) {
                                 pr_warning("ext2_get_real_block_index: indirect pointer is 0 in trebly-indirect (f=%u)\n", f);
                                 real_index = 0;
                             } else {
                                 // Read the indirect block (which contains pointers to the next set of blocks).
-                                ext2_read_block(fs, indir_blk, cache);
+                                // A failed read leaves the cache zeroed, which the caller cannot tell
+                                // apart from a hole. Say so at least; the ambiguity itself needs this
+                                // function to stop returning an index as its result.
+                                if (ext2_read_block(fs, indir_blk, cache) < 0) {
+                                    pr_err("Cannot read the index block while mapping block %u.\\n", block_index);
+                                }
                                 // Compute the index inside the final block.
                                 real_index = ((uint32_t *)cache)[g];
                                 pr_debug("ext2_get_real_block_index: trebly-indirect block %u -> real_index %u\n", block_index, real_index);
@@ -688,7 +759,13 @@ int ext2_truncate_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t ino
     // Release the blocks before the size stops naming them: the loop that
     // frees the data derives its bound from `size`, so clearing the size
     // first would leak every block of the file.
-    ext2_free_inode_blocks(fs, inode);
+    // If a block could not be released, the file is not empty: clearing the
+    // size would leave those blocks allocated with nothing describing them,
+    // which is the loss #343 is about. Report instead.
+    if (ext2_free_inode_blocks(fs, inode) < 0) {
+        pr_err("Failed to release every block of inode %u; leaving its size alone.\n", inode_index);
+        return -EIO;
+    }
     inode->size  = 0;
     inode->ctime = sys_time(NULL);
     inode->mtime = inode->ctime;

--- a/kernel/src/fs/ext2/ext2_debug.c
+++ b/kernel/src/fs/ext2/ext2_debug.c
@@ -207,7 +207,12 @@ void ext2_dump_bgdt(ext2_filesystem_t *fs)
         pr_debug("    Free Blocks  : %4u of %u\n", gd->free_blocks_count, fs->superblock.blocks_per_group);
         pr_debug("    Free Inodes  : %4u of %u\n", gd->free_inodes_count, fs->superblock.inodes_per_group);
         // Dump the block bitmap.
-        ext2_read_block(fs, gd->block_bitmap, cache);
+        // A dump that prints an unread bitmap prints zeroes, which reads as
+        // "everything is free" and is the opposite of the truth.
+        if (ext2_read_block(fs, gd->block_bitmap, cache) < 0) {
+            pr_debug("    Block bitmap : <unreadable>\n");
+            continue;
+        }
         pr_debug("    Block Bitmap at %u\n", gd->block_bitmap);
         for (uint32_t j = 0; j < fs->block_size; ++j) {
             if ((j % 8) == 0) {
@@ -222,7 +227,12 @@ void ext2_dump_bgdt(ext2_filesystem_t *fs)
             }
         }
         // Dump the block bitmap.
-        ext2_read_block(fs, gd->inode_bitmap, cache);
+        // A dump that prints an unread bitmap prints zeroes, which reads as
+        // "everything is free" and is the opposite of the truth.
+        if (ext2_read_block(fs, gd->inode_bitmap, cache) < 0) {
+            pr_debug("    Inode bitmap : <unreadable>\n");
+            continue;
+        }
         pr_debug("    Inode Bitmap at %d\n", gd->inode_bitmap);
         for (uint32_t j = 0; j < fs->block_size; ++j) {
             if ((j % 8) == 0) {

--- a/kernel/src/fs/ext2/ext2_dir.c
+++ b/kernel/src/fs/ext2/ext2_dir.c
@@ -387,7 +387,12 @@ free_block_and_fail:
     // failed append changes nothing.
     real_index = ext2_get_real_block_index(fs, &parent_inode, block_index);
     if (real_index != 0) {
-        ext2_free_block(fs, real_index);
+        // A block that cannot be released is a leak, and the entry removal
+        // above has already happened, so there is nothing to undo — report it
+        // and carry on rather than abandon the removal half-done (#342).
+        if (ext2_free_block(fs, real_index) < 0) {
+            pr_err("Failed to release block %u of inode %u.\n", real_index, inode_index);
+        }
     }
     parent_inode.size = old_size;
     if (ext2_write_inode(fs, &parent_inode, parent_inode_index) == -1) {
@@ -496,6 +501,10 @@ int ext2_destroy_direntry(
 
     // Allocate and clean the cache
     uint8_t *cache = ext2_alloc_cache(fs);
+    if (cache == NULL) {
+        pr_err("Failed to allocate the cache to destroy a direntry of inode %u.\n", inode_index);
+        return -ENOMEM;
+    }
 
     // Check if the directory is empty, if it enters the loop then it means it is not empty.
     if (!ext2_directory_is_empty(fs, cache, &inode)) {

--- a/kernel/src/fs/ext2/ext2_internal.h
+++ b/kernel/src/fs/ext2/ext2_internal.h
@@ -507,9 +507,9 @@ int ext2_write_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_
 // Defined in ext2_alloc.c.
 int ext2_allocate_inode(ext2_filesystem_t *fs, unsigned preferred_group);
 uint32_t ext2_allocate_block(ext2_filesystem_t *fs);
-void ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index);
+int ext2_free_block(ext2_filesystem_t *fs, uint32_t block_index);
 int ext2_free_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_index);
-void ext2_free_inode_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode);
+int ext2_free_inode_blocks(ext2_filesystem_t *fs, ext2_inode_t *inode);
 
 // Defined in ext2_blockmap.c.
 uint32_t ext2_get_real_block_index(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t block_index);

--- a/kernel/src/fs/ext2/ext2_io.c
+++ b/kernel/src/fs/ext2/ext2_io.c
@@ -159,7 +159,14 @@ int ext2_read_bgdt(ext2_filesystem_t *fs)
         return -1;
     }
     for (uint32_t i = 0; i < fs->bgdt_length; ++i) {
-        ext2_read_block(fs, fs->bgdt_start_block + i, (uint8_t *)((uintptr_t)fs->block_groups + (fs->block_size * i)));
+        // A descriptor block that cannot be read leaves that slice of
+        // `block_groups` holding whatever it held before, and the free counts
+        // and bitmap locations for those groups would then be fiction. The
+        // failure was discarded and the mount continued on it (#344).
+        if (ext2_read_block(fs, fs->bgdt_start_block + i, (uint8_t *)((uintptr_t)fs->block_groups + (fs->block_size * i))) < 0) {
+            pr_err("Failed to read BGDT block %u of %u.\n", i, fs->bgdt_length);
+            return -1;
+        }
     }
     return 0;
 }
@@ -187,7 +194,10 @@ int ext2_write_bgdt_for_group(ext2_filesystem_t *fs, uint32_t group_index)
 
     pr_debug("ext2_write_bgdt_for_group(group: %u, bgdt_block: %u)\n", group_index, bgdt_block_index);
     // Write only the specific BGDT block containing this group's descriptor.
-    ext2_write_block(fs, fs->bgdt_start_block + bgdt_block_index, (uint8_t *)((uintptr_t)fs->block_groups + (fs->block_size * bgdt_block_index)));
+    if (ext2_write_block(fs, fs->bgdt_start_block + bgdt_block_index, (uint8_t *)((uintptr_t)fs->block_groups + (fs->block_size * bgdt_block_index))) < 0) {
+        pr_err("Failed to write BGDT block %u for group %u.\n", bgdt_block_index, group_index);
+        return -1;
+    }
     return 0;
 }
 
@@ -201,10 +211,16 @@ static int ext2_write_bgdt(ext2_filesystem_t *fs)
         pr_err("The `block_groups` list is not initialized.\n");
         return -1;
     }
+    int failure = 0;
     for (uint32_t i = 0; i < fs->bgdt_length; ++i) {
-        ext2_write_block(fs, fs->bgdt_start_block + i, (uint8_t *)((uintptr_t)fs->block_groups + (fs->block_size * i)));
+        // Keep going: the descriptors that can be written should be, and the
+        // caller still has to learn that some could not.
+        if (ext2_write_block(fs, fs->bgdt_start_block + i, (uint8_t *)((uintptr_t)fs->block_groups + (fs->block_size * i))) < 0) {
+            pr_err("Failed to write BGDT block %u of %u.\n", i, fs->bgdt_length);
+            failure = -1;
+        }
     }
-    return 0;
+    return failure;
 }
 
 /// @brief Reads an inode.
@@ -290,16 +306,38 @@ int ext2_write_inode(ext2_filesystem_t *fs, ext2_inode_t *inode, uint32_t inode_
 
     // Get the real inode offset inside the block.
     group_offset %= fs->inodes_per_block_count;
+    uint32_t table_block = fs->block_groups[group_index].inode_table + block_index;
+
     // Allocate the cache.
     uint8_t *cache = ext2_alloc_cache(fs);
-    // Read the block containing the inode table.
-    ext2_read_block(fs, fs->block_groups[group_index].inode_table + block_index, cache);
+    if (cache == NULL) {
+        pr_err("Failed to allocate the cache to write inode %u.\n", inode_index);
+        return -1;
+    }
+    // Read the block containing the inode table. This is a read-modify-write:
+    // one inode is patched into a block that holds many, so the rest of the
+    // block has to be the block. `ext2_alloc_cache` zeroes what it returns, so
+    // a failed read here does not leave stale contents, it leaves *zeroes* —
+    // and writing those back destroys every other inode in the block, which
+    // with 4 KiB blocks and 128-byte inodes is 31 of them. Nothing may be
+    // written when the read fails (#344).
+    if (ext2_read_block(fs, table_block, cache) < 0) {
+        pr_err("Failed to read inode table block %u while writing inode %u.\n", table_block, inode_index);
+        ext2_dealloc_cache(cache);
+        return -1;
+    }
     // Write the inode.
     memcpy(
         (ext2_inode_t *)((uintptr_t)cache + (group_offset * fs->superblock.inode_size)), inode, sizeof(ext2_inode_t));
-    // Write back the block.
-    ext2_write_block(fs, fs->block_groups[group_index].inode_table + block_index, cache);
+    // Write back the block. The result is the function's result: this used to
+    // return 0 unconditionally, so an inode that never reached the disk was
+    // reported as written.
+    int ret = 0;
+    if (ext2_write_block(fs, table_block, cache) < 0) {
+        pr_err("Failed to write inode table block %u for inode %u.\n", table_block, inode_index);
+        ret = -1;
+    }
     // Free the cache.
     ext2_dealloc_cache(cache);
-    return 0;
+    return ret;
 }

--- a/kernel/src/io/proc_faultinj.c
+++ b/kernel/src/io/proc_faultinj.c
@@ -13,10 +13,10 @@
 
 #ifdef ENABLE_ATA_FAULT_INJECTION
 
+#include "errno.h"
 #include "fs/procfs.h"
 #include "stdio.h"
 #include "string.h"
-#include "errno.h"
 
 /// @brief How many transfers are still to be failed, and how many have been.
 /// @details A single-processor, non-preemptible kernel reaches the block layer
@@ -24,15 +24,38 @@
 ///          that stops being true this state has to be revisited along with
 ///          everything else that assumes it.
 static struct {
-    unsigned reads_armed;     ///< Reads still to be failed.
-    unsigned writes_armed;    ///< Writes still to be failed.
-    unsigned reads_injected;  ///< Reads failed since the last arming.
-    unsigned writes_injected; ///< Writes failed since the last arming.
+    unsigned reads_armed;      ///< Reads still to be failed.
+    unsigned writes_armed;     ///< Writes still to be failed.
+    unsigned reads_injected;   ///< Reads failed since the last arming.
+    unsigned writes_injected;  ///< Writes failed since the last arming.
+    uint32_t target_sector;    ///< Restrict read failures to this sector, 0 for any.
+    uint32_t last_read_sector; ///< The sector most recently read.
+    unsigned skip_remaining;   ///< Matching reads still to be let through.
 } __faultinj;
 
-int ata_fault_inject_read(void)
+int ata_fault_inject_read(uint32_t lba_sector)
 {
+    // Recorded whether or not anything is armed: this is how a test discovers
+    // which sector holds the metadata it wants to fail. Doing an operation,
+    // reading this back, and then arming that sector is the only way to reach
+    // a read-modify-write, because a bare count is spent by path resolution
+    // long before the interesting read happens.
+    __faultinj.last_read_sector = lba_sector;
     if (__faultinj.reads_armed == 0) {
+        return 0;
+    }
+    // A target of 0 means any sector. Sector 0 is the boot sector and is never
+    // read through this path, so it is free to use as "no restriction".
+    if ((__faultinj.target_sector != 0) && (__faultinj.target_sector != lba_sector)) {
+        return 0;
+    }
+    // Let the requested number of matching reads through first. See the note
+    // on `skip` in fault_injection.h: without it the failure lands on a read
+    // that is already checked, and the operation stops before reaching the
+    // write-back that is under test.
+    if (__faultinj.skip_remaining > 0) {
+        --__faultinj.skip_remaining;
+        pr_notice("Letting a read of sector %u through (%u to skip).\n", lba_sector, __faultinj.skip_remaining);
         return 0;
     }
     --__faultinj.reads_armed;
@@ -40,7 +63,7 @@ int ata_fault_inject_read(void)
     // -EIO rather than -EBUSY: a caller that retries transient statuses must
     // still see a hard failure propagate, and -EIO is the one the retry does
     // not swallow.
-    pr_notice("Injecting a read failure (%u left armed).\n", __faultinj.reads_armed);
+    pr_notice("Injecting a read failure on sector %u (%u left armed).\n", lba_sector, __faultinj.reads_armed);
     return -EIO;
 }
 
@@ -55,13 +78,16 @@ int ata_fault_inject_write(void)
     return -EIO;
 }
 
-void ata_fault_inject_arm(unsigned reads, unsigned writes)
+void ata_fault_inject_arm(unsigned reads, unsigned writes, uint32_t sector, unsigned skip)
 {
     __faultinj.reads_armed     = reads;
     __faultinj.writes_armed    = writes;
     __faultinj.reads_injected  = 0;
     __faultinj.writes_injected = 0;
-    pr_notice("Armed for %u read and %u write failures.\n", reads, writes);
+    __faultinj.target_sector   = sector;
+    __faultinj.skip_remaining  = skip;
+    pr_notice(
+        "Armed for %u read and %u write failures, sector %u (0 = any), skipping %u.\n", reads, writes, sector, skip);
 }
 
 /// @brief Reports what is armed and what has fired.
@@ -72,10 +98,13 @@ void ata_fault_inject_arm(unsigned reads, unsigned writes)
 /// @return the number of bytes placed in the buffer.
 static ssize_t procfaultinj_read(vfs_file_t *file, char *buf, off_t offset, size_t nbyte)
 {
-    char content[128];
+    char content[192];
     int written = sprintf(
-        content, "reads_armed %u\nwrites_armed %u\nreads_injected %u\nwrites_injected %u\n", __faultinj.reads_armed,
-        __faultinj.writes_armed, __faultinj.reads_injected, __faultinj.writes_injected);
+        content,
+        "reads_armed %u\nwrites_armed %u\nreads_injected %u\nwrites_injected %u\ntarget_sector %u\n"
+        "last_read_sector %u\nskip_remaining %u\n",
+        __faultinj.reads_armed, __faultinj.writes_armed, __faultinj.reads_injected, __faultinj.writes_injected,
+        __faultinj.target_sector, __faultinj.last_read_sector, __faultinj.skip_remaining);
     if (written < 0) {
         return -EIO;
     }
@@ -116,8 +145,44 @@ static ssize_t procfaultinj_write(vfs_file_t *file, const void *buf, off_t offse
     }
 
     if (strcmp(command, "off") == 0) {
-        ata_fault_inject_arm(0, 0);
+        ata_fault_inject_arm(0, 0, 0, 0);
         return (ssize_t)nbyte;
+    }
+    // Optional ` skip <n>` and ` sector <n>` suffixes. Parsed longest-last so
+    // each one can cut itself off the string before the next is looked for.
+    unsigned skip = 0;
+    char *skip_at = strstr(command, " skip ");
+    if (skip_at != NULL) {
+        const char *digits = skip_at + 6;
+        if (*digits == 0) {
+            return -EINVAL;
+        }
+        for (const char *c = digits; *c != 0; ++c) {
+            if ((*c < '0') || (*c > '9')) {
+                pr_err("Not a skip count: `%s`.\n", digits);
+                return -EINVAL;
+            }
+            skip = (skip * 10U) + (unsigned)(*c - '0');
+        }
+        *skip_at = 0;
+    }
+    // An optional ` sector <n>` suffix restricts read failures to one sector.
+    uint32_t sector = 0;
+    char *suffix    = strstr(command, " sector ");
+    if (suffix != NULL) {
+        const char *digits = suffix + 8;
+        if (*digits == 0) {
+            return -EINVAL;
+        }
+        for (const char *c = digits; *c != 0; ++c) {
+            if ((*c < '0') || (*c > '9')) {
+                pr_err("Not a sector: `%s`.\n", digits);
+                return -EINVAL;
+            }
+            sector = (sector * 10U) + (uint32_t)(*c - '0');
+        }
+        // Cut the suffix off so the count parser below sees only the count.
+        *suffix = 0;
     }
     // The count is whatever follows the keyword and a single space.
     unsigned count = 0;
@@ -143,9 +208,9 @@ static ssize_t procfaultinj_write(vfs_file_t *file, const void *buf, off_t offse
         count = (count * 10U) + (unsigned)(*c - '0');
     }
     if (command[0] == 'r') {
-        ata_fault_inject_arm(count, __faultinj.writes_armed);
+        ata_fault_inject_arm(count, __faultinj.writes_armed, sector, skip);
     } else {
-        ata_fault_inject_arm(__faultinj.reads_armed, count);
+        ata_fault_inject_arm(__faultinj.reads_armed, count, __faultinj.target_sector, __faultinj.skip_remaining);
     }
     return (ssize_t)nbyte;
 }

--- a/userspace/bin/runtests.c
+++ b/userspace/bin/runtests.c
@@ -98,6 +98,7 @@ static char *all_tests[] = {
     "t_wifsignaled",
     "t_write_read",
     "t_faultinj",
+    "t_meta_rmw",
 };
 
 static char **tests = &all_tests[0];

--- a/userspace/tests/CMakeLists.txt
+++ b/userspace/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TEST_LIST
     t_semget.c
     t_mkdir.c
     t_faultinj.c
+    t_meta_rmw.c
     t_syslog_format.c
     t_rmdir_dotfiles.c
     t_stdint.c

--- a/userspace/tests/t_meta_rmw.c
+++ b/userspace/tests/t_meta_rmw.c
@@ -1,0 +1,224 @@
+/// @file t_meta_rmw.c
+/// @brief Regression test for #344: a metadata block that could not be read
+/// must not be written back.
+/// @details Several ext2 functions read a metadata block into a cache, patch
+/// one field and write the whole block back. None checked the read, and
+/// `ext2_alloc_cache` zeroes what it returns — so a failed read left not stale
+/// contents but *zeroes*, and writing those back destroyed everything else in
+/// the block.
+///
+/// `ext2_write_inode` was the worst of them: one inode is patched into a block
+/// that holds many, so with 4 KiB blocks and 128-byte inodes a single failed
+/// read zeroed the other 31. It also returned 0 unconditionally, so an inode
+/// that never reached the disk was reported as written.
+///
+/// This is what the fault injection of #338 was built for, and it needed the
+/// injection to grow a sector target to be reachable at all: a bare count of
+/// failures is spent by path resolution long before the interesting read
+/// happens, which is why an earlier version of this test passed with the fix
+/// reverted. The test therefore stats a file to learn which sector carries its
+/// inode table, arms failures for that sector alone, and then creates a file
+/// whose inode goes into it. Creation is the path that reaches the defect:
+/// `ext2_create_inode` builds an inode from nothing and writes it, so the read
+/// inside `ext2_write_inode` is the first read of that block. Modifying an
+/// existing inode would not work, because `ext2_setattr` reads it first and
+/// `ext2_read_inode` already checked its read. The other inodes in the block
+/// have to survive.
+///
+/// Without ENABLE_ATA_FAULT_INJECTION there is no way to make the read fail,
+/// so the test reports the facility as absent and passes.
+/// @copyright (c) 2014-2026 This file is distributed under the MIT License.
+/// See LICENSE.md for details.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strerror.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/// The control file of the fault injection.
+#define CONTROL "/proc/faultinj"
+
+/// How many neighbours to create. They are allocated consecutively, so they
+/// share an inode table block with the file that gets modified.
+#define NEIGHBOURS 8
+
+/// The size each neighbour is given, so a zeroed inode is visible as a size of
+/// zero rather than as a plausible value.
+#define MARK_SIZE 7
+
+/// Buffer for building the paths.
+static char path[64];
+
+/// @brief Builds the path of the nth neighbour.
+/// @param n which neighbour.
+static void __path_of(unsigned n) { sprintf(path, "/home/user/t_rmw_%u.bin", n); }
+
+/// @brief Reads a counter out of the control file.
+/// @param name the counter to read.
+/// @param value where the value is stored.
+/// @return 0 on success, -1 on failure.
+static int __counter(const char *name, unsigned *value)
+{
+    int fd = open(CONTROL, O_RDONLY, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    char buffer[256] = {0};
+    ssize_t bytes    = read(fd, buffer, sizeof(buffer) - 1);
+    close(fd);
+    if (bytes <= 0) {
+        return -1;
+    }
+    char *at = strstr(buffer, name);
+    if (at == NULL) {
+        syslog(LOG_ERR, "[t_meta_rmw] " CONTROL " does not report `%s`", name);
+        return -1;
+    }
+    at += strlen(name);
+    while (*at == ' ') {
+        ++at;
+    }
+    *value = 0;
+    for (; (*at >= '0') && (*at <= '9'); ++at) {
+        *value = (*value * 10U) + (unsigned)(*at - '0');
+    }
+    return 0;
+}
+
+/// @brief Sends a command to the fault injection.
+/// @param command what to send.
+/// @return 0 on success, -1 on failure.
+static int __arm(const char *command)
+{
+    int fd = open(CONTROL, O_WRONLY, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    ssize_t written = write(fd, command, strlen(command));
+    close(fd);
+    return (written == (ssize_t)strlen(command)) ? 0 : -1;
+}
+
+int main(void)
+{
+    int probe = open(CONTROL, O_RDONLY, 0);
+    if (probe < 0) {
+        syslog(LOG_INFO, "[t_meta_rmw] " CONTROL " is absent: built without ENABLE_ATA_FAULT_INJECTION, nothing to do");
+        return EXIT_SUCCESS;
+    }
+    close(probe);
+
+    int failures = 0;
+
+    // Create the neighbours and give each a known size.
+    for (unsigned n = 0; n < NEIGHBOURS; ++n) {
+        __path_of(n);
+        int fd = creat(path, 0644);
+        if (fd < 0) {
+            syslog(LOG_ERR, "[t_meta_rmw] creating %s: %s", path, strerror(errno));
+            return EXIT_FAILURE;
+        }
+        if (write(fd, "marker", MARK_SIZE) != MARK_SIZE) {
+            syslog(LOG_ERR, "[t_meta_rmw] writing %s: %s", path, strerror(errno));
+            close(fd);
+            return EXIT_FAILURE;
+        }
+        close(fd);
+    }
+
+    // Learn which sector carries the inode table. Touching a neighbour makes
+    // its inode be read, and last_read_sector then names the block that read
+    // came from — which is the same block every one of these inodes lives in.
+    __path_of(1);
+    stat_t probe_st;
+    if (stat(path, &probe_st) < 0) {
+        syslog(LOG_ERR, "[t_meta_rmw] stat of %s to find the inode table: %s", path, strerror(errno));
+        return EXIT_FAILURE;
+    }
+    unsigned table_sector = 0;
+    if (__counter("last_read_sector", &table_sector) < 0) {
+        return EXIT_FAILURE;
+    }
+    if (table_sector == 0) {
+        syslog(LOG_ERR, "[t_meta_rmw] the injection reported no last read sector");
+        return EXIT_FAILURE;
+    }
+
+    // Target the *first* sector of that block, not the last. A filesystem
+    // block is eight 512-byte sectors, and ata_read fills the buffer up to the
+    // sector that fails — so failing the last one leaves the first seven
+    // eighths of the block intact and proves nothing. last_read_sector reports
+    // the highest sector of the block just read, so the base is that with the
+    // low three bits cleared.
+    unsigned block_base = table_sector & ~7u;
+    char command[64];
+    // Skip one matching read. Every path that writes a metadata block reads
+    // something from the same block first — here `ext2_find_direntry` reads the
+    // parent directory's inode — and that read goes through `ext2_read_inode`,
+    // which already checks its result. An unskipped failure therefore stops
+    // the creation before it reaches the write-back under test, which is what
+    // made three earlier versions of this control pass.
+    sprintf(command, "read 4 sector %u skip 1", block_base);
+    if (__arm(command) < 0) {
+        syslog(LOG_ERR, "[t_meta_rmw] could not arm the injection");
+        ++failures;
+    } else {
+        // Creating a file is what reaches the defect. `chmod` would not:
+        // ext2_setattr reads the inode first, and ext2_read_inode *does* check
+        // its read, so it fails before ext2_write_inode is ever called.
+        // ext2_create_inode builds an inode from nothing and writes it, with no
+        // prior read of the block it goes into — so the read inside
+        // ext2_write_inode is the first one, and it is the one that used to be
+        // discarded.
+        int fd = creat("/home/user/t_rmw_new.bin", 0644);
+        if (fd >= 0) {
+            close(fd);
+        }
+        unsigned injected = 0;
+        if ((__counter("reads_injected", &injected) == 0) && (injected == 0)) {
+            syslog(
+                LOG_ERR, "[t_meta_rmw] no failure was injected on sector %u; the test proved nothing", block_base);
+            ++failures;
+        }
+        __arm("off");
+        unlink("/home/user/t_rmw_new.bin");
+    }
+
+    // Whatever happened to the file that was being modified, the others share
+    // its inode table block and must be untouched. A zeroed inode reads back
+    // as size 0 and mode 0.
+    for (unsigned n = 1; n < NEIGHBOURS; ++n) {
+        __path_of(n);
+        stat_t st;
+        if (stat(path, &st) < 0) {
+            syslog(LOG_ERR, "[t_meta_rmw] %s cannot be stat'd after the injection: %s", path, strerror(errno));
+            ++failures;
+            continue;
+        }
+        if ((unsigned)st.st_size != MARK_SIZE) {
+            syslog(LOG_ERR, "[t_meta_rmw] %s is %u bytes, expected %u: its inode was overwritten", path, (unsigned)st.st_size, (unsigned)MARK_SIZE);
+            ++failures;
+        }
+        if ((st.st_mode & 0777) == 0) {
+            syslog(LOG_ERR, "[t_meta_rmw] %s has mode 0: its inode was zeroed", path);
+            ++failures;
+        }
+    }
+
+    for (unsigned n = 0; n < NEIGHBOURS; ++n) {
+        __path_of(n);
+        unlink(path);
+    }
+
+    if (failures == 0) {
+        syslog(LOG_INFO, "[t_meta_rmw] a failed metadata read left the neighbouring inodes intact");
+        return EXIT_SUCCESS;
+    }
+    syslog(LOG_ERR, "[t_meta_rmw] %d FAILURES", failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Fixes #344, #342, #343

One change, because all three need the same signature work on `ext2_free_block` and `__ext2_free_index_blocks` and share callers.

## The defect

Several ext2 functions read a metadata block into a cache, patch one field and write the whole block back. None checked the read. `ext2_alloc_cache` zeroes what it returns, and `ata_read` fills the buffer only up to the sector that fails — so a failed read leaves the block correct up to that point and **zeroes after it**, and writing that back destroys everything in the block from the failure onward.

## Negative control

With only the `ext2_write_inode` read check reverted, and one sector of the inode-table block made to fail:

```
not ok 71 - t_meta_rmw: Exit: 1
[t_meta_rmw] /home/user/t_rmw_1.bin is 0 bytes, expected 7: its inode was overwritten
[t_meta_rmw] /home/user/t_rmw_1.bin has mode 0: its inode was zeroed
[t_meta_rmw] /home/user/t_rmw_2.bin is 0 bytes, expected 7: its inode was overwritten
...
```

Seven neighbouring inodes zeroed by one failed read.

## What changed

All 22 discarded `ext2_read_block`/`ext2_write_block` results now check. The ones that mattered:

| site | consequence |
| --- | --- |
| `ext2_write_inode` (#344) | the control above; also returned 0 unconditionally, so an inode that never reached the disk was reported written |
| `ext2_free_block`, `ext2_free_inode` (#342) | a zeroed bitmap written back marked a whole group free, so the allocator would hand out storage in use |
| `__ext2_free_index_blocks` (#343) | the index block was freed whether or not it could be read, releasing the only record of what it pointed at |
| `__ext2_read_and_allocate_indexing_block` | a failed read made every slot look empty, so it allocated over an existing pointer |
| 3 sites in `ext2_set_real_block_index` | a zeroed write-back loses up to `pointers_per_block` references |
| `ext2_read_bgdt` | mount continued on group descriptors it had not read |
| `ext2_truncate_inode`, `ext2_free_inode_blocks` | no longer clear size/pointers when a block was kept |
| 2 × `ext2_alloc_cache` | plain null dereferences |
| 2 bitmap dumps | printed zeroes for an unread bitmap — the opposite of the truth |

The governing rule is narrow: **never write a metadata block you could not read.** A block that cannot be freed is a leak; a group wrongly marked free is corruption.

## Two additions to the #338 injection were needed

Three earlier versions of this control passed, and each failure was informative:

1. A **sector target** — a bare count of failures is spent by path resolution long before the interesting read.
2. A **skip count** — every path that writes a metadata block first reads something from the same block through `ext2_read_inode`, which *already* checked its read. An unskipped failure stopped the operation before the write-back under test.

`t_meta_rmw` uses both: it stats a file to learn which sector carries its inode table, arms failures for that sector with one match skipped, then creates a file whose inode lands in the block. Creation is the reachable path, because `ext2_create_inode` builds an inode from nothing and writes it.

## Correction to #344 as filed

I wrote that a failed read leaves the cache "all zeros". That is too strong: `ata_read` fills up to the failing sector, so the damage runs from that sector to the end of the block, not the whole block. Posted on the issue.

## Left deliberately

`ext2_get_real_block_index` returns an index where 0 means both "hole" and "could not read". Distinguishing them needs the function to stop returning its result as its value, which ripples to five callers. The failures are reported now; the ambiguity is filed separately.

## Verification

- **71 tests, 0 failures, 0 panics** with `-DENABLE_ATA_FAULT_INJECTION=ON`.
- **71 tests, 0 failures, 0 panics** with it off, `t_meta_rmw` reporting the facility absent.
- Negative control as quoted.